### PR TITLE
vpp/deinterlace: set interlace pipeline params

### DIFF
--- a/test/ffmpeg-qsv/vpp/deinterlace.py
+++ b/test/ffmpeg-qsv/vpp/deinterlace.py
@@ -19,35 +19,27 @@ def test_default(case, method):
   params = spec[case].copy()
   params.update(
     method = map_deinterlace_method(method),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    tff = params.get("tff", 1))
 
   if params["method"] is None:
     slash.skip_test("{} method not supported".format(method))
 
-  params["ofile"] = get_media()._test_artifact(
+  params["decoded"] = get_media()._test_artifact(
     "{}_deinterlace_{method}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
 
   if params["mformat"] is None:
     slash.skip_test("{format} format not supported".format(**params))
 
+
+  # TODO: how to configure vpp_qsv to use field rate?
   call(
     "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
-    " -v debug -f rawvideo -pix_fmt {mformat} -s:v {width}x{height} -i {source}"
-    " -vf 'format=nv12,hwupload=extra_hw_frames=16"
+    " -v debug -f rawvideo -pix_fmt {mformat} -s:v {width}x{height} -top {tff}"
+    " -i {source} -vf 'format=nv12,hwupload=extra_hw_frames=16"
     ",vpp_qsv=deinterlace={method},hwdownload,format=nv12'"
-    " -pix_fmt {mformat} -an -vframes {frames} -y {ofile}".format(**params))
+    " -pix_fmt {mformat} -an -vframes {frames} -y {decoded}".format(**params))
 
-  psnr = calculate_psnr(
-    params["source"], params["ofile"],
-    params["width"], params["height"],
-    params["frames"], params["format"])
-
-  def compare(k, ref, actual):
-    assert ref is not None, "Invalid reference value"
-    assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
-
-  get_media().baseline.check_result(
-    compare = compare, context = params.get("refctx", []), psnr = psnr)
+  params.setdefault("metric", dict(type = "md5"))
+  check_metric(**params)

--- a/test/ffmpeg-vaapi/vpp/deinterlace.py
+++ b/test/ffmpeg-vaapi/vpp/deinterlace.py
@@ -18,12 +18,13 @@ def test_default(case, method):
   params = spec[case].copy()
   params.update(
     method = map_deinterlace_method(method),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    tff = params.get("tff", 1))
 
   if params["method"] is None:
     slash.skip_test("{} method not supported".format(method))
 
-  params["ofile"] = get_media()._test_artifact(
+  params["decoded"] = get_media()._test_artifact(
     "{}_deinterlace_{method}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
 
@@ -32,21 +33,10 @@ def test_default(case, method):
 
   call(
     "ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v debug"
-    " -f rawvideo -pix_fmt {mformat} -s:v {width}x{height} -i {source}"
-    " -vf 'format=nv12,hwupload,deinterlace_vaapi=mode={method}"
-    ",hwdownload,format=nv12'"
-    " -pix_fmt {mformat} -vframes {frames} -y {ofile}".format(**params))
+    " -f rawvideo -pix_fmt {mformat} -s:v {width}x{height} -top {tff}"
+    " -i {source} -vf 'format=nv12,hwupload,deinterlace_vaapi=mode={method}"
+    ":rate=field,hwdownload,format=nv12'"
+    " -pix_fmt {mformat} -vframes {frames} -y {decoded}".format(**params))
 
-  psnr = calculate_psnr(
-    params["source"], params["ofile"],
-    params["width"], params["height"],
-    params["frames"], params["format"])
-
-  def compare(k, ref, actual):
-    assert ref is not None, "Invalid reference value"
-    assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
-
-  get_media().baseline.check_result(
-    compare = compare, context = params.get("refctx", []), psnr = psnr)
+  params.setdefault("metric", dict(type = "md5"))
+  check_metric(**params)

--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -102,7 +102,7 @@ def map_deinterlace_method(method):
     "advanced"         : "advanced",
     "advanced-no-ref"  : "advanced-no-ref",
     "advanced-scd"     : "advanced-scd",
-    "field-weave"      : "field-weave",
+    "weave"            : "field-weave",
     "none"             : "none"
   }.get(method, None)
 

--- a/test/gst-msdk/vpp/deinterlace.py
+++ b/test/gst-msdk/vpp/deinterlace.py
@@ -14,40 +14,31 @@ spec = load_test_spec("vpp", "deinterlace")
 @slash.requires(*have_gst_element("msdkvpp"))
 @slash.requires(*have_gst_element("checksumsink2"))
 @slash.requires(using_compatible_driver)
-@slash.parametrize(*gen_vpp_deinterlace_parameters(spec,["bob", "advanced", "advanced-no-ref", "advanced-scd", "field-weave"]))
+@slash.parametrize(*gen_vpp_deinterlace_parameters(spec,["bob", "advanced", "advanced-no-ref", "advanced-scd", "weave"]))
 @platform_tags(VPP_PLATFORMS)
 def test_default(case, method):
   params = spec[case].copy()
   params.update(
     method = map_deinterlace_method(method),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    tff = params.get("tff", 1))
 
   if params["method"] is None:
     slash.skip_test("{} method not supported".format(method))
 
-  params["ofile"] = get_media()._test_artifact(
+  params["decoded"] = get_media()._test_artifact(
     "{}_deinterlace_{method}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
 
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " interlaced=true top-field-first={tff}"
     " ! msdkvpp hardware=true deinterlace-mode=1 deinterlace-method={method}"
     " ! video/x-raw,format=NV12 ! videoconvert ! video/x-raw,format={format}"
     " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true dump-location={ofile}"
+    " plane-checksum=false dump-output=true dump-location={decoded}"
     "".format(**params))
 
-  psnr = calculate_psnr(
-    params["source"], params["ofile"],
-    params["width"], params["height"],
-    params["frames"], params["format"])
-
-  def compare(k, ref, actual):
-    assert ref is not None, "Invalid reference value"
-    assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
-
-  get_media().baseline.check_result(
-    compare = compare, context = params.get("refctx", []), psnr = psnr)
+  params.setdefault("metric", dict(type = "md5"))
+  check_metric(**params)

--- a/test/gst-vaapi/vpp/deinterlace.py
+++ b/test/gst-vaapi/vpp/deinterlace.py
@@ -19,33 +19,24 @@ def test_default(case, method):
   params = spec[case].copy()
   params.update(
     method = map_deinterlace_method(method),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    tff = params.get("tff", 1))
 
   if params["method"] is None:
     slash.skip_test("{} method not supported".format(method))
 
-  params["ofile"] = get_media()._test_artifact(
+  params["decoded"] = get_media()._test_artifact(
     "{}_deinterlace_{method}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
 
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " interlaced=true top-field-first={tff}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " deinterlace-mode=1 deinterlace-method={method} ! checksumsink2"
     " file-checksum=false frame-checksum=false plane-checksum=false"
-    " dump-output=true dump-location={ofile}".format(**params))
+    " dump-output=true dump-location={decoded}".format(**params))
 
-  psnr = calculate_psnr(
-    params["source"], params["ofile"],
-    params["width"], params["height"],
-    params["frames"], params["format"])
-
-  def compare(k, ref, actual):
-    assert ref is not None, "Invalid reference value"
-    assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
-
-  get_media().baseline.check_result(
-    compare = compare, context = params.get("refctx", []), psnr = psnr)
+  params.setdefault("metric", dict(type = "md5"))
+  check_metric(**params)


### PR DESCRIPTION
Refactor deinterlace tests to include interlace params
in the pipeline.  Also, set the default metric to use
md5 checksum (which can be configured in the user config).
The user config can set tff param:

 0 = bottom-field-first
 1 = top-field-first

By default, if tff is not set then 1 (top-field-first)
is assumed.

Fixes #4

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>