### PR TITLE
gst/decode: mkv file extension added as supported decoding format

### DIFF
--- a/test/gst-msdk/decode/10bit/vp9.py
+++ b/test/gst-msdk/decode/10bit/vp9.py
@@ -22,7 +22,7 @@ class default(DecoderTest):
   def test(self, case):
     vars(self).update(spec[case].copy())
 
-    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
+    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux", ".mkv" : "matroskademux"}
     ext = os.path.splitext(self.source)[1]
     assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
 

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -22,7 +22,7 @@ class default(DecoderTest):
   def test(self, case):
     vars(self).update(spec[case].copy())
 
-    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
+    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux", ".mkv" : "matroskademux"}
     ext = os.path.splitext(self.source)[1]
     assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
 


### PR DESCRIPTION
Signed-off-by: hbomminx <haribabux.bommineni@intel.com>