### PR TITLE
Include the context (refctx) in metric test details

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -110,6 +110,13 @@ class MediaPlugin(slash.plugins.PluginInterface):
     self.num_ctapt.setdefault((meta.file_path, meta.function_name), 0)
     self.num_ctapt[(meta.file_path, meta.function_name)] += 1
 
+  def _expand_context(self, context):
+    for c in context:
+      sc = str(c).strip().lower()
+      if "driver" == sc:
+        sc = "drv.{}".format(self._get_driver_name())
+      yield sc
+
   def _set_test_details(self, **kwargs):
     for k, v in kwargs.iteritems():
       slash.context.result.details.set(k, v)

--- a/lib/baseline.py
+++ b/lib/baseline.py
@@ -26,10 +26,7 @@ class Baseline:
 
   def __get_reference(self, addr, context = []):
     reference = self.references.setdefault(addr, dict())
-    for c in context:
-      c = str(c).strip().lower()
-      if "driver" == c:
-        c = "drv.{}".format(get_media()._get_driver_name())
+    for c in get_media()._expand_context(context):
       reference = reference.setdefault(c, dict())
     return reference
 
@@ -42,10 +39,13 @@ class Baseline:
     if self.rebase:
       reference.update(**kwargs)
 
+    econtext = list(get_media()._expand_context(context))
+
     for key, val in kwargs.iteritems():
       refval = reference.get(key, None)
-      get_media()._set_test_details(**{key:val})
-      get_media()._set_test_details(**{"ref_{}".format(key):refval})
+      strkey = '.'.join(econtext + [key])
+      get_media()._set_test_details(**{"{}:expect".format(strkey):refval})
+      get_media()._set_test_details(**{"{}:actual".format(strkey):val})
       compare(key, refval, val)
 
   def check_psnr(self, psnr, context = []):


### PR DESCRIPTION
Metric keys (e.g. psnr) can be reused multiple times
in the same test case but in different context (e.g.
transcode 1:N tests).  Thus, include the context in
the key when setting metric test details so that
previous metric details are not unintentionally
overwritten in the test details dictionary.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>