### PR TITLE
Consolidate have requirement methods

### DIFF
--- a/test/ffmpeg-qsv/decode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/decode/10bit/hevc.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(HEVC_DECODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["format"] in ["P010"]]))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -29,7 +29,7 @@ class default(DecoderTest):
     self.decode()
 
   @platform_tags(set(HEVC_DECODE_10BIT_PLATFORMS) & set(DECODE_10BIT_422_PLATFORMS))
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["format"] in ["P210"]]))
   def test_422(self, case):
     vars(self).update(spec[case].copy())
@@ -41,7 +41,7 @@ class default(DecoderTest):
     self.decode()
 
   @platform_tags(set(HEVC_DECODE_10BIT_PLATFORMS) & set(DECODE_10BIT_444_PLATFORMS))
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["format"] in ["P410"]]))
   def test_444(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/decode/10bit/vp9.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(VP9_DECODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp9_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/avc.py
+++ b/test/ffmpeg-qsv/decode/avc.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(AVC_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/hevc.py
+++ b/test/ffmpeg-qsv/decode/hevc.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(HEVC_DECODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["width"] <= 4096
     and v["height"] <= 4096 and v["format"] in mapsubsampling("FORMATS_420")]))
   def test(self, case):
@@ -30,7 +30,7 @@ class default(DecoderTest):
     self.decode()
 
   @platform_tags(HEVC_DECODE_8BIT_8K_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if (v["width"] > 4096
     or v["height"] > 4096) and v["format"] in mapsubsampling("FORMATS_420")]))
   def test_highres(self, case):
@@ -43,7 +43,7 @@ class default(DecoderTest):
     self.decode()
 
   @platform_tags(HEVC_DECODE_8BIT_422_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["format"] in mapsubsampling("FORMATS_422")]))
   def test_422(self, case):
     vars(self).update(spec[case].copy())
