### PR TITLE
gst-vaapi/encode: refactor tests for better code reuse

### DIFF
--- a/baseline/default
+++ b/baseline/default
@@ -5085,7 +5085,7 @@
   "test/gst-vaapi/decode/vp9.py:default.test(case=QVGA)": {
     "md5": "e0b3e642609dcd5718bc0c6d7c5b8c3d"
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cbr(bframes=0,bitrate=250,case=QCIF,fps=30,gop=30,profile=main,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cbr.test(bframes=0,bitrate=250,case=QCIF,fps=30,gop=30,profile=main,slices=1)": {
     "drv.i965": {
       "psnr": [
         36.53544450246086, 
@@ -5107,7 +5107,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cbr(bframes=0,bitrate=500,case=QVGA,fps=25,gop=30,profile=main,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cbr.test(bframes=0,bitrate=500,case=QVGA,fps=25,gop=30,profile=main,slices=1)": {
     "drv.i965": {
       "psnr": [
         34.60655379100756, 
@@ -5129,7 +5129,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cbr(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=high,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cbr.test(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=high,slices=1)": {
     "drv.i965": {
       "psnr": [
         26.774728169438028, 
@@ -5151,7 +5151,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cbr(bframes=2,bitrate=4000,case=720p,fps=30,gop=30,profile=main,slices=4)": {
+  "test/gst-vaapi/encode/avc.py:cbr.test(bframes=2,bitrate=4000,case=720p,fps=30,gop=30,profile=main,slices=4)": {
     "drv.i965": {
       "psnr": [
         27.82223689480693, 
@@ -5173,7 +5173,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=0,case=1080p,gop=1,profile=high,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=0,case=1080p,gop=1,profile=high,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         54.58553799387704, 
@@ -5195,7 +5195,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=0,case=720p,gop=1,profile=high,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=0,case=720p,gop=1,profile=high,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         45.70126335610703, 
@@ -5217,7 +5217,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=0,case=QCIF,gop=1,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=0,case=QCIF,gop=1,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         40.93839210686135, 
@@ -5239,7 +5239,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=0,case=QCIF,gop=30,profile=high,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=0,case=QCIF,gop=30,profile=high,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         38.526860169413936, 
@@ -5261,7 +5261,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=0,case=QVGA,gop=1,profile=high,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=0,case=QVGA,gop=1,profile=high,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         55.87885538144042, 
@@ -5283,7 +5283,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=2,case=1080p,gop=30,profile=main,qp=28,quality=4,slices=4)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=2,case=1080p,gop=30,profile=main,qp=28,quality=4,slices=4)": {
     "drv.i965": {
       "psnr": [
         41.883097142727195, 
@@ -5305,7 +5305,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp(bframes=2,case=QVGA,gop=30,profile=main,qp=28,quality=4,slices=4)": {
+  "test/gst-vaapi/encode/avc.py:cqp.test(bframes=2,case=QVGA,gop=30,profile=main,qp=28,quality=4,slices=4)": {
     "drv.i965": {
       "psnr": [
         41.10426603953417, 
@@ -5327,7 +5327,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=1080p,gop=30,profile=high,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=1080p,gop=30,profile=high,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         43.19042786993673, 
@@ -5349,7 +5349,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=1080p,gop=30,profile=main,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=1080p,gop=30,profile=main,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         43.19042786993673, 
@@ -5371,7 +5371,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=720p,gop=30,profile=high,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=720p,gop=30,profile=high,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         55.65120939056125, 
@@ -5393,7 +5393,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=720p,gop=30,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=720p,gop=30,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         55.65120939056125, 
@@ -5415,7 +5415,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QCIF,gop=1,profile=high,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QCIF,gop=1,profile=high,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         39.46372170055022, 
@@ -5437,7 +5437,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QCIF,gop=1,profile=main,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QCIF,gop=1,profile=main,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         39.46372170055022, 
@@ -5459,7 +5459,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QCIF,gop=30,profile=high,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QCIF,gop=30,profile=high,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         40.93904633724244, 
@@ -5481,7 +5481,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QCIF,gop=30,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QCIF,gop=30,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         40.93904633724244, 
@@ -5503,7 +5503,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QVGA,gop=1,profile=high,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QVGA,gop=1,profile=high,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         44.44677245674198, 
@@ -5525,7 +5525,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QVGA,gop=1,profile=main,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QVGA,gop=1,profile=main,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         44.44677245674198, 
@@ -5547,29 +5547,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QVGA,gop=30,profile=high,qp=14,quality=4,slices=1)": {
-    "drv.i965": {
-      "psnr": [
-        53.7446797554854, 
-        62.475768885196565, 
-        60.801842360590214, 
-        54.36581033653427, 
-        63.01143202689017, 
-        61.362931065784664
-      ]
-    }, 
-    "drv.iHD": {
-      "psnr": [
-        55.06990566434527, 
-        62.29503775233961, 
-        61.22791966144203, 
-        55.36420042780549, 
-        63.196853581247254, 
-        61.388776098839685
-      ]
-    }
-  }, 
-  "test/gst-vaapi/encode/avc.py:test_cqp_lp(case=QVGA,gop=30,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QVGA,gop=30,profile=high,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         53.7446797554854, 
@@ -5591,7 +5569,29 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_vbr(bframes=0,bitrate=4000,case=720p,fps=30,gop=30,profile=high,quality=4,refs=1,slices=3)": {
+  "test/gst-vaapi/encode/avc.py:cqp_lp.test(case=QVGA,gop=30,profile=main,qp=14,quality=4,slices=1)": {
+    "drv.i965": {
+      "psnr": [
+        53.7446797554854, 
+        62.475768885196565, 
+        60.801842360590214, 
+        54.36581033653427, 
+        63.01143202689017, 
+        61.362931065784664
+      ]
+    }, 
+    "drv.iHD": {
+      "psnr": [
+        55.06990566434527, 
+        62.29503775233961, 
+        61.22791966144203, 
+        55.36420042780549, 
+        63.196853581247254, 
+        61.388776098839685
+      ]
+    }
+  }, 
+  "test/gst-vaapi/encode/avc.py:vbr.test(bframes=0,bitrate=4000,case=720p,fps=30,gop=30,profile=high,quality=4,refs=1,slices=3)": {
     "drv.i965": {
       "psnr": [
         30.633927567717496, 
@@ -5613,7 +5613,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_vbr(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
+  "test/gst-vaapi/encode/avc.py:vbr.test(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
     "drv.i965": {
       "psnr": [
         26.92188231000773, 
@@ -5635,7 +5635,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_vbr(bframes=3,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:vbr.test(bframes=3,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
     "drv.i965": {
       "psnr": [
         27.89610711828898, 
@@ -5657,7 +5657,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/avc.py:test_vbr(bframes=3,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
+  "test/gst-vaapi/encode/avc.py:vbr.test(bframes=3,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
     "drv.i965": {
       "psnr": [
         24.621672391355183, 
@@ -5679,7 +5679,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cbr(bframes=0,bitrate=250,case=QCIF,fps=30,gop=30,profile=main,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cbr.test(bframes=0,bitrate=250,case=QCIF,fps=30,gop=30,profile=main,slices=1)": {
     "drv.i965": {
       "psnr": [
         39.71280023061145, 
@@ -5701,7 +5701,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cbr(bframes=0,bitrate=500,case=QVGA,fps=25,gop=30,profile=main,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cbr.test(bframes=0,bitrate=500,case=QVGA,fps=25,gop=30,profile=main,slices=1)": {
     "drv.i965": {
       "psnr": [
         35.615292690984425, 
@@ -5723,7 +5723,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cbr(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cbr.test(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,slices=1)": {
     "drv.i965": {
       "psnr": [
         26.60013342074261, 
@@ -5745,7 +5745,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cbr(bframes=2,bitrate=4000,case=720p,fps=30,gop=30,profile=main,slices=4)": {
+  "test/gst-vaapi/encode/hevc.py:cbr.test(bframes=2,bitrate=4000,case=720p,fps=30,gop=30,profile=main,slices=4)": {
     "drv.i965": {
       "psnr": [
         28.44322741126344, 
@@ -5767,7 +5767,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=0,case=1080p,gop=1,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=0,case=1080p,gop=1,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         58.6991057425432, 
@@ -5789,7 +5789,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=0,case=720p,gop=1,profile=main,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=0,case=720p,gop=1,profile=main,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         45.67736676057428, 
@@ -5811,7 +5811,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=0,case=QCIF,gop=1,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=0,case=QCIF,gop=1,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         56.396935671914946, 
@@ -5833,7 +5833,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=0,case=QCIF,gop=30,profile=main,qp=28,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=0,case=QCIF,gop=30,profile=main,qp=28,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         41.69388625264743, 
@@ -5855,7 +5855,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=0,case=QVGA,gop=1,profile=main,qp=14,quality=4,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=0,case=QVGA,gop=1,profile=main,qp=14,quality=4,slices=1)": {
     "drv.i965": {
       "psnr": [
         57.50664872434684, 
@@ -5877,7 +5877,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=2,case=1080p,gop=30,profile=main,qp=28,quality=4,slices=4)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=2,case=1080p,gop=30,profile=main,qp=28,quality=4,slices=4)": {
     "drv.i965": {
       "psnr": [
         41.364835452877955, 
@@ -5899,7 +5899,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_cqp(bframes=2,case=QVGA,gop=30,profile=main,qp=28,quality=4,slices=4)": {
+  "test/gst-vaapi/encode/hevc.py:cqp.test(bframes=2,case=QVGA,gop=30,profile=main,qp=28,quality=4,slices=4)": {
     "drv.i965": {
       "psnr": [
         40.724658453737554, 
@@ -5921,7 +5921,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_vbr(bframes=0,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
+  "test/gst-vaapi/encode/hevc.py:vbr.test(bframes=0,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
     "drv.i965": {
       "psnr": [
         31.171601114582867, 
@@ -5943,7 +5943,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_vbr(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
+  "test/gst-vaapi/encode/hevc.py:vbr.test(bframes=0,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=3)": {
     "drv.i965": {
       "psnr": [
         26.596062616868462, 
@@ -5965,7 +5965,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_vbr(bframes=3,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:vbr.test(bframes=3,bitrate=4000,case=720p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
     "drv.i965": {
       "psnr": [
         29.2894645857385, 
@@ -5987,7 +5987,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/hevc.py:test_8bit_vbr(bframes=3,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
+  "test/gst-vaapi/encode/hevc.py:vbr.test(bframes=3,bitrate=6000,case=1080p,fps=30,gop=30,profile=main,quality=4,refs=1,slices=1)": {
     "drv.i965": {
       "psnr": [
         25.960981815722384, 
@@ -6009,7 +6009,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=1080p,quality=10)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=1080p,quality=10)": {
     "drv.i965": {
       "psnr": [
         25.922066354431724, 
@@ -6031,7 +6031,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=1080p,quality=73)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=1080p,quality=73)": {
     "drv.i965": {
       "psnr": [
         39.77989782551977, 
@@ -6053,7 +6053,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=720p,quality=10)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=720p,quality=10)": {
     "drv.i965": {
       "psnr": [
         25.861306933927153, 
@@ -6075,7 +6075,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=720p,quality=73)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=720p,quality=73)": {
     "drv.i965": {
       "psnr": [
         39.66567811171605, 
@@ -6097,7 +6097,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=QCIF,quality=10)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=QCIF,quality=10)": {
     "drv.i965": {
       "psnr": [
         24.858540187878543, 
@@ -6119,7 +6119,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=QCIF,quality=73)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=QCIF,quality=73)": {
     "drv.i965": {
       "psnr": [
         37.978047056506945, 
@@ -6141,7 +6141,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=QVGA,quality=10)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=QVGA,quality=10)": {
     "drv.i965": {
       "psnr": [
         25.514773721752164, 
@@ -6163,7 +6163,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/jpeg.py:test_cqp(case=QVGA,quality=73)": {
+  "test/gst-vaapi/encode/jpeg.py:cqp.test(case=QVGA,quality=73)": {
     "drv.i965": {
       "psnr": [
         39.03555671356373, 
@@ -6185,7 +6185,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/mpeg2.py:test_cqp(bframes=0,case=1080p,gop=1,qp=14,quality=4)": {
+  "test/gst-vaapi/encode/mpeg2.py:cqp.test(bframes=0,case=1080p,gop=1,profile=simple,qp=14,quality=4)": {
     "drv.i965": {
       "psnr": [
         35.71357525452988, 
@@ -6197,7 +6197,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/mpeg2.py:test_cqp(bframes=0,case=720p,gop=30,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/mpeg2.py:cqp.test(bframes=0,case=720p,gop=30,profile=simple,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         33.81620160363789, 
@@ -6209,7 +6209,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/mpeg2.py:test_cqp(bframes=0,case=QCIF,gop=1,qp=14,quality=4)": {
+  "test/gst-vaapi/encode/mpeg2.py:cqp.test(bframes=0,case=QCIF,gop=1,profile=simple,qp=14,quality=4)": {
     "drv.i965": {
       "psnr": [
         34.124215165522315, 
@@ -6221,7 +6221,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/mpeg2.py:test_cqp(bframes=0,case=QCIF,gop=30,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/mpeg2.py:cqp.test(bframes=0,case=QCIF,gop=30,profile=simple,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         32.36074443056917, 
@@ -6233,7 +6233,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cbr(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0)": {
+  "test/gst-vaapi/encode/vp8.py:cbr.test(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0)": {
     "drv.i965": {
       "psnr": [
         36.665094633737354, 
@@ -6245,7 +6245,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cbr(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0)": {
+  "test/gst-vaapi/encode/vp8.py:cbr.test(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0)": {
     "drv.i965": {
       "psnr": [
         29.339279611855513, 
@@ -6257,7 +6257,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cbr(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0)": {
+  "test/gst-vaapi/encode/vp8.py:cbr.test(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0)": {
     "drv.i965": {
       "psnr": [
         30.927860077078613, 
@@ -6269,7 +6269,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cbr(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0)": {
+  "test/gst-vaapi/encode/vp8.py:cbr.test(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0)": {
     "drv.i965": {
       "psnr": [
         27.49218371385833, 
@@ -6281,7 +6281,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4)": {
     "drv.i965": {
       "psnr": [
         50.10386790822138, 
@@ -6293,7 +6293,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         46.19256715746195, 
@@ -6305,7 +6305,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=720p,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=720p,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         46.09876137037703, 
@@ -6317,7 +6317,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=QCIF,ipmode=0,looplvl=0,loopshp=0,qp=14,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=QCIF,ipmode=0,looplvl=0,loopshp=0,qp=14,quality=4)": {
     "drv.i965": {
       "psnr": [
         48.06313234804869, 
@@ -6329,7 +6329,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=QCIF,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=QCIF,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         44.36731847724069, 
@@ -6341,7 +6341,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=QVGA,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=QVGA,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4)": {
     "drv.i965": {
       "psnr": [
         45.14363704902833, 
@@ -6353,7 +6353,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_cqp(case=QVGA,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:cqp.test(case=QVGA,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4)": {
     "drv.i965": {
       "psnr": [
         49.15052602481726, 
@@ -6365,7 +6365,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_vbr(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:vbr.test(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
     "drv.i965": {
       "psnr": [
         37.234779513676145, 
@@ -6377,7 +6377,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_vbr(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:vbr.test(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
     "drv.i965": {
       "psnr": [
         27.71747822908672, 
@@ -6389,7 +6389,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_vbr(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:vbr.test(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
     "drv.i965": {
       "psnr": [
         32.29631249929656, 
@@ -6401,7 +6401,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp8.py:test_vbr(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
+  "test/gst-vaapi/encode/vp8.py:vbr.test(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4)": {
     "drv.i965": {
       "psnr": [
         27.485200578808303, 
@@ -6413,7 +6413,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cbr(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cbr.test(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
     "drv.i965": {
       "psnr": [
         32.38053149957535, 
@@ -6425,7 +6425,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cbr(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cbr.test(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
     "drv.i965": {
       "psnr": [
         25.66308781969253, 
@@ -6437,7 +6437,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cbr(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cbr.test(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
     "drv.i965": {
       "psnr": [
         27.511540045758856, 
@@ -6449,7 +6449,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cbr(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cbr.test(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,refmode=0)": {
     "drv.i965": {
       "psnr": [
         24.361865339772596, 
@@ -6461,7 +6461,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4,refmode=1)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4,refmode=1)": {
     "drv.i965": {
       "psnr": [
         57.97463854735773, 
@@ -6473,7 +6473,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=1080p,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         54.28287440583625, 
@@ -6485,7 +6485,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=720p,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4,refmode=1)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=720p,ipmode=0,looplvl=0,loopshp=0,qp=28,quality=4,refmode=1)": {
     "drv.i965": {
       "psnr": [
         57.29511337091395, 
@@ -6497,7 +6497,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=QCIF,ipmode=0,looplvl=0,loopshp=0,qp=14,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=QCIF,ipmode=0,looplvl=0,loopshp=0,qp=14,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         59.448817332773, 
@@ -6509,7 +6509,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=QCIF,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4,refmode=1)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=QCIF,ipmode=1,looplvl=0,loopshp=0,qp=28,quality=4,refmode=1)": {
     "drv.i965": {
       "psnr": [
         52.32608263191446, 
@@ -6521,7 +6521,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=QVGA,ipmode=0,looplvl=16,loopshp=7,qp=28,quality=4,refmode=1)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=QVGA,ipmode=0,looplvl=16,loopshp=7,qp=28,quality=4,refmode=1)": {
     "drv.i965": {
       "psnr": [
         56.22931116375008, 
@@ -6533,7 +6533,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_cqp(case=QVGA,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:cqp.test(case=QVGA,ipmode=1,looplvl=0,loopshp=0,qp=14,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         57.41697035616731, 
@@ -6545,7 +6545,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_vbr(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:vbr.test(bitrate=250,case=QCIF,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         34.696322900286425, 
@@ -6557,7 +6557,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_vbr(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:vbr.test(bitrate=4000,case=720p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         27.530425401542704, 
@@ -6569,7 +6569,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_vbr(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:vbr.test(bitrate=500,case=QVGA,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         29.832595794569325, 
@@ -6581,7 +6581,7 @@
       ]
     }
   }, 
-  "test/gst-vaapi/encode/vp9.py:test_8bit_vbr(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
+  "test/gst-vaapi/encode/vp9.py:vbr.test(bitrate=6000,case=1080p,fps=30,gop=30,looplvl=0,loopshp=0,quality=4,refmode=0)": {
     "drv.i965": {
       "psnr": [
         24.875716835084532, 

--- a/test/gst-vaapi/encode/10bit/__init__.py
+++ b/test/gst-vaapi/encode/10bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -4,31 +4,31 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from .....lib import *
+from ...util import *
+from ..encoder import EncoderTest
 
-spec = load_test_spec("hevc", "encode", "8bit")
+spec = load_test_spec("hevc", "encode", "10bit")
 
-class HEVC8EncoderTest(EncoderTest):
+class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
-      codec         = "hevc-8",
+      codec         = "hevc-10",
       gstencoder    = "vaapih265enc",
       gstdecoder    = "h265parse ! vaapih265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
     )
-    super(HEVC8EncoderTest, self).before()
+    super(HEVC10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
-class cqp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+class cqp(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     vars(self).update(spec[case].copy())
     vars(self).update(
@@ -43,11 +43,11 @@ class cqp(HEVC8EncoderTest):
     )
     self.encode()
 
-class cbr(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+class cbr(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     vars(self).update(spec[case].copy())
     vars(self).update(
@@ -64,11 +64,11 @@ class cbr(HEVC8EncoderTest):
     )
     self.encode()
 
-class vbr(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+class vbr(HEVC10EncoderTest):
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -6,214 +6,107 @@
 
 from ....lib import *
 from ..util import *
+from .encoder import EncoderTest
 
 spec = load_test_spec("avc", "encode")
 
-def check_psnr(params):
-  call(
-    "gst-launch-1.0 -vf filesrc location={encoded}"
-    " ! h264parse ! vaapih264dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(
-      mformatu = mapformatu(params["format"]), **params
+class AVCEncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "avc",
+      gstencoder    = "vaapih264enc",
+      gstdecoder    = "h264parse ! vaapih264dec",
+      gstmediatype  = "video/x-h264",
+      gstparser     = "h264parse",
     )
-  )
+    super(AVCEncoderTest, self).before()
 
-  get_media().baseline.check_psnr(
-    psnr = calculate_psnr(
-      params["source"], params["decoded"],
-      params["width"], params["height"],
-      params["frames"], params["format"]),
-    context = params.get("refctx", []),
-  )
+  def get_file_ext(self):
+    return "h264"
 
-#-------------------------------------------------#
-#---------------------- CQP ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_avc_cqp_parameters(spec, ['main', 'high']))
-@platform_tags(AVC_ENCODE_PLATFORMS)
-def test_cqp(case, gop, slices, bframes, qp, quality, profile):
-  params = spec[case].copy()
+class cqp(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih264enc"))
+  @slash.requires(*have_gst_element("vaapih264dec"))
+  @slash.parametrize(*gen_avc_cqp_parameters(spec, ['main', 'high']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      lowpower  = False,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+    self.encode()
 
-  mprofile = mapprofile("avc", profile)
-  if mprofile is None:
-    slash.skip_test("{} profile is not supported".format(profile))
+class cqp_lp(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_LP_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih264enc"))
+  @slash.requires(*have_gst_element("vaapih264dec"))
+  @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, qp, quality, profile):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = gop,
+      lowpower  = True,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+    self.encode()
 
-  params.update(
-    gop = gop, slices = slices, bframes = bframes, qp = qp, quality = quality,
-    profile = mprofile, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
+class cbr(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih264enc"))
+  @slash.requires(*have_gst_element("vaapih264dec"))
+  @slash.parametrize(*gen_avc_cbr_parameters(spec, ['main', 'high']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      lowpower  = False,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+    self.encode()
 
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{qp}-{quality}-{profile}"
-    ".h264".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{qp}-{quality}-{profile}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapih264enc rate-control=cqp init-qp={qp} quality-level={quality}"
-    " keyframe-period={gop} num-slices={slices} max-bframes={bframes}"
-    " ! video/x-h264,profile={profile} ! h264parse"
-    " ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
-@platform_tags(AVC_ENCODE_LP_PLATFORMS)
-def test_cqp_lp(case, gop, slices, qp, quality, profile):
-  params = spec[case].copy()
-
-  mprofile = mapprofile("avc", profile)
-  if mprofile is None:
-    slash.skip_test("{} profile is not supported".format(profile))
-
-  params.update(
-    profile = mprofile, gop = gop, slices = slices, qp = qp,
-    quality = quality, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{qp}-{quality}-{profile}"
-    ".h264".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{qp}-{quality}-{profile}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapih264enc rate-control=cqp init-qp={qp} quality-level={quality}"
-    " keyframe-period={gop} num-slices={slices} tune=low-power"
-    " ! video/x-h264,profile={profile} ! h264parse"
-    " ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
-
-#-------------------------------------------------#
-#---------------------- CBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_avc_cbr_parameters(spec, ['main', 'high']))
-@platform_tags(AVC_ENCODE_PLATFORMS)
-def test_cbr(case, gop, slices, bframes, bitrate, fps, profile):
-  params = spec[case].copy()
-
-  mprofile = mapprofile("avc", profile)
-  if mprofile is None:
-    slash.skip_test("{} profile is not supported".format(profile))
-
-  params.update(
-    gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
-    profile = mprofile, fps = fps, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}"
-    ".h264".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapih264enc rate-control=cbr bitrate={bitrate} keyframe-period={gop}"
-    " num-slices={slices} max-bframes={bframes}"
-    " ! video/x-h264,profile={profile} ! h264parse"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-  bitrate_gap = abs(bitrate_actual - bitrate) / bitrate
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual),
-    bitrate_gap = "{:.2%}".format(bitrate_gap))
-
-  assert(bitrate_gap <= 0.10)
-
-  check_psnr(params)
-
-
-#-------------------------------------------------#
-#---------------------- VBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_avc_vbr_parameters(spec, ['main', 'high']))
-@platform_tags(AVC_ENCODE_PLATFORMS)
-def test_vbr(case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-  params = spec[case].copy()
-
-  mprofile = mapprofile("avc", profile)
-  if mprofile is None:
-    slash.skip_test("{} profile is not supported".format(profile))
-
-  # target percentage 70% (hard-coded in gst-vaapi)
-  # gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
-  minrate = bitrate
-  maxrate = int(bitrate / 0.7)
-
-  params.update(
-    gop = gop, slices = slices, bframes = bframes, bitrate = bitrate,
-    profile = mprofile, fps = fps, quality = quality, refs = refs,
-    minrate = minrate, maxrate = maxrate, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}-{quality}-{refs}"
-    ".h264".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{slices}-{bframes}-{bitrate}-{profile}-{fps}-{quality}-{refs}"
-    "-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapih264enc rate-control=vbr bitrate={maxrate} keyframe-period={gop}"
-    " num-slices={slices} max-bframes={bframes} refs={refs}"
-    " quality-level={quality} ! video/x-h264,profile={profile} ! h264parse"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual))
-
-  # acceptable bitrate within 25% of minrate and 10% of maxrate
-  assert(minrate * 0.75 <= bitrate_actual <= maxrate * 1.10)
-
-  check_psnr(params)
+class vbr(AVCEncoderTest):
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapih264enc"))
+  @slash.requires(*have_gst_element("vaapih264dec"))
+  @slash.parametrize(*gen_avc_vbr_parameters(spec, ['main', 'high']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      lowpower  = 0,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate   = int(bitrate / 0.7),
+      minrate   = bitrate,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "vbr",
+      refs      = refs,
+      slices    = slices,
+    )
+    self.encode()

--- a/test/gst-vaapi/encode/encoder.py
+++ b/test/gst-vaapi/encode/encoder.py
@@ -1,0 +1,177 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("vaapi"))
+@slash.requires(*have_gst_element("checksumsink2"))
+class EncoderTest(slash.Test):
+  def gen_input_opts(self):
+    opts = "filesrc location={source} num-buffers={frames}"
+    opts += " ! rawvideoparse format={mformat} width={width} height={height}"
+
+    if vars(self).get("fps", None) is not None:
+      opts += " framerate={fps}"
+
+    opts += " ! videoconvert ! video/x-raw,format={hwformat}"
+
+    return opts.format(**vars(self))
+
+  def gen_output_opts(self):
+    opts = "{gstencoder}"
+
+    if self.codec not in ["jpeg",]:
+      opts += " rate-control={rcmode}"
+
+    if vars(self).get("gop", None) is not None:
+      opts += " keyframe-period={gop}"
+    if vars(self).get("qp", None) is not None:
+      if self.codec in ["vp8", "vp9",]:
+        opts += " yac-qi={qp}"
+      elif self.codec in ["mpeg2"]:
+        opts += " quantizer={mqp}"
+      else:
+        opts += " init-qp={qp}"
+    if vars(self).get("quality", None) is not None:
+      if self.codec in ["jpeg",]:
+        opts += " quality={quality}"
+      else:
+        opts += " quality-level={quality}"
+    if vars(self).get("slices", None) is not None:
+      opts += " num-slices={slices}"
+    if vars(self).get("bframes", None) is not None:
+      opts += " max-bframes={bframes}"
+    if vars(self).get("maxrate", None) is not None:
+      opts += " bitrate={maxrate}"
+    if vars(self).get("refmode", None) is not None:
+      opts += " ref-pic-mode={refmode}"
+    if vars(self).get("refs", None) is not None:
+      opts += " refs={refs}"
+    if vars(self).get("lowpower", False):
+      opts += " tune=low-power"
+    if vars(self).get("loopshp", None) is not None:
+      opts += " sharpness-level={loopshp}"
+    if vars(self).get("looplvl", None) is not None:
+      opts += " loop-filter-level={looplvl}"
+
+    if self.codec not in ["jpeg", "mpeg2", "vp8", "vp9",]:
+      opts += " ! {gstmediatype},profile={mprofile}"
+
+    if vars(self).get("gstparser", None) is not None:
+      opts += " ! {gstparser}"
+
+    if vars(self).get("gstmuxer", None) is not None:
+      opts += " ! {gstmuxer}"
+
+    opts += " ! filesink location={encoded}"
+
+    return opts.format(**vars(self))
+
+  def gen_name(self):
+    name = "{case}-{rcmode}-{profile}"
+    if vars(self).get("fps", None) is not None:
+      name += "-{fps}"
+    if vars(self).get("gop", None) is not None:
+      name += "-{gop}"
+    if vars(self).get("qp", None) is not None:
+      name += "-{qp}"
+    if vars(self).get("slices", None) is not None:
+      name += "-{slices}"
+    if vars(self).get("quality", None) is not None:
+      name += "-{quality}"
+    if vars(self).get("bframes", None) is not None:
+      name += "-{bframes}"
+    if vars(self).get("minrate", None) is not None:
+      name += "-{minrate}k"
+    if vars(self).get("maxrate", None) is not None:
+      name += "-{maxrate}k"
+    if vars(self).get("refmode", None) is not None:
+      name += "-{refmode}"
+    if vars(self).get("refs", None) is not None:
+      name += "-{refs}"
+    if vars(self).get("lowpower", False):
+      name += "-low-power"
+    if vars(self).get("loopshp", None) is not None:
+      name += "-{loopshp}"
+    if vars(self).get("looplvl", None) is not None:
+      name += "-{looplvl}"
+    return name.format(**vars(self))
+
+  def before(self):
+    self.refctx = []
+
+  def encode(self):
+    self.mprofile = mapprofile(self.codec, self.profile)
+    if self.mprofile is None:
+      slash.skip_test("{profile} profile is not supported".format(**vars(self)))
+
+    self.mformat = mapformat(self.format)
+    self.mformatu = mapformatu(self.format)
+    self.hwformat = mapformat_hwup(self.format)
+    if self.mformat is None:
+      slash.skip_test("{format} format not supported".format(**vars(self)))
+
+    self.encoded = get_media()._test_artifact(
+      "{}.{}".format(self.gen_name(), self.get_file_ext()))
+
+    iopts = self.gen_input_opts()
+    oopts = self.gen_output_opts()
+
+    self.output = call(
+      "gst-launch-1.0 -vf"
+      " {iopts} ! {oopts}".format(iopts = iopts, oopts = oopts)
+    )
+
+    self.check_bitrate()
+    self.check_metrics()
+
+  def check_metrics(self):
+    self.decoded = get_media()._test_artifact(
+      "{}-{width}x{height}-{format}.yuv".format(self.gen_name(), **vars(self)))
+
+    call(
+      "gst-launch-1.0 -vf filesrc location={encoded}"
+      " ! {gstdecoder}"
+      " ! videoconvert ! video/x-raw,format={mformatu}"
+      " ! checksumsink2 file-checksum=false frame-checksum=false"
+      " plane-checksum=false dump-output=true qos=false"
+      " dump-location={decoded}".format(**vars(self))
+    )
+
+    get_media().baseline.check_psnr(
+      psnr = calculate_psnr(
+        self.source, self.decoded,
+        self.width, self.height,
+        self.frames, self.format),
+      context = self.refctx,
+    )
+
+  def check_bitrate(self):
+    if "cbr" == self.rcmode:
+      encsize = os.path.getsize(self.encoded)
+      bitrate_actual = encsize * 8 * self.fps / 1024.0 / self.frames
+      bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
+
+      get_media()._set_test_details(
+        size_encoded = encsize,
+        bitrate_actual = "{:-.2f}".format(bitrate_actual),
+        bitrate_gap = "{:.2%}".format(bitrate_gap))
+
+      # acceptable bitrate within 10% of bitrate
+      assert(bitrate_gap <= 0.10)
+
+    elif "vbr" == self.rcmode:
+      encsize = os.path.getsize(self.encoded)
+      bitrate_actual = encsize * 8 * self.fps / 1024.0 / self.frames
+
+      get_media()._set_test_details(
+        size_encoded = encsize,
+        bitrate_actual = "{:-.2f}".format(bitrate_actual))
+
+      # acceptable bitrate within 25% of minrate and 10% of maxrate
+      assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -6,56 +6,35 @@
 
 from ....lib import *
 from ..util import *
+from .encoder import EncoderTest
 
 spec = load_test_spec("jpeg", "encode")
 
-def check_psnr(params):
-  call(
-    "gst-launch-1.0 -vf filesrc location={encoded}"
-    " ! jpegparse ! vaapijpegdec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(
-      mformatu = mapformatu(params["format"]), **params
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "jpeg",
+      gstencoder    = "vaapijpegenc",
+      gstdecoder    = "jpegparse ! vaapijpegdec",
+      gstmediatype  = "image/jpeg",
+      gstparser     = "jpegparse",
+      profile       = "baseline",
     )
-  )
+    super(JPEGEncoderTest, self).before()
 
-  get_media().baseline.check_psnr(
-    psnr = calculate_psnr(
-      params["source"], params["decoded"],
-      params["width"], params["height"],
-      params["frames"], params["format"]),
-    context = params.get("refctx", []),
-  )
+  def get_file_ext(self):
+    return "mjpeg" if self.frames > 1 else "jpg"
 
-#-------------------------------------------------#
-#---------------------- CQP ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapijpegenc"))
-@slash.requires(*have_gst_element("vaapijpegdec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_jpeg_cqp_parameters(spec))
-@platform_tags(JPEG_ENCODE_PLATFORMS)
-def test_cqp(case, quality):
-  params = spec[case].copy()
-
-  params.update(
-    quality = quality, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{quality}.jpg".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{quality}-{width}x{height}-{format}.yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapijpegenc quality={quality} ! jpegparse"
-    " ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
+class cqp(JPEGEncoderTest):
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapijpegenc"))
+  @slash.requires(*have_gst_element("vaapijpegdec"))
+  @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
+  def test(self, case, quality):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case    = case,
+      quality = quality,
+      rcmode  = "cqp",
+    )
+    self.encode()

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -6,62 +6,39 @@
 
 from ....lib import *
 from ..util import *
+from .encoder import EncoderTest
 
 spec = load_test_spec("mpeg2", "encode")
 
-def check_psnr(params):
-  call(
-    "gst-launch-1.0 -vf filesrc location={encoded}"
-    " ! mpegvideoparse ! vaapimpeg2dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(
-      mformatu = mapformatu(params["format"]), **params
+class MPEG2EncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "mpeg2",
+      gstencoder    = "vaapimpeg2enc",
+      gstdecoder    = "mpegvideoparse ! vaapimpeg2dec",
+      gstmediatype  = "video/mpeg",
+      gstparser     = "mpegvideoparse",
     )
-  )
+    super(MPEG2EncoderTest, self).before()
 
-  get_media().baseline.check_psnr(
-    psnr = calculate_psnr(
-      params["source"], params["decoded"],
-      params["width"], params["height"],
-      params["frames"], params["format"]),
-    context = params.get("refctx", []),
-  )
+  def get_file_ext(self):
+    return "m2v"
 
-#-------------------------------------------------#
-#---------------------- CQP ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapimpeg2enc"))
-@slash.requires(*have_gst_element("vaapimpeg2dec"))
-@slash.requires(*have_gst_element("checksumsink2"))
-@slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['default']))
-@platform_tags(MPEG2_ENCODE_PLATFORMS)
-def test_cqp(case, gop, bframes, qp, quality, **unused):
-  params = spec[case].copy()
-
-  params.update(
-    gop = gop, bframes = bframes, qp = qp,
-    mqp = mapRange(qp, [0, 100], [2, 62]),
-    quality = quality, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bframes}-{qp}-{quality}"
-    ".mpg".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bframes}-{qp}-{quality}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapimpeg2enc rate-control=cqp quantizer={mqp} keyframe-period={gop}"
-    " max-bframes={bframes} quality-level={quality}"
-    " ! mpegvideoparse ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
+class cqp(MPEG2EncoderTest):
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapimpeg2enc"))
+  @slash.requires(*have_gst_element("vaapimpeg2dec"))
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['simple']))
+  def test(self, case, gop, bframes, qp, quality, profile):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      case    = case,
+      gop     = gop,
+      mqp     = mapRange(qp, [0, 100], [2, 62]),
+      profile = profile,
+      qp      = qp,
+      quality = quality,
+      rcmode  = "cqp",
+    )
+    self.encode()

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -6,162 +6,84 @@
 
 from ....lib import *
 from ..util import *
+from .encoder import EncoderTest
 
 spec = load_test_spec("vp8", "encode")
 
-def check_psnr(params):
-  call(
-    "gst-launch-1.0 -vf filesrc location={encoded}"
-    " ! matroskademux ! vaapivp8dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(
-      mformatu = mapformatu(params["format"]), **params
+class VP8EncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "vp8",
+      gstencoder    = "vaapivp8enc",
+      gstdecoder    = "matroskademux ! vaapivp8dec",
+      gstmediatype  = "video/vp8",
+      gstmuxer      = "matroskamux",
+      profile       = "version0_3",
     )
-  )
+    super(VP8EncoderTest, self).before()
 
-  get_media().baseline.check_psnr(
-    psnr = calculate_psnr(
-      params["source"], params["decoded"],
-      params["width"], params["height"],
-      params["frames"], params["format"]),
-    context = params.get("refctx", []),
-  )
+  def get_file_ext(self):
+    return "webm"
 
-#-------------------------------------------------#
-#---------------------- CQP ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp8enc"))
-@slash.requires(*have_gst_element("vaapivp8dec"))
-@slash.parametrize(*gen_vp8_cqp_parameters(spec))
-@platform_tags(VP8_ENCODE_PLATFORMS)
-def test_cqp(case, ipmode, qp, quality, looplvl, loopshp):
-  params = spec[case].copy()
+class cqp(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp8enc"))
+  @slash.requires(*have_gst_element("vaapivp8dec"))
+  @slash.parametrize(*gen_vp8_cqp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+    )
+    self.encode()
 
-  params.update(
-    ipmode = ipmode, qp = qp, quality = quality, looplvl = looplvl,
-    gop = 30 if ipmode != 0 else 1,
-    loopshp = loopshp, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
+class cbr(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp8enc"))
+  @slash.requires(*have_gst_element("vaapivp8dec"))
+  @slash.parametrize(*gen_vp8_cbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+    )
+    self.encode()
 
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{ipmode}-{qp}-{quality}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{ipmode}-{qp}-{quality}-{looplvl}-{loopshp}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp8enc rate-control=cqp keyframe-period={gop}"
-    " yac-qi={qp} quality-level={quality}"
-    " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
-#-------------------------------------------------#
-#---------------------- CBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp8enc"))
-@slash.requires(*have_gst_element("vaapivp8dec"))
-@slash.parametrize(*gen_vp8_cbr_parameters(spec))
-@platform_tags(VP8_ENCODE_PLATFORMS)
-def test_cbr(case, gop, bitrate, fps, looplvl, loopshp):
-  params = spec[case].copy()
-
-  params.update(
-    gop = gop, bitrate = bitrate, fps = fps, looplvl = looplvl,
-    loopshp = loopshp, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{looplvl}-{loopshp}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp8enc rate-control=cbr bitrate={bitrate} keyframe-period={gop}"
-    " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-  bitrate_gap = abs(bitrate_actual - bitrate) / bitrate
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual),
-    bitrate_gap = "{:.2%}".format(bitrate_gap))
-
-  assert(bitrate_gap <= 0.10)
-
-  check_psnr(params)
-
-#-------------------------------------------------#
-#---------------------- VBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp8enc"))
-@slash.requires(*have_gst_element("vaapivp8dec"))
-@slash.parametrize(*gen_vp8_vbr_parameters(spec))
-@platform_tags(VP8_ENCODE_PLATFORMS)
-def test_vbr(case, gop, bitrate, fps, quality, looplvl, loopshp):
-  params = spec[case].copy()
-
-  # target percentage 70% (hard-coded in gst-vaapi)
-  # gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
-  minrate = bitrate
-  maxrate = int(bitrate / 0.7)
-
-  params.update(
-    gop = gop, bitrate = bitrate, fps = fps, quality = quality,
-    looplvl = looplvl, loopshp = loopshp, minrate = minrate,
-    maxrate = maxrate, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{quality}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{quality}-{looplvl}-{loopshp}"
-    "-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp8enc rate-control=vbr bitrate={maxrate} keyframe-period={gop}"
-    " loop-filter-level={looplvl} sharpness-level={loopshp}"
-    " quality-level={quality} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual))
-
-  # acceptable bitrate within 25% of minrate and 10% of maxrate
-  assert(minrate * 0.75 <= bitrate_actual <= maxrate * 1.10)
-
-  check_psnr(params)
+class vbr(VP8EncoderTest):
+  @platform_tags(VP8_ENCODE_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp8enc"))
+  @slash.requires(*have_gst_element("vaapivp8dec"))
+  @slash.parametrize(*gen_vp8_vbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate   = int(bitrate / 0.7),
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+    )
+    self.encode()

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -6,164 +6,87 @@
 
 from ....lib import *
 from ..util import *
+from .encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
-def check_psnr(params):
-  call(
-    "gst-launch-1.0 -vf filesrc location={encoded}"
-    " ! matroskademux ! vaapivp9dec"
-    " ! videoconvert ! video/x-raw,format={mformatu}"
-    " ! checksumsink2 file-checksum=false frame-checksum=false"
-    " plane-checksum=false dump-output=true qos=false"
-    " dump-location={decoded}".format(
-      mformatu = mapformatu(params["format"]), **params
+class VP9EncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "vp9",
+      gstencoder    = "vaapivp9enc",
+      gstdecoder    = "matroskademux ! vaapivp9dec",
+      gstmediatype  = "video/vp9",
+      gstmuxer      = "matroskamux",
+      profile       = "profile0",
     )
-  )
+    super(VP9EncoderTest, self).before()
 
-  get_media().baseline.check_psnr(
-    psnr = calculate_psnr(
-      params["source"], params["decoded"],
-      params["width"], params["height"],
-      params["frames"], params["format"]),
-    context = params.get("refctx", []),
-  )
+  def get_file_ext(self):
+    return "webm"
 
-#-------------------------------------------------#
-#---------------------- CQP ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-@slash.parametrize(*gen_vp9_cqp_parameters(spec))
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-def test_8bit_cqp(case, ipmode, qp, quality, refmode, looplvl, loopshp):
-  params = spec[case].copy()
+class cqp(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      refmode   = refmode,
+    )
+    self.encode()
 
-  params.update(
-    ipmode = ipmode, qp = qp, quality = quality, looplvl = looplvl,
-    gop = 30 if ipmode != 0 else 1, refmode = refmode,
-    loopshp = loopshp, mformat = mapformat(params["format"]),
-    hwup_format = mapformat_hwup(params["format"]))
+class cbr(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      refmode   = refmode,
+    )
+    self.encode()
 
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{ipmode}-{qp}-{quality}-{refmode}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{ipmode}-{qp}-{quality}-{refmode}-{looplvl}-{loopshp}-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp9enc rate-control=cqp keyframe-period={gop}"
-    " yac-qi={qp} quality-level={quality} ref-pic-mode={refmode}"
-    " loop-filter-level={looplvl} sharpness-level={loopshp} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  check_psnr(params)
-
-#-------------------------------------------------#
-#---------------------- CBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-@slash.parametrize(*gen_vp9_cbr_parameters(spec))
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-def test_8bit_cbr(case, gop, bitrate, fps, refmode, looplvl, loopshp):
-  params = spec[case].copy()
-
-  params.update(
-    gop = gop, bitrate = bitrate, fps = fps, refmode = refmode,
-    looplvl = looplvl, loopshp = loopshp, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{refmode}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{refmode}-{looplvl}-{loopshp}"
-    "-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp9enc rate-control=cbr keyframe-period={gop} bitrate={bitrate}"
-    " ref-pic-mode={refmode} loop-filter-level={looplvl}"
-    " sharpness-level={loopshp} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-  bitrate_gap = abs(bitrate_actual - bitrate) / bitrate
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual),
-    bitrate_gap = "{:.2%}".format(bitrate_gap))
-
-  assert(bitrate_gap <= 0.10)
-
-  check_psnr(params)
-
-#-------------------------------------------------#
-#---------------------- VBR ----------------------#
-#-------------------------------------------------#
-@slash.requires(have_gst)
-@slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-@slash.parametrize(*gen_vp9_vbr_parameters(spec))
-@platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-def test_8bit_vbr(case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-  params = spec[case].copy()
-
-  # target percentage 70% (hard-coded in gst-vaapi)
-  # gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
-  minrate = bitrate
-  maxrate = int(bitrate / 0.7)
-
-  params.update(
-    gop = gop, bitrate = bitrate, fps = fps, refmode = refmode,
-    quality = quality, looplvl = looplvl, loopshp = loopshp, minrate = minrate,
-    maxrate = maxrate, mformat = mapformat(params["format"]),
-    frames = params.get("brframes", params["frames"]),
-    hwup_format = mapformat_hwup(params["format"]))
-
-  params["encoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{refmode}-{quality}-{looplvl}-{loopshp}"
-    ".webm".format(case, **params))
-  params["decoded"] = get_media()._test_artifact(
-    "{}-{gop}-{bitrate}-{fps}-{refmode}-{quality}-{looplvl}-{loopshp}"
-    "-{width}x{height}-{format}"
-    ".yuv".format(case, **params))
-
-  call(
-    "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
-    " ! rawvideoparse format={mformat} width={width} height={height}"
-    " framerate={fps} ! videoconvert ! video/x-raw,format={hwup_format}"
-    " ! vaapivp9enc rate-control=vbr keyframe-period={gop} bitrate={maxrate}"
-    " ref-pic-mode={refmode} loop-filter-level={looplvl}"
-    " sharpness-level={loopshp} quality-level={quality} ! matroskamux"
-    " ! filesink location={encoded}".format(**params))
-
-  # calculate actual bitrate
-  encsize = os.path.getsize(params["encoded"])
-  bitrate_actual = encsize * 8 * params["fps"] / 1024.0 / params["frames"]
-
-  get_media()._set_test_details(
-    size_encoded = encsize,
-    bitrate_actual = "{:-.2f}".format(bitrate_actual))
-
-  # acceptable bitrate within 25% of minrate and 10% of maxrate
-  assert(minrate * 0.75 <= bitrate_actual <= maxrate * 1.10)
-
-  check_psnr(params)
+class vbr(VP9EncoderTest):
+  @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate   = int(bitrate / 0.7),
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      refmode   = refmode,
+    )
+    self.encode()

--- a/test/gst-vaapi/util.py
+++ b/test/gst-vaapi/util.py
@@ -140,6 +140,18 @@ def mapprofile(codec, profile):
     "hevc-10"  : {
       "main10"                : "main-10",
     },
+    "jpeg"     : {
+      "baseline"              : "baseline",
+    },
+    "mpeg2"    : {
+      "simple"                : "simple",
+    },
+    "vp8"      : {
+      "version0_3"            : "version0_3",
+    },
+    "vp9"      : {
+      "profile0"              : "profile0",
+    },
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):

--- a/tools/xform-baseline-1.sh
+++ b/tools/xform-baseline-1.sh
@@ -42,3 +42,22 @@ sed -i "s/test\/gst-vaapi\/decode\/jpeg.py:test_default(/test\/gst-vaapi\/decode
 sed -i "s/test\/gst-vaapi\/decode\/mpeg2.py:test_default(/test\/gst-vaapi\/decode\/mpeg2.py:default.test(/g" $1
 sed -i "s/test\/gst-vaapi\/decode\/vc1.py:test_default(/test\/gst-vaapi\/decode\/vc1.py:default.test(/g" $1
 sed -i "s/test\/gst-vaapi\/decode\/vp8.py:test_default(/test\/gst-vaapi\/decode\/vp8.py:default.test(/g" $1
+
+sed -i "s/test\/gst-vaapi\/encode\/avc.py:test_cqp(/test\/gst-vaapi\/encode\/avc.py:cqp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/avc.py:test_cqp_lp(/test\/gst-vaapi\/encode\/avc.py:cqp_lp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/avc.py:test_cbr(/test\/gst-vaapi\/encode\/avc.py:cbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/avc.py:test_vbr(/test\/gst-vaapi\/encode\/avc.py:vbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_8bit_cqp(/test\/gst-vaapi\/encode\/hevc.py:cqp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_8bit_cbr(/test\/gst-vaapi\/encode\/hevc.py:cbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_8bit_vbr(/test\/gst-vaapi\/encode\/hevc.py:vbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_10bit_cqp(/test\/gst-vaapi\/encode\/10bit\/hevc.py:cqp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_10bit_cbr(/test\/gst-vaapi\/encode\/10bit\/hevc.py:cbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/hevc.py:test_10bit_vbr(/test\/gst-vaapi\/encode\/10bit\/hevc.py:vbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/jpeg.py:test_cqp(/test\/gst-vaapi\/encode\/jpeg.py:cqp.test(/g" $1
+sed -Ei "s/test\/gst-vaapi\/encode\/mpeg2.py:test_cqp\(bframes=(.*),case=(.*),gop=(.*),qp=(.*),quality=(.*)\)/test\/gst-vaapi\/encode\/mpeg2.py:cqp.test\(bframes=\1,case=\2,gop=\3,profile=simple,qp=\4,quality=\5\)/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp8.py:test_cqp(/test\/gst-vaapi\/encode\/vp8.py:cqp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp8.py:test_cbr(/test\/gst-vaapi\/encode\/vp8.py:cbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp8.py:test_vbr(/test\/gst-vaapi\/encode\/vp8.py:vbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp9.py:test_8bit_cqp(/test\/gst-vaapi\/encode\/vp9.py:cqp.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp9.py:test_8bit_cbr(/test\/gst-vaapi\/encode\/vp9.py:cbr.test(/g" $1
+sed -i "s/test\/gst-vaapi\/encode\/vp9.py:test_8bit_vbr(/test\/gst-vaapi\/encode\/vp9.py:vbr.test(/g" $1


### PR DESCRIPTION
This improves code reuse and design for gst-vaapi/encode
tests.

10bit encode tests have moved into its own sub-directory.

Updated test names in baseline.

Update tools/xform-baseline-1.sh script to convert old
baseline test names to new test names.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>