### PR TITLE
platform: enable iHD VP8 Enc tests on KBL+

### DIFF
--- a/lib/platform.py
+++ b/lib/platform.py
@@ -73,7 +73,7 @@ elif "iHD" == driver:
   HEVC_ENCODE_10BIT_PLATFORMS    = [                                                "KBL",        "CFL", "WHL", "ICL"]
   HEVC_ENCODE_10BIT_LP_PLATFORMS = [                                                                            "ICL"]
   VP8_DECODE_PLATFORMS           = [                    "BDW",        "SKL", "APL", "KBL",        "CFL", "WHL", "ICL"]
-  VP8_ENCODE_PLATFORMS           = [                                                                            "ICL"]
+  VP8_ENCODE_PLATFORMS           = [                                                "KBL",        "CFL", "WHL", "ICL"]
   VP9_DECODE_8BIT_PLATFORMS      = [                                         "APL", "KBL",        "CFL", "WHL", "ICL"]
   VP9_ENCODE_8BIT_PLATFORMS      = [                                                                            "ICL"]
   VP9_DECODE_10BIT_PLATFORMS     = [                                                "KBL",        "CFL", "WHL", "ICL"]


### PR DESCRIPTION
See: https://github.com/intel/media-driver/issues/568

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>