### PR TITLE
hevc vdenc: fix add missing lowdelayb=1 in gst-vaapi

### DIFF
--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -51,14 +51,15 @@ class cqp_lp(HEVC8EncoderTest):
   def test(self, case, gop, slices, qp, quality, profile):
     vars(self).update(spec[case].copy())
     vars(self).update(
-      case    = case,
-      gop     = gop,
-      qp      = qp,
-      lowpower= True,
-      quality = quality,
-      profile = profile,
-      rcmode  = "cqp",
-      slices  = slices,
+      case         = case,
+      gop          = gop,
+      qp           = qp,
+      lowpower     = True,
+      lowdelayb    = 1,
+      quality      = quality,
+      profile      = profile,
+      rcmode       = "cqp",
+      slices       = slices,
     )
     self.encode()
 


### PR DESCRIPTION
add lowdelayb=1 in gst-vaapi/encode/hevc.py cqp_lp
gst-vaapi hevc vdenc cqp/cbr/vbr need to add low-delay-b=1 in command line .  Previous I missed adding  in cqp_lp . I should check more carefully next time .