### PR TITLE
gst-vaapi/decode: refactor tests for better code reuse

### DIFF
--- a/baseline/default
+++ b/baseline/default
@@ -5037,52 +5037,52 @@
       ]
     }
   }, 
-  "test/gst-vaapi/decode/avc.py:test_default(case=1080p)": {
+  "test/gst-vaapi/decode/avc.py:default.test(case=1080p)": {
     "md5": "2873526ec49defd754c7853f0658799d"
   }, 
-  "test/gst-vaapi/decode/avc.py:test_default(case=720p)": {
+  "test/gst-vaapi/decode/avc.py:default.test(case=720p)": {
     "md5": "e6b24a42be6b698f1bf96b75d1480ade"
   }, 
-  "test/gst-vaapi/decode/avc.py:test_default(case=QCIF)": {
+  "test/gst-vaapi/decode/avc.py:default.test(case=QCIF)": {
     "md5": "61aeb97a3ab5da00a28a962ae9d69a28"
   }, 
-  "test/gst-vaapi/decode/avc.py:test_default(case=QVGA)": {
+  "test/gst-vaapi/decode/avc.py:default.test(case=QVGA)": {
     "md5": "767f88894d9635691c6e1af82b1a738b"
   }, 
-  "test/gst-vaapi/decode/hevc.py:test_8bit(case=1080p)": {
+  "test/gst-vaapi/decode/hevc.py:default.test(case=1080p)": {
     "md5": "3f66eca6367872ffbe2d53ab0c573852"
   }, 
-  "test/gst-vaapi/decode/hevc.py:test_8bit(case=720p)": {
+  "test/gst-vaapi/decode/hevc.py:default.test(case=720p)": {
     "md5": "fc0bde09b5befabb0c17593ca51bdb37"
   }, 
-  "test/gst-vaapi/decode/hevc.py:test_8bit(case=QCIF)": {
+  "test/gst-vaapi/decode/hevc.py:default.test(case=QCIF)": {
     "md5": "c6d9e88dcbcec23942344649c0c01bc4"
   }, 
-  "test/gst-vaapi/decode/hevc.py:test_8bit(case=QVGA)": {
+  "test/gst-vaapi/decode/hevc.py:default.test(case=QVGA)": {
     "md5": "f9ea7bcce345d7775c888e71de435721"
   }, 
-  "test/gst-vaapi/decode/vp8.py:test_default(case=1080p)": {
+  "test/gst-vaapi/decode/vp8.py:default.test(case=1080p)": {
     "md5": "02571f75accdd3c04475ca4158692b5a"
   }, 
-  "test/gst-vaapi/decode/vp8.py:test_default(case=720p)": {
+  "test/gst-vaapi/decode/vp8.py:default.test(case=720p)": {
     "md5": "6ad352c5fa46789c9ec041b5b40c166f"
   }, 
-  "test/gst-vaapi/decode/vp8.py:test_default(case=QCIF)": {
+  "test/gst-vaapi/decode/vp8.py:default.test(case=QCIF)": {
     "md5": "85cd30186f09ee9cd0ba62a27e80e0c9"
   }, 
-  "test/gst-vaapi/decode/vp8.py:test_default(case=QVGA)": {
+  "test/gst-vaapi/decode/vp8.py:default.test(case=QVGA)": {
     "md5": "f3c9ed63ec11f05dc80d4c4e11d466ae"
   }, 
-  "test/gst-vaapi/decode/vp9.py:test_8bit(case=1080p)": {
+  "test/gst-vaapi/decode/vp9.py:default.test(case=1080p)": {
     "md5": "6c4e5c87c6f0e28aaf9fd22d76e67502"
   }, 
-  "test/gst-vaapi/decode/vp9.py:test_8bit(case=720p)": {
+  "test/gst-vaapi/decode/vp9.py:default.test(case=720p)": {
     "md5": "94fa781d49e61edb726bc67745aff937"
   }, 
-  "test/gst-vaapi/decode/vp9.py:test_8bit(case=QCIF)": {
+  "test/gst-vaapi/decode/vp9.py:default.test(case=QCIF)": {
     "md5": "c983151ec2d2b6ebfcff776112a5ae3f"
   }, 
-  "test/gst-vaapi/decode/vp9.py:test_8bit(case=QVGA)": {
+  "test/gst-vaapi/decode/vp9.py:default.test(case=QVGA)": {
     "md5": "e0b3e642609dcd5718bc0c6d7c5b8c3d"
   }, 
   "test/gst-vaapi/encode/avc.py:test_cbr(bframes=0,bitrate=250,case=QCIF,fps=30,gop=30,profile=main,slices=1)": {

--- a/test/gst-vaapi/decode/10bit/__init__.py
+++ b/test/gst-vaapi/decode/10bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-vaapi/decode/10bit/hevc.py
+++ b/test/gst-vaapi/decode/10bit/hevc.py
@@ -4,11 +4,11 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from .....lib import *
+from ...util import *
+from ..decoder import DecoderTest
 
-spec = load_test_spec("vp8", "decode")
+spec = load_test_spec("hevc", "decode", "10bit")
 
 class default(DecoderTest):
   def before(self):
@@ -16,18 +16,13 @@ class default(DecoderTest):
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
-  @platform_tags(VP8_DECODE_PLATFORMS)
-  @slash.requires(*have_gst_element("vaapivp8dec"))
+  @platform_tags(HEVC_DECODE_10BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-
-    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
-    ext = os.path.splitext(self.source)[1]
-    assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
-
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp8dec".format(dxmap[ext]),
+      gstdecoder  = "h265parse ! vaapih265dec",
     )
     self.decode()

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -4,11 +4,11 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from .....lib import *
+from ...util import *
+from ..decoder import DecoderTest
 
-spec = load_test_spec("vp8", "decode")
+spec = load_test_spec("vp9", "decode", "10bit")
 
 class default(DecoderTest):
   def before(self):
@@ -16,8 +16,8 @@ class default(DecoderTest):
     self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
     super(default, self).before()
 
-  @platform_tags(VP8_DECODE_PLATFORMS)
-  @slash.requires(*have_gst_element("vaapivp8dec"))
+  @platform_tags(VP9_DECODE_10BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -28,6 +28,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp8dec".format(dxmap[ext]),
+      gstdecoder  = "{} ! vaapivp9dec".format(dxmap[ext]),
     )
     self.decode()

--- a/test/gst-vaapi/decode/avc.py
+++ b/test/gst-vaapi/decode/avc.py
@@ -6,36 +6,23 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec.keys()))
-@platform_tags(AVC_DECODE_PLATFORMS)
-def test_default(case):
-  params = spec[case].copy()
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    super(default, self).before()
 
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! h264parse ! vaapih264dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0))
-  check_metric(**params)
-
-
+  @platform_tags(AVC_DECODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih264dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "h264parse ! vaapih264dec",
+    )
+    self.decode()

--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -1,0 +1,36 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("vaapi"))
+@slash.requires(*have_gst_element("checksumsink2"))
+class DecoderTest(slash.Test):
+  def before(self):
+    self.refctx = []
+
+  def decode(self):
+    self.mformatu = mapformatu(self.format)
+    if self.mformatu is None:
+      slash.skip_test("{format} format not supported".format(**vars(self)))
+
+    self.decoded = get_media()._test_artifact(
+      "{case}_{width}x{height}_{format}.yuv".format(**vars(self)))
+
+    call(
+      "gst-launch-1.0 -vf filesrc location={source}"
+      " ! {gstdecoder}"
+      " ! videoconvert ! video/x-raw,format={mformatu}"
+      " ! checksumsink2 file-checksum=false qos=false"
+      " frame-checksum=false plane-checksum=false dump-output=true"
+      " dump-location={decoded}".format(**vars(self)))
+
+    self.check_metrics()
+
+  def check_metrics(self):
+    check_metric(**vars(self))

--- a/test/gst-vaapi/decode/hevc.py
+++ b/test/gst-vaapi/decode/hevc.py
@@ -6,69 +6,23 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih265dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec.keys()))
-@platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
-def test_8bit(case):
-  params = spec[case].copy()
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    super(default, self).before()
 
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! h265parse ! vaapih265dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0))
-  check_metric(**params)
-
-#-------------------------------------------------#
-#---------------------10BIT-----------------------#
-#-------------------------------------------------#
-
-spec10 = load_test_spec("hevc", "decode", "10bit")
-
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih265dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec10.keys()))
-@platform_tags(HEVC_DECODE_10BIT_PLATFORMS)
-def test_10bit(case):
-  params = spec10[case].copy()
-
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! h265parse ! vaapih265dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0))
-  check_metric(**params)
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih265dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "h265parse ! vaapih265dec",
+    )
+    self.decode()

--- a/test/gst-vaapi/decode/jpeg.py
+++ b/test/gst-vaapi/decode/jpeg.py
@@ -6,34 +6,23 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapijpegdec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec.keys()))
-@platform_tags(JPEG_DECODE_PLATFORMS)
-def test_default(case):
-  params = spec[case].copy()
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    super(default, self).before()
 
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! jpegparse ! vaapijpegdec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99))
-  check_metric(**params)
+  @platform_tags(JPEG_DECODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapijpegdec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "jpegparse ! vaapijpegdec",
+    )
+    self.decode()

