### PR TITLE
ffmpeg/transcode: remove hwupload in hw to hw filter

### DIFF
--- a/test/ffmpeg-qsv/transcode/transcoder.py
+++ b/test/ffmpeg-qsv/transcode/transcoder.py
@@ -168,10 +168,7 @@ class TranscoderTest(slash.Test):
       if ("hw", "sw") == tmode:   # HW to SW transcode
         filters.extend(["hwdownload", "format=nv12"])
       elif ("sw", "hw") == tmode: # SW to HW transcode
-        filters.append("format=nv12")
-
-      if "hw" == mode:            # SW/HW to HW transcode
-        filters.append("hwupload=extra_hw_frames=64")
+        filters.append(["format=nv12", "hwupload=extra_hw_frames=64"])
 
       vppscale = self.get_vpp_scale(
         output.get("width", None), output.get("height", None), mode)

--- a/test/ffmpeg-vaapi/transcode/transcoder.py
+++ b/test/ffmpeg-vaapi/transcode/transcoder.py
@@ -168,10 +168,7 @@ class TranscoderTest(slash.Test):
       if ("hw", "sw") == tmode:   # HW to SW transcode
         filters.extend(["hwdownload", "format=nv12"])
       elif ("sw", "hw") == tmode: # SW to HW transcode
-        filters.append("format=nv12")
-
-      if "hw" == mode:            # SW/HW to HW transcode
-        filters.append("hwupload")
+        filters.append(["format=nv12", "hwupload"])
 
       vppscale = self.get_vpp_scale(
         output.get("width", None), output.get("height", None), mode)


### PR DESCRIPTION
According [VIZ-15572](https://jira.devtools.intel.com/browse/VIZ-15572) lizhong's comments

if add "-hwaccel_output_format vaapi" , thus means decoding output is working on video memory,  then hwupload is not needed. 

if remove hwaccel_output_format, vaapi decoder will output to system memory, then hwupload is needed.