### PR TITLE
gst-msdk/vpp/scale: use msdkvpp for scaling

### DIFF
--- a/test/gst-msdk/vpp/scale.py
+++ b/test/gst-msdk/vpp/scale.py
@@ -20,6 +20,7 @@ def test_default(case, scale_width, scale_height):
   params = spec[case].copy()
   params.update(
     mformat = mapformat(params["format"]),
+    mformatu = mapformatu(params["format"]),
     scale_width = scale_width, scale_height = scale_height)
 
   params["scaled"] = get_media()._test_artifact(
@@ -29,9 +30,10 @@ def test_default(case, scale_width, scale_height):
   call(
     "gst-launch-1.0 -vf filesrc location={source} num-buffers={frames}"
     " ! rawvideoparse format={mformat} width={width} height={height}"
-    " ! msdkvpp hardware=true scaling-mode=1 ! video/x-raw,format=NV12"
+    " ! msdkvpp hardware=true scaling-mode=1"
+    " ! video/x-raw,format=NV12,width={scale_width},height={scale_height}"
     " ! videoconvert"
-    " ! video/x-raw,width={scale_width},height={scale_height},format={format}"
+    " ! video/x-raw,format={mformatu}"
     " ! checksumsink2 file-checksum=false frame-checksum=false"
     " plane-checksum=false dump-output=true dump-location={scaled}"
     "".format(**params))


### PR DESCRIPTION
Don't use videoconvert to do the scaling... it
defeats the purpose of the test.  Instead, scaling
should be tested with msdkvpp.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>