--- a/test/gst-vaapi/decode/mpeg2.py
+++ b/test/gst-vaapi/decode/mpeg2.py
@@ -6,34 +6,23 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapimpeg2dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec.keys()))
-@platform_tags(MPEG2_DECODE_PLATFORMS)
-def test_default(case):
-  params = spec[case].copy()
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    super(default, self).before()
 
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! mpegvideoparse ! vaapimpeg2dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99))
-  check_metric(**params)
+  @platform_tags(MPEG2_DECODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapimpeg2dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "mpegvideoparse ! vaapimpeg2dec",
+    )
+    self.decode()

--- a/test/gst-vaapi/decode/vc1.py
+++ b/test/gst-vaapi/decode/vc1.py
@@ -6,36 +6,25 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
 spec = load_test_spec("vc1", "decode")
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivc1dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec.keys()))
-@platform_tags(VC1_DECODE_PLATFORMS)
-def test_default(case):
-  params = spec[case].copy()
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    super(default, self).before()
 
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! 'video/x-wmv,profile=(string)advanced'"
-    " ,width={width},height={height},framerate=14/1"
-    " ! vaapivc1dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false qos=false"
-    " frame-checksum=false plane-checksum=false dump-output=true"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99))
-  check_metric(**params)
+  @platform_tags(VC1_DECODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivc1dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "'video/x-wmv,profile=(string)advanced'"
+                    ",width={width},height={height},framerate=14/1"
+                    " ! vaapivc1dec".format(**vars(self)),
+    )
+    self.decode()

