### PR TITLE
Consolidate common R2R vs. non-R2R code

### DIFF
--- a/test/ffmpeg-vaapi/decode/decoder.py
+++ b/test/ffmpeg-vaapi/decode/decoder.py
@@ -19,6 +19,12 @@ class DecoderTest(slash.Test):
       " -i {source} -pix_fmt {mformat} -f rawvideo -vsync passthrough"
       " -vframes {frames} -y {decoded}".format(**vars(self)))
 
+  def gen_name(self):
+    name = "{case}_{width}x{height}_{format}"
+    if vars(self).get("r2r", None) is not None:
+      name += "_r2r"
+    return name
+
   def decode(self):
     self.mformat = mapformat(self.format)
 
@@ -27,28 +33,23 @@ class DecoderTest(slash.Test):
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
+    name = self.gen_name().format(**vars(self))
+    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_ffmpeg()
+
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      for self.i in xrange(self.r2r):
-        self.decoded = get_media()._test_artifact(
-          "{case}_{width}x{height}_{format}_{i}.yuv".format(**vars(self)))
-
+      md5ref = md5(self.decoded)
+      get_media()._set_test_details(md5_ref = md5ref)
+      for i in xrange(1, self.r2r):
+        self.decoded = get_media()._test_artifact("{}_{}.yuv".format(name, i))
         self.call_ffmpeg()
         result = md5(self.decoded)
-        get_media()._set_test_details(**{ "md5_{}".format(self.i) : result})
-
-        if 0 == self.i:
-          md5ref = result
-          continue
-
+        get_media()._set_test_details(**{"md5_{:03}".format(i) : result})
         assert result == md5ref, "r2r md5 mismatch"
         # delete decoded file after each iteration
         get_media()._purge_test_artifact(self.decoded)
     else:
-      self.decoded = get_media()._test_artifact(
-        "{case}_{width}x{height}_{format}.yuv".format(**vars(self)))
-
-      self.call_ffmpeg()
       self.check_output()
       self.check_metrics()
 

--- a/test/ffmpeg-vaapi/encode/encoder.py
+++ b/test/ffmpeg-vaapi/encode/encoder.py
@@ -113,32 +113,28 @@ class EncoderTest(slash.Test):
       slash.skip_test("{format} format not supported".format(**vars(self)))
 
     vars(self).update(rcmodeu = self.rcmode.upper())
+
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
-    name  = self.gen_name()
+    name  = self.gen_name().format(**vars(self))
+    ext   = self.get_file_ext()
+
+    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
+    self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      for i in xrange(self.r2r):
-        self.encoded = get_media()._test_artifact(
-          "{}_{}.{}".format(name.format(**vars(self)), i, self.get_file_ext()))
-
+      md5ref = md5(self.encoded)
+      get_media()._set_test_details(md5_ref = md5ref)
+      for i in xrange(1, self.r2r):
+        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
         self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
         result = md5(self.encoded)
-        get_media()._set_test_details(**{ "md5_{}".format(i) : result})
-
-        if 0 == i:
-          md5ref = result
-          continue
- 
+        get_media()._set_test_details(**{"md5_{:03}".format(i) : result})
         assert result == md5ref, "r2r md5 mismatch"
         # delete encoded file after each iteration
         get_media()._purge_test_artifact(self.encoded)
     else:
-      self.encoded = get_media()._test_artifact(
-        "{}.{}".format(name.format(**vars(self)), self.get_file_ext()))
-
-      self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
       self.check_output()
       self.check_bitrate()
       self.check_metrics()
@@ -184,14 +180,13 @@ class EncoderTest(slash.Test):
     assert m is not None, "Possible incorrect IPB mode used"
 
   def check_metrics(self):
-    name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact(
-      "{}-{width}x{height}-{format}.yuv".format(name, **vars(self)))
-
-    call(
-      "ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose"
-      " -i {encoded} -pix_fmt {mformat} -f rawvideo -vsync passthrough"
-      " -vframes {frames} -y {decoded}".format(**vars(self)))
+    iopts = "-i {encoded}"
+    oopts = (
+      "-pix_fmt {mformat} -f rawvideo -vsync passthrough"
+      " -vframes {frames} -y {decoded}")
+    name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
+    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
 
     get_media().baseline.check_psnr(
       psnr = calculate_psnr(

--- a/test/gst-vaapi/encode/encoder.py
+++ b/test/gst-vaapi/encode/encoder.py
@@ -102,13 +102,14 @@ class EncoderTest(slash.Test):
       name += "-{loopshp}"
     if vars(self).get("looplvl", None) is not None:
       name += "-{looplvl}"
+    if vars(self).get("r2r", None) is not None:
+      name += "-r2r"
+
     return name
 
-  def call_encode(self, iopts, oopts):
-    self.output = call(
-      "gst-launch-1.0 -vf"
-       " {iopts} ! {oopts}".format(iopts = iopts, oopts = oopts)
-    )
+  def call_gst(self, iopts, oopts):
+    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+      iopts = iopts, oopts = oopts))
 
   def before(self):
     self.refctx = []
@@ -126,47 +127,38 @@ class EncoderTest(slash.Test):
 
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
-    name  = self.gen_name()
+    name  = self.gen_name().format(**vars(self))
+    ext   = self.get_file_ext()
+
+    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
+    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      for i in xrange(self.r2r):
-        self.encoded = get_media()._test_artifact(
-          "{}_{}.{}".format(name.format(**vars(self)), i, self.get_file_ext()))
-        self.call_encode(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
+      md5ref = md5(self.encoded)
+      get_media()._set_test_details(md5_ref = md5ref)
+      for i in xrange(1, self.r2r):
+        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
+        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
         result = md5(self.encoded)
-        get_media()._set_test_details(**{"md5_{}".format(i): result})
-
-        if i == 0:
-          md5ref = result
-          continue
-
+        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
         assert md5ref == result, "r2r md5 mismatch"
         # delete encoded file after each iteration
         get_media()._purge_test_artifact(self.encoded)
-
     else:
-      self.encoded = get_media()._test_artifact(
-          "{}.{}".format(name.format(**vars(self)), self.get_file_ext()))
-
-      self.call_encode(iopts.format(**vars(self)), oopts.format(**vars(self)))
       self.check_bitrate()
       self.check_metrics()
 
   def check_metrics(self):
-    name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact(
-      "{}-{width}x{height}-{format}.yuv".format(name, **vars(self)))
+    iopts = "filesrc location={encoded} ! {gstdecoder}"
+    oopts = (
+      " videoconvert ! video/x-raw,format={mformatu} ! checksumsink2"
+      " file-checksum=false frame-checksum=false plane-checksum=false"
+      " dump-output=true qos=false dump-location={decoded}")
+    name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
 
-    call(
-      "gst-launch-1.0 -vf filesrc location={encoded}"
-      " ! {gstdecoder}"
-      " ! videoconvert ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false frame-checksum=false"
-      " plane-checksum=false dump-output=true qos=false"
-      " dump-location={decoded}".format(**vars(self))
-    )
+    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
 
     get_media().baseline.check_psnr(
       psnr = calculate_psnr(


### PR DESCRIPTION
The first encode/decode command is always the same for first call in r2r and non-r2r cases.  Thus, share that code.  Also, cleanup other unnecessary complexities.