### PR TITLE
gst-vaapi/vpp: convert input format to NV12 before vpp

### DIFF
--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -48,7 +48,8 @@ def test_cqp(case, gop, slices, bframes, qp, quality, profile):
 
   params.update(
     gop = gop, slices = slices, bframes = bframes, qp = qp, quality = quality,
-    profile = mprofile, mformat = mapformat(params["format"]))
+    profile = mprofile, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{qp}-{quality}-{profile}"
@@ -60,7 +61,7 @@ def test_cqp(case, gop, slices, bframes, qp, quality, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih264enc rate-control=cqp init-qp={qp} quality-level={quality}"
     " keyframe-period={gop} num-slices={slices} max-bframes={bframes}"
     " ! video/x-h264,profile={profile} ! h264parse"
@@ -84,7 +85,8 @@ def test_cqp_lp(case, gop, slices, qp, quality, profile):
 
   params.update(
     profile = mprofile, gop = gop, slices = slices, qp = qp,
-    quality = quality, mformat = mapformat(params["format"]))
+    quality = quality, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{qp}-{quality}-{profile}"
@@ -96,7 +98,7 @@ def test_cqp_lp(case, gop, slices, qp, quality, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih264enc rate-control=cqp init-qp={qp} quality-level={quality}"
     " keyframe-period={gop} num-slices={slices} tune=low-power"
     " ! video/x-h264,profile={profile} ! h264parse"
@@ -124,7 +126,8 @@ def test_cbr(case, gop, slices, bframes, bitrate, fps, profile):
 
   params.update(
     gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
-    profile = mprofile, fps = fps, mformat = mapformat(params["format"]))
+    profile = mprofile, fps = fps, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}"
@@ -136,7 +139,7 @@ def test_cbr(case, gop, slices, bframes, bitrate, fps, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih264enc rate-control=cbr bitrate={bitrate} keyframe-period={gop}"
     " num-slices={slices} max-bframes={bframes}"
     " ! video/x-h264,profile={profile} ! h264parse"
@@ -182,7 +185,8 @@ def test_vbr(case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
   params.update(
     gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
     profile = mprofile, fps = fps, quality = quality, refs = refs,
-    minrate = minrate, maxrate = maxrate, mformat = mapformat(params["format"]))
+    minrate = minrate, maxrate = maxrate, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}-{quality}-{refs}"
@@ -195,7 +199,7 @@ def test_vbr(case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih264enc rate-control=vbr bitrate={maxrate} keyframe-period={gop}"
     " num-slices={slices} max-bframes={bframes} refs={refs}"
     " quality-level={quality} ! video/x-h264,profile={profile} ! h264parse"

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -61,7 +61,8 @@ def test_8bit_cqp(case, gop, slices, bframes, qp, quality, profile):
 
   params.update(
     gop = gop, slices = slices, bframes = bframes, qp = qp, quality = quality,
-    profile = mprofile, mformat = mapformat(params["format"]))
+    profile = mprofile, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{qp}-{quality}-{profile}"
@@ -73,7 +74,7 @@ def test_8bit_cqp(case, gop, slices, bframes, qp, quality, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih265enc rate-control=cqp init-qp={qp} quality-level={quality}"
     " keyframe-period={gop} num-slices={slices} max-bframes={bframes}"
     " ! video/x-h265,profile={profile} ! h265parse"
@@ -100,7 +101,8 @@ def test_8bit_cbr(case, gop, slices, bframes, bitrate, fps, profile):
 
   params.update(
     gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
-    profile = mprofile, fps = fps, mformat = mapformat(params["format"]))
+    profile = mprofile, fps = fps, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}"
@@ -112,7 +114,7 @@ def test_8bit_cbr(case, gop, slices, bframes, bitrate, fps, profile):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih265enc rate-control=cbr bitrate={bitrate} keyframe-period={gop}"
     " num-slices={slices} max-bframes={bframes}"
     " ! video/x-h265,profile={profile} ! h265parse"
@@ -157,7 +159,8 @@ def test_8bit_vbr(case, gop, slices, bframes, bitrate, fps, quality, refs, profi
   params.update(
     gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
     profile = mprofile, fps = fps, quality = quality, refs = refs,
-    minrate = minrate, maxrate = maxrate, mformat = mapformat(params["format"]))
+    minrate = minrate, maxrate = maxrate, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}-{quality}-{refs}"
@@ -170,7 +173,7 @@ def test_8bit_vbr(case, gop, slices, bframes, bitrate, fps, quality, refs, profi
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapih265enc rate-control=vbr bitrate={maxrate} keyframe-period={gop}"
     " num-slices={slices} max-bframes={bframes} refs={refs}"
     " quality-level={quality} ! video/x-h265,profile={profile} ! h265parse"

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -41,7 +41,10 @@ def check_psnr(params):
 @platform_tags(JPEG_ENCODE_PLATFORMS)
 def test_cqp(case, quality):
   params = spec[case].copy()
-  params.update(quality = quality, mformat = mapformat(params["format"]))
+
+  params.update(
+    quality = quality, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["encoded"] = get_media()._test_artifact(
     "{}-{quality}.jpg".format(case, **params))
   params["decoded"] = get_media()._test_artifact(
@@ -50,7 +53,7 @@ def test_cqp(case, quality):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapijpegenc quality={quality} ! jpegparse"
     " ! filesink location={encoded}".format(**params))
 

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -41,9 +41,11 @@ def check_psnr(params):
 @platform_tags(MPEG2_ENCODE_PLATFORMS)
 def test_cqp(case, gop, bframes, qp, quality, **unused):
   params = spec[case].copy()
+
   params.update(
     gop = gop, bframes = bframes, qp = qp, quality = quality,
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{bframes}-{qp}-{quality}"
@@ -55,7 +57,7 @@ def test_cqp(case, gop, bframes, qp, quality, **unused):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapimpeg2enc rate-control=cqp quantizer={qp} keyframe-period={gop}"
     " max-bframes={bframes} quality-level={quality}"
     " ! mpegvideoparse ! filesink location={encoded}".format(**params))

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -40,10 +40,12 @@ def check_psnr(params):
 @platform_tags(VP8_ENCODE_PLATFORMS)
 def test_cqp(case, ipmode, qp, quality, looplvl, loopshp):
   params = spec[case].copy()
+
   params.update(
     ipmode = ipmode, qp = qp, quality = quality, looplvl = looplvl,
     gop = 30 if ipmode != 0 else 1,
-    loopshp = loopshp, mformat = mapformat(params["format"]))
+    loopshp = loopshp, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{ipmode}-{qp}-{quality}-{looplvl}-{loopshp}"
@@ -55,7 +57,7 @@ def test_cqp(case, ipmode, qp, quality, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp8enc rate-control=cqp keyframe-period={gop}"
     " yac-qi={qp} quality-level={quality}"
     " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
@@ -74,10 +76,12 @@ def test_cqp(case, ipmode, qp, quality, looplvl, loopshp):
 @platform_tags(VP8_ENCODE_PLATFORMS)
 def test_cbr(case, gop, bitrate, fps, looplvl, loopshp):
   params = spec[case].copy()
+
   params.update(
     gop = gop, bitrate = bitrate, fps = fps, looplvl = looplvl,
     loopshp = loopshp, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]))
+    frames = params.get("brframes", params["frames"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{bitrate}-{fps}-{looplvl}-{loopshp}"
@@ -89,7 +93,7 @@ def test_cbr(case, gop, bitrate, fps, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp8enc rate-control=cbr bitrate={bitrate} keyframe-period={gop}"
     " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
     " ! filesink location={encoded}".format(**params))
@@ -129,7 +133,8 @@ def test_vbr(case, gop, bitrate, fps, quality, looplvl, loopshp):
     gop = gop, bitrate = bitrate, fps = fps, quality = quality,
     looplvl = looplvl, loopshp = loopshp, minrate = minrate,
     maxrate = maxrate, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]))
+    frames = params.get("brframes", params["frames"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{bitrate}-{fps}-{quality}-{looplvl}-{loopshp}"
@@ -142,7 +147,7 @@ def test_vbr(case, gop, bitrate, fps, quality, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp8enc rate-control=vbr bitrate={maxrate} keyframe-period={gop}"
     " loop-filter-level={looplvl} sharpness-level={loopshp}"
     " quality-level={quality} ! matroskamux"

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -40,10 +40,12 @@ def check_psnr(params):
 @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
 def test_8bit_cqp(case, ipmode, qp, quality, refmode, looplvl, loopshp):
   params = spec[case].copy()
+
   params.update(
     ipmode = ipmode, qp = qp, quality = quality, looplvl = looplvl,
     gop = 30 if ipmode != 0 else 1, refmode = refmode,
-    loopshp = loopshp, mformat = mapformat(params["format"]))
+    loopshp = loopshp, mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{ipmode}-{qp}-{quality}-{refmode}-{looplvl}-{loopshp}"
@@ -55,7 +57,7 @@ def test_8bit_cqp(case, ipmode, qp, quality, refmode, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format=NV12"
+    " ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp9enc rate-control=cqp keyframe-period={gop}"
     " yac-qi={qp} quality-level={quality} ref-pic-mode={refmode}"
     " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
@@ -74,10 +76,12 @@ def test_8bit_cqp(case, ipmode, qp, quality, refmode, looplvl, loopshp):
 @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
 def test_8bit_cbr(case, gop, bitrate, fps, refmode, looplvl, loopshp):
   params = spec[case].copy()
+
   params.update(
     gop = gop, bitrate = bitrate, fps = fps, refmode = refmode,
     looplvl = looplvl, loopshp = loopshp, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]))
+    frames = params.get("brframes", params["frames"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{bitrate}-{fps}-{refmode}-{looplvl}-{loopshp}"
@@ -90,7 +94,7 @@ def test_8bit_cbr(case, gop, bitrate, fps, refmode, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp9enc rate-control=cbr keyframe-period={gop} bitrate={bitrate}"
     " ref-pic-mode={refmode} loop-filter-level={looplvl}"
     " sharpness-level={loopshp} ! matroskamux"
@@ -131,7 +135,8 @@ def test_8bit_vbr(case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     gop = gop, bitrate = bitrate, fps = fps, refmode = refmode,
     quality = quality, looplvl = looplvl, loopshp = loopshp, minrate = minrate,
     maxrate = maxrate, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]))
+    frames = params.get("brframes", params["frames"]),
+    hwup_format = mapformat_hwup(params["format"]))
 
   params["encoded"] = get_media()._test_artifact(
     "{}-{gop}-{bitrate}-{fps}-{refmode}-{quality}-{looplvl}-{loopshp}"
@@ -144,7 +149,7 @@ def test_8bit_vbr(case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format=NV12"
+    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
     " ! vaapivp9enc rate-control=vbr keyframe-period={gop} bitrate={maxrate}"
     " ref-pic-mode={refmode} loop-filter-level={looplvl}"
     " sharpness-level={loopshp} quality-level={quality} ! matroskamux"

--- a/test/gst-vaapi/util.py
+++ b/test/gst-vaapi/util.py
@@ -76,6 +76,21 @@ def have_gst_element(element):
   return result, element
 
 @memoize
+def mapformat_hwup(format):
+  from ...lib import get_media
+  fmt = {
+    "iHD" : {
+      "I420"  : "NV12",
+      "AYUV"  : "NV12",
+    },
+    "i965" : {
+      "AYUV"  : "NV12",
+    },
+  }.get(get_media()._get_driver_name(), {}).get(format, format)
+
+  return mapformatu(fmt)
+
+@memoize
 def mapformat(format):
   return {
     "I420"  : "i420",

--- a/test/gst-vaapi/vpp/brightness.py
+++ b/test/gst-vaapi/vpp/brightness.py
@@ -19,7 +19,8 @@ def test_default(case, level):
   params = spec[case].copy()
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [-1.0, 1.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_brightness_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -27,6 +28,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " brightness={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"

--- a/test/gst-vaapi/vpp/contrast.py
+++ b/test/gst-vaapi/vpp/contrast.py
@@ -19,7 +19,8 @@ def test_default(case, level):
   params = spec[case].copy()
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [0.0, 2.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_contrast_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -27,6 +28,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " contrast={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"

--- a/test/gst-vaapi/vpp/denoise.py
+++ b/test/gst-vaapi/vpp/denoise.py
@@ -19,7 +19,8 @@ def test_default(case, level):
   params = spec[case].copy()
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [0.0, 1.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_denoise_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -27,6 +28,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " denoise={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"

--- a/test/gst-vaapi/vpp/hue.py
+++ b/test/gst-vaapi/vpp/hue.py
@@ -19,7 +19,8 @@ def test_default(case, level):
   params = spec[case].copy()
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [-180.0, 180.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_hue_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -27,6 +28,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " hue={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"

--- a/test/gst-vaapi/vpp/saturation.py
+++ b/test/gst-vaapi/vpp/saturation.py
@@ -19,7 +19,8 @@ def test_default(case, level):
   params = spec[case].copy()
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [0.0, 2.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_saturation_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -27,6 +28,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " saturation={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"

--- a/test/gst-vaapi/vpp/scale.py
+++ b/test/gst-vaapi/vpp/scale.py
@@ -19,6 +19,7 @@ def test_default(case, scale_width, scale_height):
   params = spec[case].copy()
   params.update(
     mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]),
     scale_width = scale_width, scale_height = scale_height)
 
   params["scaled"] = get_media()._test_artifact(
@@ -28,6 +29,7 @@ def test_default(case, scale_width, scale_height):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={scale_width} height={scale_height}"
     " ! checksumsink2 file-checksum=false frame-checksum=false plane-checksum=false"
     " dump-output=true dump-location={scaled}".format(**params))

--- a/test/gst-vaapi/vpp/sharpen.py
+++ b/test/gst-vaapi/vpp/sharpen.py
@@ -26,7 +26,8 @@ def test_default(case, level):
 
   params.update(
     level = level, mlevel = mapRange(level, [0, 100], [-1.0, 1.0]),
-    mformat = mapformat(params["format"]))
+    mformat = mapformat(params["format"]),
+    hwup_format = mapformat_hwup(params["format"]))
   params["ofile"] = get_media()._test_artifact(
     "{}_sharpen_{level}_{format}_{width}x{height}"
     ".yuv".format(case, **params))
@@ -34,6 +35,7 @@ def test_default(case, level):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
+    " ! videoconvert ! video/x-raw, format={hwup_format}"
     " ! vaapipostproc format={mformat} width={width} height={height}"
     " sharpen={mlevel} ! checksumsink2 file-checksum=false"
     " frame-checksum=false plane-checksum=false dump-output=true"


### PR DESCRIPTION
convert input format to NV12 before vpp so that it can be applied for iHD driver