--- a/test/gst-vaapi/decode/vp9.py
+++ b/test/gst-vaapi/decode/vp9.py
@@ -6,83 +6,28 @@
 
 from ....lib import *
 from ..util import *
+from .decoder import DecoderTest
 
-#-------------------------------------------------#
-#----------------------8BIT-----------------------#
-#-------------------------------------------------#
+spec = load_test_spec("vp9", "decode", "8bit")
 
-spec_8bit = load_test_spec("vp9", "decode", "8bit")
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    super(default, self).before()
 
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(("case"), sorted(spec_8bit.keys()))
-@platform_tags(VP9_DECODE_8BIT_PLATFORMS)
-def test_8bit(case):
-  params = spec_8bit[case].copy()
+  @platform_tags(VP9_DECODE_8BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
 
-  params.update(mformatu = mapformatu(params["format"]))
+    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
+    ext = os.path.splitext(self.source)[1]
+    assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
 
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  dxmap = {".ivf":"ivfparse", ".webm":"matroskademux"}
-  ext = os.path.splitext(params["source"])[1]
-  assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
-  params["demux"] = dxmap[ext]
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! {demux} ! vaapivp9dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0))
-  check_metric(**params)
-
-#-------------------------------------------------#
-#---------------------10BIT-----------------------#
-#-------------------------------------------------#
-
-spec_10bit = load_test_spec("vp9", "decode", "10bit")
-
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@platform_tags(VP9_DECODE_10BIT_PLATFORMS)
-@slash.parametrize(("case"), sorted(spec_10bit.keys()))
-def test_10bit(case):
-  params = spec_10bit[case].copy()
-
-  params.update(mformatu = mapformatu(params["format"]))
-
-  if params["mformatu"] is None:
-    slash.skip_test("{format} format not supported".format(**params))
-
-  params["decoded"] = get_media()._test_artifact(
-    "{}_{width}x{height}_{format}.yuv".format(case, **params))
-
-  dxmap = {".ivf":"ivfparse", ".webm":"matroskademux"}
-  ext = os.path.splitext(params["source"])[1]
-  assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
-  params["demux"] = dxmap[ext]
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source}"
-    " ! {demux} ! vaapivp9dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(**params))
-
-  params.setdefault(
-    "metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0))
-  check_metric(**params)
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "{} ! vaapivp9dec".format(dxmap[ext]),
+    )
+    self.decode()

