### PR TITLE
switch to directing people to http://intel.com/security

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ See [here](http://chris.beams.io/posts/git-commit/) for some more good advice ab
 
 ## Reporting a Security Issue:
 
-Please send email to secure-opensource@intel.com for security issue.
+Please visit http://intel.com/security for security issue report.


### PR DESCRIPTION
switch to directing people to http://intel.com/security 
rather than 01.org’s secure-opensource@intel.com
(That’s a recent policy change)

Signed-off-by: Luo Focus <focus.luo@intel.com>