### PR TITLE
Fix ffmpeg vpp csc filter requirements

### DIFF
--- a/test/ffmpeg-qsv/vpp/csc.py
+++ b/test/ffmpeg-qsv/vpp/csc.py
@@ -11,7 +11,7 @@ spec = load_test_spec("vpp", "csc")
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_qsv_accel)
-@slash.requires(*have_ffmpeg_filter("vpp_qsv"))
+@slash.requires(*have_ffmpeg_filter("scale_qsv"))
 @slash.requires(using_compatible_driver)
 @slash.parametrize(*gen_vpp_csc_parameters(spec))
 @platform_tags(VPP_PLATFORMS)

--- a/test/ffmpeg-vaapi/vpp/csc.py
+++ b/test/ffmpeg-vaapi/vpp/csc.py
@@ -11,7 +11,7 @@ spec = load_test_spec("vpp", "csc")
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_vaapi_accel)
-@slash.requires(*have_ffmpeg_filter("colorspace"))
+@slash.requires(*have_ffmpeg_filter("scale_vaapi"))
 @slash.parametrize(*gen_vpp_csc_parameters(spec))
 @platform_tags(VPP_PLATFORMS)
 def test_default(case, csc):


### PR DESCRIPTION
Fix incorrectly specified filter requirements for VPP CSC tests in ffmpeg-qsv and ffmpeg-vaapi.