--- a/tools/xform-baseline-1.sh
+++ b/tools/xform-baseline-1.sh
@@ -2,6 +2,7 @@
 
 set -x
 
+# ffmpeg-vaapi
 sed -i "s/test\/ffmpeg-vaapi\/decode\/avc.py:test_default(/test\/ffmpeg-vaapi\/decode\/avc.py:default.test(/g" $1
 sed -i "s/test\/ffmpeg-vaapi\/decode\/hevc.py:test_8bit(/test\/ffmpeg-vaapi\/decode\/hevc.py:default.test(/g" $1
 sed -i "s/test\/ffmpeg-vaapi\/decode\/hevc.py:test_10bit(/test\/ffmpeg-vaapi\/decode\/10bit\/hevc.py:default.test(/g" $1
@@ -30,3 +31,14 @@ sed -i "s/test\/ffmpeg-vaapi\/encode\/vp8.py:test_vbr(/test\/ffmpeg-vaapi\/encod
 sed -i "s/test\/ffmpeg-vaapi\/encode\/vp9.py:test_8bit_cqp(/test\/ffmpeg-vaapi\/encode\/vp9.py:cqp.test(/g" $1
 sed -i "s/test\/ffmpeg-vaapi\/encode\/vp9.py:test_8bit_cbr(/test\/ffmpeg-vaapi\/encode\/vp9.py:cbr.test(/g" $1
 sed -i "s/test\/ffmpeg-vaapi\/encode\/vp9.py:test_8bit_vbr(/test\/ffmpeg-vaapi\/encode\/vp9.py:vbr.test(/g" $1
+
+# gst-vaapi
+sed -i "s/test\/gst-vaapi\/decode\/avc.py:test_default(/test\/gst-vaapi\/decode\/avc.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/hevc.py:test_8bit(/test\/gst-vaapi\/decode\/hevc.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/hevc.py:test_10bit(/test\/gst-vaapi\/decode\/10bit\/hevc.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/vp9.py:test_8bit(/test\/gst-vaapi\/decode\/vp9.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/vp9.py:test_10bit(/test\/gst-vaapi\/decode\/10bit\/vp9.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/jpeg.py:test_default(/test\/gst-vaapi\/decode\/jpeg.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/mpeg2.py:test_default(/test\/gst-vaapi\/decode\/mpeg2.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/vc1.py:test_default(/test\/gst-vaapi\/decode\/vc1.py:default.test(/g" $1
+sed -i "s/test\/gst-vaapi\/decode\/vp8.py:test_default(/test\/gst-vaapi\/decode\/vp8.py:default.test(/g" $1


### PR DESCRIPTION
This improves code reuse and design for gst-vaapi/decode
tests.

10bit decode tests have moved into its own sub-directory.

Updated test names in baseline.

Updated tools/xform-baseline-1.sh script to convert old
baseline test names to new test names.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>