### PR TITLE
ffmpeg-vaapi/encode: R2R support added

### DIFF
--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -9,6 +9,7 @@ from ...util import *
 from ..encoder import EncoderTest
 
 spec = load_test_spec("hevc", "encode", "10bit")
+spec_r2r = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
@@ -24,92 +25,136 @@ class HEVC10EncoderTest(EncoderTest):
     return "h265"
 
 class cqp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      case    = case,
+      gop     = gop,
+      profile = profile,
+      qp      = qp,
+      quality = quality,
+      rcmode  = "cqp",
+      slices  = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cqp_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       case    = case,
       gop     = gop,
+      lowpower= 1,
       profile = profile,
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",
       slices  = slices,
     )
-    self.encode()
 
-class cqp_lp(HEVC10EncoderTest):
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case    = case,
-      gop     = gop,
-      lowpower= 1,
-      profile = profile,
-      qp      = qp,
-      quality = quality,
-      rcmode  = "cqp",
-      slices  = slices,
-    )
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      minrate = bitrate,
+      maxrate = bitrate,
+      profile = profile,
+      rcmode  = "cbr",
+      slices  = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
+      lowpower= 1,
       minrate = bitrate,
       maxrate = bitrate,
       profile = profile,
       rcmode  = "cbr",
       slices  = slices,
     )
-    self.encode()
 
-class cbr_lp(HEVC10EncoderTest):
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate = bitrate,
-      case    = case,
-      fps     = fps,
-      gop     = gop,
-      lowpower= 1,
-      minrate = bitrate,
-      maxrate = bitrate,
-      profile = profile,
-      rcmode  = "cbr",
-      slices  = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(HEVC10EncoderTest):
-  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       bitrate = bitrate,
@@ -124,15 +169,27 @@ class vbr(HEVC10EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC10EncoderTest):
-  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
@@ -147,4 +204,21 @@ class vbr_lp(HEVC10EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -9,6 +9,7 @@ from ..util import *
 from .encoder import EncoderTest
 
 spec = load_test_spec("avc", "encode")
+spec_r2r = load_test_spec("avc", "encode", "r2r")
 
 class AVCEncoderTest(EncoderTest):
   def before(self):
@@ -24,94 +25,138 @@ class AVCEncoderTest(EncoderTest):
     return "h264"
 
 class cqp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      lowpower  = 0,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
   @platform_tags(AVC_ENCODE_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_qsv_encode)
   @slash.requires(have_ffmpeg_h264_qsv_decode)
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main', 'baseline']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cqp_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes   = bframes,
       case      = case,
       gop       = gop,
-      lowpower  = 0,
+      lowpower  = 1,
       profile   = profile,
       qp        = qp,
       quality   = quality,
       rcmode    = "cqp",
       slices    = slices,
     )
-    self.encode()
 
-class cqp_lp(AVCEncoderTest):
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_qsv_encode)
   @slash.requires(have_ffmpeg_h264_qsv_decode)
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case      = case,
-      gop       = gop,
-      lowpower  = 1,
-      profile   = profile,
-      qp        = qp,
-      quality   = quality,
-      rcmode    = "cqp",
-      slices    = slices,
-    )
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      lowpower  = 0,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
   @platform_tags(AVC_ENCODE_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_qsv_encode)
   @slash.requires(have_ffmpeg_h264_qsv_decode)
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes   = bframes,
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = 0,
+      lowpower  = 1,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
       rcmode    = "cbr",
       slices    = slices,
     )
-    self.encode()
 
-class cbr_lp(AVCEncoderTest):
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_qsv_encode)
   @slash.requires(have_ffmpeg_h264_qsv_decode)
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate   = bitrate,
-      case      = case,
-      fps       = fps,
-      gop       = gop,
-      lowpower  = 1,
-      maxrate   = bitrate,
-      minrate   = bitrate,
-      profile   = profile,
-      rcmode    = "cbr",
-      slices    = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(AVCEncoderTest):
-  @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
-  @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main', 'baseline']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
       bitrate   = bitrate,
@@ -127,15 +172,27 @@ class vbr(AVCEncoderTest):
       refs      = refs,
       slices    = slices,
     )
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(AVCEncoderTest):
-  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
-  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -150,6 +207,21 @@ class vbr_lp(AVCEncoderTest):
       refs      = refs,
       slices    = slices,
     )
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_qsv_encode)
+  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
 class vbr_la(AVCEncoderTest):

