### PR TITLE
 Default test timeout time increased

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -64,7 +64,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
       type = int,
       help = "{} = Keep None; {} = Keep Failed; {} = Keep All".format(
         self.RETENTION_NONE, self.RETENTION_FAIL, self.RETENTION_ALL))
-    parser.add_argument("--call-timeout", default = 300, type = int,
+    parser.add_argument("--call-timeout", default = 720, type = int,
       help = "call timeout in seconds")
     parser.add_argument("--ctapt", default = -1, type = int,
       help = "number of call timeouts allowed per test function")


### PR DESCRIPTION
Default test timeout time increased from 300 seconds to 600 seconds for allowing larger files to complete decoding.
Ex: VP9 10-bit 4K test stream TheWorldinHDR.mkv taking around 600 seconds to complete VP9 decoding.

Signed-off-by: hbomminx <haribabux.bommineni@intel.com>