### PR TITLE
test/ffmpeg-vaapi: do not use requires at class level

### DIFF
--- a/test/ffmpeg-vaapi/decode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/decode/10bit/hevc.py
@@ -10,13 +10,13 @@ from ..decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
-@platform_tags(HEVC_DECODE_10BIT_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
+  @platform_tags(HEVC_DECODE_10BIT_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/avc.py
+++ b/test/ffmpeg-vaapi/decode/avc.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
-@platform_tags(AVC_DECODE_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
+  @platform_tags(AVC_DECODE_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/hevc.py
+++ b/test/ffmpeg-vaapi/decode/hevc.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
-@platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/jpeg.py
+++ b/test/ffmpeg-vaapi/decode/jpeg.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 
-@platform_tags(JPEG_DECODE_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
     super(default, self).before()
 
+  @platform_tags(JPEG_DECODE_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/mpeg2.py
+++ b/test/ffmpeg-vaapi/decode/mpeg2.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 
-@platform_tags(MPEG2_DECODE_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
     super(default, self).before()
 
+  @platform_tags(MPEG2_DECODE_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/vc1.py
+++ b/test/ffmpeg-vaapi/decode/vc1.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("vc1", "decode")
 
-@platform_tags(VC1_DECODE_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
     super(default, self).before()
 
+  @platform_tags(VC1_DECODE_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/vp8.py
+++ b/test/ffmpeg-vaapi/decode/vp8.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
-@platform_tags(VP8_DECODE_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
+  @platform_tags(VP8_DECODE_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/vp9.py
+++ b/test/ffmpeg-vaapi/decode/vp9.py
@@ -10,13 +10,13 @@ from .decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
-@platform_tags(VP9_DECODE_8BIT_PLATFORMS)
 class default(DecoderTest):
   def before(self):
     # default metric
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
+  @platform_tags(VP9_DECODE_8BIT_PLATFORMS)
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -8,7 +8,6 @@ from .....lib import *
 from ...util import *
 from ..encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_hevc_vaapi_encode)
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -28,8 +27,9 @@ class HEVC10EncoderTest(EncoderTest):
 
 spec = load_test_spec("hevc", "encode", "10bit")
 
-@platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
 class cqp(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -45,8 +45,9 @@ class cqp(HEVC10EncoderTest):
     )
     self.encode()
 
-@platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
 class cbr(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     vars(self).update(spec[case].copy())
@@ -64,8 +65,9 @@ class cbr(HEVC10EncoderTest):
     )
     self.encode()
 
-@platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
 class vbr(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_h264_vaapi_encode)
 class AVCEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -30,8 +29,9 @@ class AVCEncoderTest(EncoderTest):
 
 spec = load_test_spec("avc", "encode")
 
-@platform_tags(AVC_ENCODE_PLATFORMS)
 class cqp(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     vars(self).update(spec[case].copy())
@@ -48,8 +48,9 @@ class cqp(AVCEncoderTest):
     )
     self.encode()
 
-@platform_tags(AVC_ENCODE_LP_PLATFORMS)
 class cqp_lp(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     vars(self).update(spec[case].copy())
@@ -65,8 +66,9 @@ class cqp_lp(AVCEncoderTest):
     )
     self.encode()
 
-@platform_tags(AVC_ENCODE_PLATFORMS)
 class cbr(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     vars(self).update(spec[case].copy())
@@ -85,8 +87,9 @@ class cbr(AVCEncoderTest):
     )
     self.encode()
 
-@platform_tags(AVC_ENCODE_PLATFORMS)
 class vbr(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_hevc_vaapi_encode)
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -28,8 +27,9 @@ class HEVC8EncoderTest(EncoderTest):
 
 spec = load_test_spec("hevc", "encode", "8bit")
 
-@platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
 class cqp(HEVC8EncoderTest):
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -45,8 +45,9 @@ class cqp(HEVC8EncoderTest):
     )
     self.encode()
 
-@platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
 class cbr(HEVC8EncoderTest):
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     vars(self).update(spec[case].copy())
@@ -64,8 +65,9 @@ class cbr(HEVC8EncoderTest):
     )
     self.encode()
 
-@platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
 class vbr(HEVC8EncoderTest):
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
 class JPEGEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -27,8 +26,9 @@ class JPEGEncoderTest(EncoderTest):
 
 spec = load_test_spec("jpeg", "encode")
 
-@platform_tags(JPEG_ENCODE_PLATFORMS)
 class cqp(JPEGEncoderTest):
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -29,8 +28,9 @@ class MPEG2EncoderTest(EncoderTest):
 
 spec = load_test_spec("mpeg2", "encode")
 
-@platform_tags(MPEG2_ENCODE_PLATFORMS)
 class cqp(MPEG2EncoderTest):
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
   def test(self, case, gop, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_vp8_vaapi_encode)
 class VP8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -27,8 +26,9 @@ class VP8EncoderTest(EncoderTest):
 
 spec = load_test_spec("vp8", "encode")
 
-@platform_tags(VP8_ENCODE_PLATFORMS)
 class cqp(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -43,8 +43,9 @@ class cqp(VP8EncoderTest):
     )
     self.encode()
 
-@platform_tags(VP8_ENCODE_PLATFORMS)
 class cbr(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
     vars(self).update(spec[case].copy())
@@ -62,8 +63,9 @@ class cbr(VP8EncoderTest):
     )
     self.encode()
 
-@platform_tags(VP8_ENCODE_PLATFORMS)
 class vbr(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -8,7 +8,6 @@ from ....lib import *
 from ..util import *
 from .encoder import EncoderTest
 
-@slash.requires(have_ffmpeg_vp9_vaapi_encode)
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -27,8 +26,9 @@ class VP9EncoderTest(EncoderTest):
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
 class cqp(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
   @slash.parametrize(*gen_vp9_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -44,8 +44,9 @@ class cqp(VP9EncoderTest):
     )
     self.encode()
 
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
 class cbr(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
   @slash.parametrize(*gen_vp9_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -64,8 +65,9 @@ class cbr(VP9EncoderTest):
     )
     self.encode()
 
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
 class vbr(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
   @slash.parametrize(*gen_vp9_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")


### PR DESCRIPTION
Using slash.requires at the class level causes the
requirement to be applied to all branches of the
entire class inheritance tree starting from the base
class.  This is problematic because if one requirement
is not met on a derived class, then every class that
is derived from the same base gets flagged for that
unmet requirement.

See https://github.com/getslash/slash/issues/928 for
more details about this issue.

Thus, move slash.requires to the test functions where
we intend for that requirement only to be used within
that scope.

Also, to be safe, don't use slash.tags at the class
level either.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>