### PR TITLE
csc: modify the min ssim standard

### DIFF
--- a/test/ffmpeg-qsv/vpp/csc.py
+++ b/test/ffmpeg-qsv/vpp/csc.py
@@ -40,7 +40,8 @@ def test_default(case, csc):
 
   check_metric(
     # if user specified metric, then use it.  Otherwise, use ssim metric with perfect score
-    metric = params.get("metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
+    metric = params.get("metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+      if params.get("reference") else dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
     # If user specified reference, use it.  Otherwise, assume source is the reference.
     reference = format_value(params["reference"], case = case, **params)
       if params.get("reference") else params["source"],

--- a/test/ffmpeg-vaapi/vpp/csc.py
+++ b/test/ffmpeg-vaapi/vpp/csc.py
@@ -38,7 +38,8 @@ def test_default(case, csc):
 
   check_metric(
     # if user specified metric, then use it.  Otherwise, use ssim metric with perfect score
-    metric = params.get("metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
+    metric = params.get("metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+      if params.get("reference") else dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
     # If user specified reference, use it.  Otherwise, assume source is the reference.
     reference = format_value(params["reference"], case = case, **params)
       if params.get("reference") else params["source"],

--- a/test/gst-msdk/vpp/csc.py
+++ b/test/gst-msdk/vpp/csc.py
@@ -35,7 +35,8 @@ def test_default(case, csc):
 
   check_metric(
     # if user specified metric, then use it.  Otherwise, use ssim metric with perfect score
-    metric = params.get("metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
+    metric = params.get("metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+      if params.get("reference") else dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
     # If user specified reference, use it.  Otherwise, assume source is the reference.
     reference = format_value(params["reference"], case = case, **params)
       if params.get("reference") else params["source"],

--- a/test/gst-vaapi/vpp/csc.py
+++ b/test/gst-vaapi/vpp/csc.py
@@ -32,7 +32,8 @@ def test_default(case, csc):
 
   check_metric(
     # if user specified metric, then use it.  Otherwise, use ssim metric with perfect score
-    metric = params.get("metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
+    metric = params.get("metric", dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+      if params.get("reference") else dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
     # If user specified reference, use it.  Otherwise, assume source is the reference.
     reference = format_value(params["reference"], case = case, **params)
       if params.get("reference") else params["source"],


### PR DESCRIPTION
  use 1.0 as default min ssim
  use 0.99 as min ssim if reference file exists

Signed-off-by: Wang Zhanjun <zhanjunx.wang@intel.com>