@@ -55,7 +55,7 @@ class default(DecoderTest):
     self.decode()
 
   @platform_tags(HEVC_DECODE_8BIT_444_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted([k for k,v in spec.items() if v["format"] in mapsubsampling("FORMATS_444")]))
   def test_444(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/jpeg.py
+++ b/test/ffmpeg-qsv/decode/jpeg.py
@@ -26,14 +26,14 @@ class default(DecoderTest):
     )
 
   @platform_tags(JPEG_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
   @platform_tags(JPEG_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/mpeg2.py
+++ b/test/ffmpeg-qsv/decode/mpeg2.py
@@ -26,14 +26,14 @@ class default(DecoderTest):
     )
 
   @platform_tags(MPEG2_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
   @platform_tags(MPEG2_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/vc1.py
+++ b/test/ffmpeg-qsv/decode/vc1.py
@@ -26,14 +26,14 @@ class default(DecoderTest):
     )
 
   @platform_tags(VC1_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
   @platform_tags(VC1_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vc1_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/vp8.py
+++ b/test/ffmpeg-qsv/decode/vp8.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(VP8_DECODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp8_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("vp8_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/vp9.py
+++ b/test/ffmpeg-qsv/decode/vp9.py
@@ -17,7 +17,7 @@ class default(DecoderTest):
     super(default, self).before()
 
   @platform_tags(VP9_DECODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp9_qsv_decode)
+  @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -39,16 +39,16 @@ class cqp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -70,16 +70,16 @@ class cqp_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -103,16 +103,16 @@ class cbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -136,16 +136,16 @@ class cbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -171,16 +171,16 @@ class vbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -206,16 +206,16 @@ class vbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -40,16 +40,16 @@ class cqp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -71,16 +71,16 @@ class cqp_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -105,16 +105,16 @@ class cbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -138,16 +138,16 @@ class cbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -174,16 +174,16 @@ class vbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -209,16 +209,16 @@ class vbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
@@ -226,8 +226,8 @@ class vbr_lp(AVCEncoderTest):
 
 class vbr_la(AVCEncoderTest):
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_qsv_encode)
-  @slash.requires(have_ffmpeg_h264_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -39,16 +39,16 @@ class cqp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -70,16 +70,16 @@ class cqp_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -103,16 +103,16 @@ class cbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -136,16 +136,16 @@ class cbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -171,16 +171,16 @@ class vbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -206,16 +206,16 @@ class vbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_qsv_encode)
-  @slash.requires(have_ffmpeg_hevc_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -41,7 +41,7 @@ class cqp(JPEGEncoderTest):
     )
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
   ## NOTE: Temporary Workaround for qsv mjpeg encode test until
   ## a qsv mjpeg decoder is available.
   @slash.requires(have_ffmpeg_vaapi_accel)
@@ -52,7 +52,7 @@ class cqp(JPEGEncoderTest):
     self.encode()
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_qsv_encode)
+  @slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
   ## NOTE: Temporary Workaround for qsv mjpeg encode test until
   ## a qsv mjpeg decoder is available.
   @slash.requires(have_ffmpeg_vaapi_accel)

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -39,16 +39,16 @@ class cqp(MPEG2EncoderTest):
     )
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("mpeg2_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
   def test(self, case, gop, bframes, qp, quality, profile):
     self.init(spec, case, gop, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_encode)
-  @slash.requires(have_ffmpeg_mpeg2_qsv_decode)
+  @slash.requires(*have_ffmpeg_encoder("mpeg2_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r, ['main', 'simple']))
   def test_r2r(self, case, gop, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, bframes, qp, quality, profile)

--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -18,58 +18,6 @@ def have_ffmpeg_qsv_accel():
   return try_call("ffmpeg -hide_banner -hwaccels | grep qsv")
 
 @memoize
-def have_ffmpeg_h264_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep h264_qsv")
-
-@memoize
-def have_ffmpeg_hevc_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep hevc_qsv")
-
-@memoize
-def have_ffmpeg_mjpeg_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep mjpeg_qsv")
-
-@memoize
-def have_ffmpeg_mpeg2_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep mpeg2_qsv")
-
-@memoize
-def have_ffmpeg_vc1_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep vc1_qsv")
-
-@memoize
-def have_ffmpeg_vp8_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep vp8_qsv")
-
-@memoize
-def have_ffmpeg_vp9_qsv_decode():
-  return try_call("ffmpeg -hide_banner -decoders | grep vp9_qsv")
-
-@memoize
-def have_ffmpeg_h264_qsv_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep h264_qsv")
-
-@memoize
-def have_ffmpeg_x264_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep libx264")
-
-@memoize
-def have_ffmpeg_hevc_qsv_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep hevc_qsv")
-
-@memoize
-def have_ffmpeg_x265_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep libx265")
-
-@memoize
-def have_ffmpeg_mjpeg_qsv_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep mjpeg_qsv")
-
-@memoize
-def have_ffmpeg_mpeg2_qsv_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep mpeg2_qsv")
-
-@memoize
 def have_ffmpeg_filter(name):
   result = try_call("ffmpeg -hide_banner -filters | awk '{{print $2}}' | grep -w {}".format(name))
   return result, name

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -43,14 +43,14 @@ class cqp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -72,14 +72,14 @@ class cqp_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -103,14 +103,14 @@ class cbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -134,14 +134,14 @@ class cbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -167,14 +167,14 @@ class vbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -200,14 +200,14 @@ class vbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -46,14 +46,14 @@ class cqp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -75,14 +75,14 @@ class cqp_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -107,14 +107,14 @@ class cbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -138,14 +138,14 @@ class cbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -172,14 +172,14 @@ class vbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -205,14 +205,14 @@ class vbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.int(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_h264_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.int(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -43,14 +43,14 @@ class cqp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -72,14 +72,14 @@ class cqp_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -103,14 +103,14 @@ class cbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -134,14 +134,14 @@ class cbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -167,14 +167,14 @@ class vbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -200,14 +200,14 @@ class vbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_ffmpeg_hevc_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -37,14 +37,14 @@ class cqp(JPEGEncoderTest):
     )
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mjpeg_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -44,14 +44,14 @@ class cqp(MPEG2EncoderTest):
     )
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['main', 'simple']))
   def test(self, case, gop, bframes, qp, quality, profile):
     self.init(spec, case, gop, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_mpeg2_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r, ['main', 'simple']))
   def test_r2r(self, case, gop, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, bframes, qp, quality, profile)

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -28,7 +28,7 @@ spec = load_test_spec("vp8", "encode")
 
 class cqp(VP8EncoderTest):
   @platform_tags(VP8_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -45,7 +45,7 @@ class cqp(VP8EncoderTest):
 
 class cbr(VP8EncoderTest):
   @platform_tags(VP8_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
     vars(self).update(spec[case].copy())
@@ -65,7 +65,7 @@ class cbr(VP8EncoderTest):
 
 class vbr(VP8EncoderTest):
   @platform_tags(VP8_ENCODE_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp8_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -28,7 +28,7 @@ spec = load_test_spec("vp9", "encode", "8bit")
 
 class cqp(VP9EncoderTest):
   @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -46,7 +46,7 @@ class cqp(VP9EncoderTest):
 
 class cbr(VP9EncoderTest):
   @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -67,7 +67,7 @@ class cbr(VP9EncoderTest):
 
 class vbr(VP9EncoderTest):
   @platform_tags(VP9_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_ffmpeg_vp9_vaapi_encode)
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/util.py
+++ b/test/ffmpeg-vaapi/util.py
@@ -15,33 +15,6 @@ def have_ffmpeg_vaapi_accel():
   return try_call("ffmpeg -hide_banner -hwaccels | grep vaapi")
 
 @memoize
-def have_ffmpeg_h264_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep h264_vaapi")
-
-@memoize
-def have_ffmpeg_hevc_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep hevc_vaapi")
-
-def have_ffmpeg_mjpeg_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep mjpeg_vaapi")
-
-@memoize
-def have_ffmpeg_mpeg2_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep mpeg2_vaapi")
-
-@memoize
-def have_ffmpeg_vc1_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep vc1_vaapi")
-
-@memoize
-def have_ffmpeg_vp8_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep vp8_vaapi")
-
-@memoize
-def have_ffmpeg_vp9_vaapi_encode():
-  return try_call("ffmpeg -hide_banner -encoders | grep vp9_vaapi")
-
-@memoize
 def have_ffmpeg_filter(name):
   result = try_call("ffmpeg -hide_banner -filters | awk '{{print $2}}' | grep -w {}".format(name))
   return result, name

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -40,15 +40,15 @@ class cqp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -70,15 +70,15 @@ class cqp_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -102,15 +102,15 @@ class cbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -134,15 +134,15 @@ class cbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -169,15 +169,15 @@ class vbr(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -204,15 +204,15 @@ class vbr_lp(HEVC10EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_10BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -42,15 +42,15 @@ class cqp(AVCEncoderTest):
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -72,15 +72,15 @@ class cqp_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CQP_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -105,15 +105,15 @@ class cbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -137,15 +137,15 @@ class cbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -173,15 +173,15 @@ class vbr(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -208,15 +208,15 @@ class vbr_lp(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(AVC_ENCODE_CBRVBR_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
@@ -243,15 +243,15 @@ class vbr_la(AVCEncoderTest):
     )
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
-  @slash.requires(have_gst_msdkh264dec)
+  @slash.requires(*have_gst_element("msdkh264enc"))
+  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.init(spec, case, bframes, bitrate, fps, quality, refs, profile, ladepth)
     self.encode()
 
   @platform_tags(AVC_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkh264enc)
+  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.init(spec_r2r, case, bframes, bitrate, fps, quality, refs, profile, ladepth)

--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -8,7 +8,7 @@ from ....lib import *
 from ..util import *
 
 @slash.requires(have_gst)
-@slash.requires(have_gst_msdk)
+@slash.requires(*have_gst_element("msdk"))
 @slash.requires(*have_gst_element("checksumsink2"))
 @slash.requires(using_compatible_driver)
 class EncoderTest(slash.Test):

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -41,15 +41,15 @@ class cqp(HEVC8EncoderTest):
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
@@ -71,15 +71,15 @@ class cqp_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
@@ -103,15 +103,15 @@ class cbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
@@ -135,15 +135,15 @@ class cbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
@@ -170,15 +170,15 @@ class vbr(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
@@ -205,15 +205,15 @@ class vbr_lp(HEVC8EncoderTest):
     )
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
-  @slash.requires(have_gst_msdkh265dec)
+  @slash.requires(*have_gst_element("msdkh265enc"))
+  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
   @platform_tags(HEVC_ENCODE_8BIT_LP_PLATFORMS)
-  @slash.requires(have_gst_msdkh265enc)
+  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -36,15 +36,15 @@ class cqp(JPEGEncoderTest):
     )
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkmjpegenc)
-  @slash.requires(have_gst_msdkmjpegdec)
+  @slash.requires(*have_gst_element("msdkmjpegenc"))
+  @slash.requires(*have_gst_element("msdkmjpegdec"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
   @platform_tags(JPEG_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkmjpegenc)
+  @slash.requires(*have_gst_element("msdkmjpegenc"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -40,15 +40,15 @@ class cqp(MPEG2EncoderTest):
     )
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkmpeg2enc)
-  @slash.requires(have_gst_msdkmpeg2dec)
+  @slash.requires(*have_gst_element("msdkmpeg2enc"))
+  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec, ['high', 'main', 'simple']))
   def test(self, case, gop, bframes, qp, quality, profile):
     self.init(spec, case, gop, bframes, qp, quality, profile)
     self.encode()
 
   @platform_tags(MPEG2_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkmpeg2enc)
+  @slash.requires(*have_gst_element("msdkmpeg2enc"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r, ['high', 'main', 'simple']))
   def test_r2r(self, case, gop, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, bframes, qp, quality, profile)

--- a/test/gst-msdk/encode/vp8.py
+++ b/test/gst-msdk/encode/vp8.py
@@ -27,8 +27,8 @@ class VP8EncoderTest(EncoderTest):
 
 class cqp(VP8EncoderTest):
   @platform_tags(VP8_ENCODE_PLATFORMS)
-  @slash.requires(have_gst_msdkvp8enc)
-  @slash.requires(have_gst_msdkvp8dec)
+  @slash.requires(*have_gst_element("msdkvp8enc"))
+  @slash.requires(*have_gst_element("msdkvp8dec"))
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     if looplvl != 0 or loopshp != 0:

--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -14,54 +14,6 @@ def have_gst():
   return try_call("which gst-launch-1.0") and try_call("which gst-inspect-1.0")
 
 @memoize
-def have_gst_msdk():
-  return try_call("gst-inspect-1.0 msdk")
-
-@memoize
-def have_gst_msdkh264dec():
-  return try_call("gst-inspect-1.0 msdkh264dec")
-
-@memoize
-def have_gst_msdkh265dec():
-  return try_call("gst-inspect-1.0 msdkh265dec")
-
-@memoize
-def have_gst_msdkmjpegdec():
-  return try_call("gst-inspect-1.0 msdkmjpegdec")
-
-@memoize
-def have_gst_msdkmpeg2dec():
-  return try_call("gst-inspect-1.0 msdkmpeg2dec")
-
-@memoize
-def have_gst_msdkvc1dec():
-  return try_call("gst-inspect-1.0 msdkvc1dec")
-
-@memoize
-def have_gst_msdkvp8dec():
-  return try_call("gst-inspect-1.0 msdkvp8dec")
-
-@memoize
-def have_gst_msdkh264enc():
-  return try_call("gst-inspect-1.0 msdkh264enc")
-
-@memoize
-def have_gst_msdkh265enc():
-  return try_call("gst-inspect-1.0 msdkh265enc")
-
-@memoize
-def have_gst_msdkmjpegenc():
-  return try_call("gst-inspect-1.0 msdkmjpegenc")
-
-@memoize
-def have_gst_msdkmpeg2enc():
-  return try_call("gst-inspect-1.0 msdkmpeg2enc")
-
-@memoize
-def have_gst_msdkvp8enc():
-  return try_call("gst-inspect-1.0 msdkvp8enc")
-
-@memoize
 def have_gst_element(element):
   result = try_call("gst-inspect-1.0 {}".format(element))
   return result, element

--- a/test/gst-vaapi/util.py
+++ b/test/gst-vaapi/util.py
@@ -11,66 +11,6 @@ def have_gst():
   return try_call("which gst-launch-1.0") and try_call("which gst-inspect-1.0")
 
 @memoize
-def have_gst_vaapi():
-  return try_call("gst-inspect-1.0 vaapi")
-
-@memoize
-def have_gst_vaapih264dec():
-  return try_call("gst-inspect-1.0 vaapih264dec")
-
-@memoize
-def have_gst_vaapih265dec():
-  return try_call("gst-inspect-1.0 vaapih265dec")
-
-@memoize
-def have_gst_vaapijpegdec():
-  return try_call("gst-inspect-1.0 vaapijpegdec")
-
-@memoize
-def have_gst_vaapimpeg2dec():
-  return try_call("gst-inspect-1.0 vaapimpeg2dec")
-
-@memoize
-def have_gst_vaapivc1dec():
-  return try_call("gst-inspect-1.0 vaapivc1dec")
-
-@memoize
-def have_gst_vaapivp8dec():
-  return try_call("gst-inspect-1.0 vaapivp8dec")
-
-@memoize
-def have_gst_vaapivp9dec():
-  return try_call("gst-inspect-1.0 vaapivp9dec")
-
-@memoize
-def have_gst_vaapih264enc():
-  return try_call("gst-inspect-1.0 vaapih264enc")
-
-@memoize
-def have_gst_vaapih265enc():
-  return try_call("gst-inspect-1.0 vaapih265enc")
-
-@memoize
-def have_gst_vaapijpegenc():
-  return try_call("gst-inspect-1.0 vaapijpegenc")
-
-@memoize
-def have_gst_vaapimpeg2enc():
-  return try_call("gst-inspect-1.0 vaapimpeg2enc")
-
-@memoize
-def have_gst_vaapivc1enc():
-  return try_call("gst-inspect-1.0 vaapivc1enc")
-
-@memoize
-def have_gst_vaapivp8enc():
-  return try_call("gst-inspect-1.0 vaapivp8enc")
-
-@memoize
-def have_gst_vaapipostproc():
-  return try_call("gst-inspect-1.0 vaapipostproc")
-
-@memoize
 def have_gst_element(element):
   result = try_call("gst-inspect-1.0 {}".format(element))
   return result, element


### PR DESCRIPTION
Use common have requirement methods instead of specializing for each plugin/element.