--- a/test/ffmpeg-qsv/encode/encoder.py
+++ b/test/ffmpeg-qsv/encode/encoder.py
@@ -19,7 +19,7 @@ class EncoderTest(slash.Test):
 
     opts += " -i {source}"
 
-    return opts.format(**vars(self))
+    return opts
 
   def gen_output_opts(self):
     opts = "-vf 'format={hwformat},hwupload=extra_hw_frames=120' -an"
@@ -58,7 +58,7 @@ class EncoderTest(slash.Test):
 
     opts += " -vframes {frames} -y {encoded}"
 
-    return opts.format(**vars(self))
+    return opts
 
   def gen_name(self):
     name = "{case}-{rcmode}-{profile}"
@@ -84,11 +84,18 @@ class EncoderTest(slash.Test):
       name += "-{lowpower}"
     if vars(self).get("ladepth", None) is not None:
       name += "-{ladepth}"
+    if vars(self).get("r2r", None) is not None:
+      name += "-r2r"
 
-    return name.format(**vars(self))
+    return name
 
   def before(self):
     self.refctx = []
+
+  def call_ffmpeg(self, iopts, oopts):
+    self.output = call(
+      "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
+      " -v verbose {iopts} {oopts}".format(iopts = iopts, oopts = oopts))
 
   def encode(self):
     self.mprofile = mapprofile(self.codec, self.profile)
@@ -99,19 +106,36 @@ class EncoderTest(slash.Test):
     if self.mformat is None:
       slash.skip_test("{format} format not supported".format(**vars(self)))
 
-    self.encoded = get_media()._test_artifact(
-      "{}.{}".format(self.gen_name(), self.get_file_ext()))
-
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
+    name  = self.gen_name()
 
-    self.output = call(
-      "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
-      " -v verbose {iopts} {oopts}".format(iopts = iopts, oopts = oopts))
 
-    self.check_output()
-    self.check_bitrate()
-    self.check_metrics()
+    if vars(self).get("r2r", None) is not None:
+      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
+      for i in xrange(self.r2r):
+        self.encoded = get_media()._test_artifact(
+          "{}_{}.{}".format(name.format(**vars(self)), i, self.get_file_ext()))
+
+        self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
+        result = md5(self.encoded)
+        get_media()._set_test_details(**{ "md5_{}".format(i) : result})
+
+        if 0 == i:
+          md5ref = result
+          continue
+ 
+        assert result == md5ref, "r2r md5 mismatch"
+        # delete encoded file after each iteration
+        get_media()._purge_test_artifact(self.encoded)
+    else:
+      self.encoded = get_media()._test_artifact(
+        "{}.{}".format(name.format(**vars(self)), self.get_file_ext()))
+
+      self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
+      self.check_output()
+      self.check_bitrate()
+      self.check_metrics()
 
   def check_output(self):
     m = re.search("Initialize MFX session", self.output, re.MULTILINE)

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -9,6 +9,7 @@ from ..util import *
 from .encoder import EncoderTest
 
 spec = load_test_spec("hevc", "encode", "8bit")
+spec_r2r = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
@@ -24,12 +25,8 @@ class HEVC8EncoderTest(EncoderTest):
     return "h265"
 
 class cqp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
@@ -40,15 +37,27 @@ class cqp(HEVC8EncoderTest):
       rcmode  = "cqp",
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
@@ -59,57 +68,93 @@ class cqp_lp(HEVC8EncoderTest):
       rcmode   = "cqp",
       slices   = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, qp, quality, profile):
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      maxrate = bitrate,
+      minrate = bitrate,
+      profile = profile,
+      rcmode  = "cbr",
+      slices  = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
+      lowpower= 1,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,
       rcmode  = "cbr",
       slices  = slices,
     )
-    self.encode()
 
