### PR TITLE
ffmpeg/encode: fix filename bug

### DIFF
--- a/test/ffmpeg-qsv/encode/encoder.py
+++ b/test/ffmpeg-qsv/encode/encoder.py
@@ -146,8 +146,9 @@ class EncoderTest(slash.Test):
       assert m is not None, "It appears that the lookahead did not load"
 
   def check_metrics(self):
+    name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact(
-      "{}-{width}x{height}-{format}.yuv".format(self.gen_name(), **vars(self)))
+      "{}-{width}x{height}-{format}.yuv".format(name, **vars(self)))
 
     call(
       "ffmpeg -hwaccel qsv -hwaccel_device /dev/dri/renderD128 -v verbose"

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -66,8 +66,9 @@ class cqp(JPEGEncoderTest):
   ## NOTE: Temporary Workaround for qsv mjpeg encode test until
   ## a qsv mjpeg decoder is available.
   def check_metrics(self):
+    name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact(
-      "{}-{width}x{height}-{format}.yuv".format(self.gen_name(), **vars(self)))
+      "{}-{width}x{height}-{format}.yuv".format(name, **vars(self)))
 
     call(
       "ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose"

--- a/test/ffmpeg-vaapi/encode/encoder.py
+++ b/test/ffmpeg-vaapi/encode/encoder.py
@@ -184,8 +184,9 @@ class EncoderTest(slash.Test):
     assert m is not None, "Possible incorrect IPB mode used"
 
   def check_metrics(self):
+    name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact(
-      "{}-{width}x{height}-{format}.yuv".format(self.gen_name(), **vars(self)))
+      "{}-{width}x{height}-{format}.yuv".format(name, **vars(self)))
 
     call(
       "ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose"


### PR DESCRIPTION
Since f06ed1c4926b and 6eb8b07b1c17, the gen_name()
method no longer formats the return value for the caller.
The caller is responsible to format it.  This was not
accounted for in the check_metrics function where it
gen_name() is also used.  Fixed.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>