### PR TITLE
ffmpeg-qsv/transcode: Transcoding feature support

### DIFF
--- a/test/ffmpeg-qsv/transcode/__init__.py
+++ b/test/ffmpeg-qsv/transcode/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-qsv/transcode/avc.py
+++ b/test/ffmpeg-qsv/transcode/avc.py
@@ -1,0 +1,194 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+from .transcoder import TranscoderTest
+
+spec = load_test_spec("avc", "transcode")
+class to_avc(TranscoderTest):
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwhw"))
+  @platform_tags(set(AVC_DECODE_PLATFORMS) & set(AVC_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'h264_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+ 
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_x264_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwsw"))
+  @platform_tags(AVC_DECODE_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'libx264',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+ 
+  @slash.requires(have_ffmpeg_h264_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "swhw"))
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'h264',
+      ffencoder    = 'h264_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_hevc(TranscoderTest):
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwhw"))
+  @platform_tags(set(AVC_DECODE_PLATFORMS) & set(HEVC_ENCODE_8BIT_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_x265_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwsw"))
+  @platform_tags(AVC_DECODE_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'libx265',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "swhw"))
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'h264',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_mjpeg(TranscoderTest):
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwhw"))
+  @platform_tags(set(AVC_DECODE_PLATFORMS) & set(JPEG_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwsw"))
+  @platform_tags(AVC_DECODE_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'mjpeg',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "swhw"))
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'h264',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_mpeg2(TranscoderTest):
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwhw"))
+  @platform_tags(set(AVC_DECODE_PLATFORMS) & set(MPEG2_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwsw"))
+  @platform_tags(AVC_DECODE_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'h264_qsv',
+      ffencoder    = 'mpeg2video',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_h264_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "swhw"))
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'h264',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()

--- a/test/ffmpeg-qsv/transcode/hevc.py
+++ b/test/ffmpeg-qsv/transcode/hevc.py
@@ -1,0 +1,194 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+from .transcoder import TranscoderTest
+
+spec = load_test_spec("hevc", "transcode")
+class to_avc(TranscoderTest):
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwhw"))
+  @platform_tags(set(HEVC_DECODE_8BIT_PLATFORMS) & set(AVC_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'h264_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+ 
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_x264_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwsw"))
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'libx264',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+ 
+  @slash.requires(have_ffmpeg_hevc_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "swhw"))
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'hevc',
+      ffencoder    = 'h264_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_hevc(TranscoderTest):
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwhw"))
+  @platform_tags(set(HEVC_DECODE_8BIT_PLATFORMS) & set(HEVC_ENCODE_8BIT_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_x265_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwsw"))
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'libx265',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "swhw"))
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'hevc',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_mjpeg(TranscoderTest):
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwhw"))
+  @platform_tags(set(HEVC_DECODE_8BIT_PLATFORMS) & set(JPEG_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwsw"))
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'mjpeg',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "swhw"))
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'hevc',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()
+
+class to_mpeg2(TranscoderTest):
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwhw"))
+  @platform_tags(set(HEVC_DECODE_8BIT_PLATFORMS) & set(MPEG2_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwsw"))
+  @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
+  def test_hwsw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'hevc_qsv',
+      ffencoder    = 'mpeg2video',
+      mode         = 'hwsw',
+    )
+    self.transcode_1to1()
+
+  @slash.requires(have_ffmpeg_hevc_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "swhw"))
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  def test_swhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'hevc',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'swhw',
+    )
+    self.transcode_1to1()

--- a/test/ffmpeg-qsv/transcode/mpeg2.py
+++ b/test/ffmpeg-qsv/transcode/mpeg2.py
@@ -1,0 +1,74 @@
+##
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+from .transcoder import TranscoderTest
+
+spec = load_test_spec("mpeg2", "transcode")
+class to_avc(TranscoderTest):
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwhw"))
+  @platform_tags(set(MPEG2_DECODE_PLATFORMS) & set(AVC_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'mpeg2_qsv',
+      ffencoder    = 'h264_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_hevc(TranscoderTest):
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwhw"))
+  @platform_tags(set(MPEG2_DECODE_PLATFORMS) & set(HEVC_ENCODE_8BIT_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'mpeg2_qsv',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_mjpeg(TranscoderTest):
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwhw"))
+  @platform_tags(set(MPEG2_DECODE_PLATFORMS) & set(JPEG_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'mpeg2_qsv',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_mpeg2(TranscoderTest):
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwhw"))
+  @platform_tags(set(MPEG2_DECODE_PLATFORMS) & set(MPEG2_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'mpeg2_qsv',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()

--- a/test/ffmpeg-qsv/transcode/transcoder.py
+++ b/test/ffmpeg-qsv/transcode/transcoder.py
@@ -1,0 +1,74 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+import os
+
+@slash.requires(have_ffmpeg)
+@slash.requires(have_ffmpeg_qsv_accel)
+class TranscoderTest(slash.Test):
+  def before(self):
+    self.refctx = []
+
+  def transcode_1to1(self):
+    self.decoded = get_media()._test_artifact(
+      "{case}_{width}x{height}_{mode}.{dstextension}".format(**vars(self)))
+
+    if vars(self).get("dstextension", None) == 'mjpeg':
+      self.mjpeg_quality = "-global_quality 60"
+    else:
+      self.mjpeg_quality = ""
+
+    if vars(self).get("mode", None) == 'hwhw':
+      self.output = call(
+        "ffmpeg -hwaccel qsv -hwaccel_device /dev/dri/renderD128 -v verbose"
+        " -c:v {ffdecoder} -i {source} -an -init_hw_device qsv:hw -c:v {ffencoder}"
+        " -vframes {frames} -y {decoded}".format(**vars(self)))
+    elif  vars(self).get("mode", None) == 'hwsw':
+      self.output = call(
+        "ffmpeg -v verbose -init_hw_device qsv:hw"
+        "  -c:v {ffdecoder} -i {source}  -an -c:v {ffencoder}"
+        " {mjpeg_quality} -vframes {frames} -y {decoded}".format(**vars(self)))
+    elif  vars(self).get("mode", None) == 'swhw':
+      self.output = call(
+        "ffmpeg -hwaccel qsv -init_hw_device qsv=hw -filter_hw_device hw -v verbose "
+        " -c:v {ffdecoder} -i {source} -an -vf hwupload=extra_hw_frames=64,format=qsv  -c:v {ffencoder}"
+        " {mjpeg_quality} -vframes {frames} -y {decoded}".format(**vars(self)))
+    else:
+        assert "non supported transcoding"
+
+    self.check_output()
+    self.convert_toyuv()
+    self.check_metrics()
+
+  def check_output(self):
+    m = re.search(
+      "not supported for hardware decode", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+
+    m = re.search(
+      "hwaccel initialisation returned error", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+  
+  def convert_toyuv(self):
+    self.decodedYUV = get_media()._test_artifact(
+       "{case}_{width}x{height}_{mode}_{ffencoder}.yuv".format(**vars(self)))
+    call("ffmpeg -i {decoded} -pix_fmt yuv420p -vframes {frames} -y {decodedYUV}".format(**vars(self)))
+
+    #src file to yuv
+    self.referenceFile = get_media()._test_artifact(
+       "{case}_{width}x{height}_{mode}_ref.yuv".format(**vars(self)))
+    call("ffmpeg -i {source} -pix_fmt yuv420p -vframes {frames} -y {referenceFile}".format(**vars(self)))
+
+  def check_metrics(self):
+    get_media().baseline.check_psnr(
+      psnr = calculate_psnr(
+        self.referenceFile, self.decodedYUV,
+        self.width, self.height,
+        self.frames),
+      context = self.refctx,
+    )

--- a/test/ffmpeg-qsv/transcode/vc1.py
+++ b/test/ffmpeg-qsv/transcode/vc1.py
@@ -1,0 +1,74 @@
+##
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+from .transcoder import TranscoderTest
+
+spec = load_test_spec("vc1", "transcode")
+class to_avc(TranscoderTest):
+  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "avc", "hwhw"))
+  @platform_tags(set(VC1_DECODE_PLATFORMS) & set(AVC_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h264',
+      ffdecoder    = 'vc1_qsv',
+      ffencoder    = 'h264_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_hevc(TranscoderTest):
+  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "hevc", "hwhw"))
+  @platform_tags(set(VC1_DECODE_PLATFORMS) & set(HEVC_ENCODE_8BIT_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'h265',
+      ffdecoder    = 'vc1_qsv',
+      ffencoder    = 'hevc_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_mjpeg(TranscoderTest):
+  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mjpeg", "hwhw"))
+  @platform_tags(set(VC1_DECODE_PLATFORMS) & set(JPEG_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'mjpeg',
+      ffdecoder    = 'vc1_qsv',
+      ffencoder    = 'mjpeg_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()
+
+class to_mpeg2(TranscoderTest):
+  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.parametrize(*gen_transcode_1to1_parameters(spec, "mpeg2", "hwhw"))
+  @platform_tags(set(VC1_DECODE_PLATFORMS) & set(MPEG2_ENCODE_PLATFORMS))
+  def test_hwhw_1to1(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case         = case,
+      dstextension = 'm2v',
+      ffdecoder    = 'vc1_qsv',
+      ffencoder    = 'mpeg2_qsv',
+      mode         = 'hwhw',
+    )
+    self.transcode_1to1()

--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -22,8 +22,16 @@ def have_ffmpeg_h264_qsv_decode():
   return try_call("ffmpeg -hide_banner -decoders | grep h264_qsv")
 
 @memoize
+def have_ffmpeg_h264_decode():
+  return try_call("ffmpeg -hide_banner -decoders | awk '{print $2}' | grep -w h264")
+
+@memoize
 def have_ffmpeg_hevc_qsv_decode():
   return try_call("ffmpeg -hide_banner -decoders | grep hevc_qsv")
+
+@memoize
+def have_ffmpeg_hevc_decode():
+  return try_call("ffmpeg -hide_banner -decoders | awk '{print $2}' | grep -w hevc")
 
 @memoize
 def have_ffmpeg_mjpeg_qsv_decode():
@@ -50,16 +58,32 @@ def have_ffmpeg_h264_qsv_encode():
   return try_call("ffmpeg -hide_banner -encoders | grep h264_qsv")
 
 @memoize
+def have_ffmpeg_x264_encode():
+  return try_call("ffmpeg -hide_banner -encoders | grep libx264")
+
+@memoize
 def have_ffmpeg_hevc_qsv_encode():
   return try_call("ffmpeg -hide_banner -encoders | grep hevc_qsv")
+
+@memoize
+def have_ffmpeg_x265_encode():
+  return try_call("ffmpeg -hide_banner -encoders | grep libx265")
 
 @memoize
 def have_ffmpeg_mjpeg_qsv_encode():
   return try_call("ffmpeg -hide_banner -encoders | grep mjpeg_qsv")
 
 @memoize
+def have_ffmpeg_mjpeg_encode():
+  return try_call("ffmpeg -hide_banner -encoders | awk '{print $2}' | grep -w mjpeg")
+
+@memoize
 def have_ffmpeg_mpeg2_qsv_encode():
   return try_call("ffmpeg -hide_banner -encoders | grep mpeg2_qsv")
+
+@memoize
+def have_ffmpeg_mpeg2_encode():
+  return try_call("ffmpeg -hide_banner -encoders | awk '{print $2}' | grep -w mpeg2video")
 
 @memoize
 def have_ffmpeg_filter(name):


### PR DESCRIPTION
    1. It supports transcoding of AVC, HEVC, MPEG2 and VC1 test streams
    2. HWtoHW, HWtoSW and SWtoHW transcoding support added for ffmpeg-qsv

Signed-off-by: hbomminx <haribabux.bommineni@intel.com>