-class cbr_lp(HEVC8EncoderTest):
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_qsv_encode)
   @slash.requires(have_ffmpeg_hevc_qsv_decode)
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate = bitrate,
-      case    = case,
-      fps     = fps,
-      gop     = gop,
-      lowpower= 1,
-      maxrate = bitrate,
-      minrate = bitrate,
-      profile = profile,
-      rcmode  = "cbr",
-      slices  = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       bitrate = bitrate,
@@ -124,15 +169,27 @@ class vbr(HEVC8EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
@@ -147,4 +204,20 @@ class vbr_lp(HEVC8EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_qsv_encode)
+  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -9,6 +9,7 @@ from ..util import *
 from .encoder import EncoderTest
 
 spec = load_test_spec("mpeg2", "encode")
+spec_r2r = load_test_spec("mpeg2", "encode", "r2r")
 
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
@@ -24,12 +25,8 @@ class MPEG2EncoderTest(EncoderTest):
     return "m2v"
 
 class cqp(MPEG2EncoderTest):
-  @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
-  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
-  def test(self, case, gop, bframes, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
@@ -40,4 +37,20 @@ class cqp(MPEG2EncoderTest):
       quality = quality,
       rcmode  = "cqp",
     )
+
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
+  def test(self, case, gop, bframes, qp, quality, profile):
+    self.init(spec, case, gop, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
+  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r, ['main', 'simple']))
+  def test_r2r(self, case, gop, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -26,90 +26,132 @@ class HEVC10EncoderTest(EncoderTest):
     }[self.profile]
 
 spec = load_test_spec("hevc", "encode", "10bit")
+spec_r2r = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 class cqp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      case    = case,
+      gop     = gop,
+      profile = profile,
+      qp      = qp,
+      rcmode  = "cqp",
+      slices  = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cqp_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       case    = case,
       gop     = gop,
+      lowpower= 1,
       profile = profile,
       qp      = qp,
       rcmode  = "cqp",
       slices  = slices,
     )
-    self.encode()
 
-class cqp_lp(HEVC10EncoderTest):
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case    = case,
-      gop     = gop,
-      lowpower= 1,
-      profile = profile,
-      qp      = qp,
-      rcmode  = "cqp",
-      slices  = slices,
-    )
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case = case,
+      fps = fps,
+      gop = gop,
+      minrate = bitrate,
+      maxrate = bitrate,
+      profile = profile,
+      rcmode = "cbr",
+      slices = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       bitrate = bitrate,
       case = case,
       fps = fps,
       gop = gop,
+      lowpower= 1,
       minrate = bitrate,
       maxrate = bitrate,
       profile = profile,
       rcmode = "cbr",
       slices = slices,
     )
-    self.encode()
 
-class cbr_lp(HEVC10EncoderTest):
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate = bitrate,
-      case = case,
-      fps = fps,
-      gop = gop,
-      lowpower= 1,
-      minrate = bitrate,
-      maxrate = bitrate,
-      profile = profile,
-      rcmode = "cbr",
-      slices = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(HEVC10EncoderTest):
-  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       bitrate = bitrate,
@@ -123,15 +165,26 @@ class vbr(HEVC10EncoderTest):
       refs = refs,
       slices = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC10EncoderTest):
-  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case = case,
@@ -145,4 +198,18 @@ class vbr_lp(HEVC10EncoderTest):
       refs = refs,
       slices = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -28,91 +28,133 @@ class AVCEncoderTest(EncoderTest):
     }[self.profile]
 
 spec = load_test_spec("avc", "encode")
+spec_r2r = load_test_spec("avc", "encode", "r2r")
 
 class cqp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      lowpower  = 0,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
   @platform_tags(AVC_ENCODE_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cqp_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes   = bframes,
       case      = case,
       gop       = gop,
-      lowpower  = 0,
+      lowpower  = 1,
       profile   = profile,
       qp        = qp,
       quality   = quality,
       rcmode    = "cqp",
       slices    = slices,
     )
-    self.encode()
 
-class cqp_lp(AVCEncoderTest):
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case      = case,
-      gop       = gop,
-      lowpower  = 1,
-      profile   = profile,
-      qp        = qp,
-      quality   = quality,
-      rcmode    = "cqp",
-      slices    = slices,
-    )
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      lowpower  = 0,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
   @platform_tags(AVC_ENCODE_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes   = bframes,
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = 0,
+      lowpower  = 1,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
       rcmode    = "cbr",
       slices    = slices,
     )
-    self.encode()
 
-class cbr_lp(AVCEncoderTest):
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_h264_vaapi_encode)
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate   = bitrate,
-      case      = case,
-      fps       = fps,
-      gop       = gop,
-      lowpower  = 1,
-      maxrate   = bitrate,
-      minrate   = bitrate,
-      profile   = profile,
-      rcmode    = "cbr",
-      slices    = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(AVCEncoderTest):
-  @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
-  @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
       bitrate   = bitrate,
