### PR TITLE
gst-vaapi/gst-msdk: add decode scaling option

### DIFF
--- a/test/gst-msdk/decode/decoder.py
+++ b/test/gst-msdk/decode/decoder.py
@@ -23,10 +23,16 @@ class DecoderTest(slash.Test):
     self.decoded = get_media()._test_artifact(
       "{case}_{width}x{height}_{format}.yuv".format(**vars(self)))
 
+    self.gstscaler = ""
+    if vars(self).get("scale_output", False):
+      self.gstscaler = (
+        " ! videoscale"
+        " ! video/x-raw,width={width},height={height}".format(**vars(self)))
+
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder} ! videoconvert ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false"
+      " {gstscaler} ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))
 

--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -22,10 +22,16 @@ class DecoderTest(slash.Test):
     self.decoded = get_media()._test_artifact(
       "{case}_{width}x{height}_{format}.yuv".format(**vars(self)))
 
+    self.gstscaler = ""
+    if vars(self).get("scale_output", False):
+      self.gstscaler = (
+        " ! videoscale"
+        " ! video/x-raw,width={width},height={height}".format(**vars(self)))
+
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
-      " ! videoconvert ! video/x-raw,format={mformatu}"
+      " ! videoconvert ! video/x-raw,format={mformatu} {gstscaler}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))


### PR DESCRIPTION
Add option "scale_output" to allow the test case config
to instruct the gst-vaapi or gst-msdk decode tests to
apply videoscale (SW scaling) to the output.  This is
mostly useful for testing decode cases where the input
file has multiple resolutions and we want decoded output
to be in a single resolution so that it can work with
certain metrics settings.

By default, ffmpeg automatically scales (SW scaling)
output (which can't be disabled, afaik).  Thus, ffmpeg
tests don't need to do anything with scale_output.
