### PR TITLE
ffmpeg-vaapi/decode: fail if SW fallback is used

### DIFF
--- a/test/ffmpeg-vaapi/decode/decoder.py
+++ b/test/ffmpeg-vaapi/decode/decoder.py
@@ -24,7 +24,7 @@ class DecoderTest(slash.Test):
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
     self.output = call(
-      "ffmpeg -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -v verbose"
+      "ffmpeg -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -v debug"
       " -i {source} -pix_fmt {mformat} -f rawvideo -vsync passthrough"
       " -vframes {frames} -y {decoded}".format(**vars(self)))
 
@@ -39,6 +39,10 @@ class DecoderTest(slash.Test):
     m = re.search(
       "hwaccel initialisation returned error", self.output, re.MULTILINE)
     assert m is None, "Failed to use hardware decode"
+
+    m = re.search( # this requires ffmpeg debug verbosity
+      "Format vaapi_vld chosen by get_format", self.output, re.MULTILINE)
+    assert m is not None, "Failed to choose vaapi_vld decode format"
 
   def check_metrics(self):
     check_metric(**vars(self))


### PR DESCRIPTION
There is no way to force ffmpeg-vaapi decode commands
to fail if SW fallback is used.  However, with debug
verbosity, ffmpeg logs will indicate when vaapi_vld
is chosen as the decode format.  The vaapi_vld format
is the indicator that HW acceleration is being used.
Thus, we should fail the test if vaapi_vld message is
missing to avoid test escapes.

Also see https://trac.ffmpeg.org/ticket/7519

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>