@@ -128,14 +170,25 @@ class vbr(AVCEncoderTest):
       refs      = refs,
       slices    = slices,
     )
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(AVCEncoderTest):
-  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
-  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -150,4 +203,18 @@ class vbr_lp(AVCEncoderTest):
       refs      = refs,
       slices    = slices,
     )
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.int(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.int(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -26,14 +26,12 @@ class HEVC8EncoderTest(EncoderTest):
     }[self.profile]
 
 spec = load_test_spec("hevc", "encode", "8bit")
+spec_r2r = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class cqp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
@@ -43,15 +41,26 @@ class cqp(HEVC8EncoderTest):
       rcmode  = "cqp",
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
@@ -61,55 +70,88 @@ class cqp_lp(HEVC8EncoderTest):
       rcmode   = "cqp",
       slices   = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, qp, quality, profile):
+    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, qp, quality, profile):
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cbr(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      maxrate = bitrate,
+      minrate = bitrate,
+      profile = profile,
+      rcmode  = "cbr",
+      slices  = slices,
+    )
+
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr_lp(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
-      bframes = bframes,
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
+      lowpower= 1,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,
       rcmode  = "cbr",
       slices  = slices,
     )
-    self.encode()
 
-class cbr_lp(HEVC8EncoderTest):
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
   @slash.requires(have_ffmpeg_hevc_vaapi_encode)
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      bitrate = bitrate,
-      case    = case,
-      fps     = fps,
-      gop     = gop,
-      lowpower= 1,
-      maxrate = bitrate,
-      minrate = bitrate,
-      profile = profile,
-      rcmode  = "cbr",
-      slices  = slices,
-    )
+    self.init(spec, case, gop, slices, bitrate, fps, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       bitrate = bitrate,
@@ -123,15 +165,26 @@ class vbr(HEVC8EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC8EncoderTest):
-  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
-  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
@@ -145,4 +198,18 @@ class vbr_lp(HEVC8EncoderTest):
       refs    = refs,
       slices  = slices,
     )
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.encode()
+
+  @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
+  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
+  def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -25,16 +25,28 @@ class JPEGEncoderTest(EncoderTest):
     return "VAProfileJPEGBaseline"
 
 spec = load_test_spec("jpeg", "encode")
+spec_r2r = load_test_spec("jpeg", "encode", "r2r")
 
 class cqp(JPEGEncoderTest):
-  @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
-  @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
-  def test(self, case, quality):
-    vars(self).update(spec[case].copy())
+  def init(self, tspec, case, quality):
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
       quality = quality,
       rcmode  = "cqp",
     )
+
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
+  @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
+  def test(self, case, quality):
+    self.init(spec, case, quality)
+    self.encode()
+
+  @platform_tags(JPEG_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
+  @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
+  def test_r2r(self, case, quality):
+    self.init(spec_r2r, case, quality)
+    vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -27,14 +27,12 @@ class MPEG2EncoderTest(EncoderTest):
     }[self.profile]
 
 spec = load_test_spec("mpeg2", "encode")
+spec_r2r = load_test_spec("mpeg2", "encode", "r2r")
 
 class cqp(MPEG2EncoderTest):
-  @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
-  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
-  def test(self, case, gop, bframes, qp, quality, profile):
+  def init(self, tspec, case, gop, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
@@ -44,4 +42,18 @@ class cqp(MPEG2EncoderTest):
       mqp     = mapRange(qp, [0, 100], [1, 31]),
       rcmode  = "cqp",
     )
+
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
+  def test(self, case, gop, bframes, qp, quality, profile):
+    self.init(spec, case, gop, bframes, qp, quality, profile)
+    self.encode()
+
+  @platform_tags(MPEG2_ENCODE_PLATFORMS)
+  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r, ['main', 'simple']))
+  def test_r2r(self, case, gop, bframes, qp, quality, profile):
+    self.init(spec_r2r, case, gop, bframes, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
     self.encode()


### PR DESCRIPTION
1. It supports AVC encoding for multiple iterations in single test run
2. md5 is used for validating each encode iteration

Signed-off-by: hbomminx <haribabux.bommineni@intel.com>