### PR TITLE
Add optional hw scaling support to decode tests

### DIFF
--- a/test/ffmpeg-qsv/decode/decoder.py
+++ b/test/ffmpeg-qsv/decode/decoder.py
@@ -7,6 +7,13 @@
 from ....lib import *
 from ..util import *
 
+__scalers__ = {
+  "hw"  : lambda: "-vf 'hwupload,vpp_qsv=w={width}:h={height},hwdownload,format={hwformat}'",
+  "sw"  : lambda: "-vf 'hwdownload,format={hwformat}' -s:v {width}x{height}",
+  True  : lambda: __scalers__["sw"](),
+  False : lambda: "-vf 'hwdownload,format={hwformat}'",
+}
+
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_qsv_accel)
 @slash.requires(using_compatible_driver)
@@ -17,8 +24,8 @@ class DecoderTest(slash.Test):
   @timefn("ffmpeg")
   def call_ffmpeg(self):
     self.output = call(
-      "ffmpeg -hwaccel qsv -hwaccel_device /dev/dri/renderD128 -v verbose"
-      " -c:v {ffdecoder} -i {source} -vf 'hwdownload,format={hwformat}'"
+      "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
+      " -v verbose -c:v {ffdecoder} -i {source} {ffscaler}"
       " -pix_fmt {mformat} -f rawvideo -vsync passthrough"
       " -vframes {frames} -y {decoded}".format(**vars(self)))
 
@@ -36,6 +43,8 @@ class DecoderTest(slash.Test):
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
+    self.ffscaler = __scalers__.get(
+      vars(self).get("scale_output", False), lambda: "")().format(**vars(self))
     name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     self.call_ffmpeg()

--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -40,6 +40,9 @@ def mapformat_hwup(format):
 
   return mapformatu(fmt)
 
+# alias
+maphwformat = mapformat_hwup
+
 @memoize
 def mapformat(format):
   return {

--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -7,6 +7,12 @@
 from ....lib import *
 from ..util import *
 
+__scalers__ = {
+  "hw"  : lambda: "! vaapipostproc scale-method=fast ! video/x-raw,width={width},height={height},format={hwformat}",
+  "sw"  : lambda: "! videoscale ! video/x-raw,width={width},height={height}",
+  True  : lambda: __scalers__["sw"](),
+}
+
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("vaapi"))
 @slash.requires(*have_gst_element("checksumsink2"))
@@ -16,16 +22,10 @@ class DecoderTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self):
-    self.gstscaler = ""
-    if vars(self).get("scale_output", False):
-      self.gstscaler = (
-        " ! videoscale"
-        " ! video/x-raw,width={width},height={height}".format(**vars(self)))
-
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder}"
-      " ! videoconvert ! video/x-raw,format={mformatu} {gstscaler}"
+      " ! {gstdecoder} {gstscaler}"
+      " ! videoconvert ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))
@@ -37,12 +37,15 @@ class DecoderTest(slash.Test):
     return name
 
   def decode(self):
+    self.hwformat = maphwformat(self.format)
     self.mformatu = mapformatu(self.format)
     if self.mformatu is None:
       slash.skip_test("{format} format not supported".format(**vars(self)))
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
+    self.gstscaler = __scalers__.get(
+      vars(self).get("scale_output", False), lambda: "")().format(**vars(self))
     name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     self.call_gst()

--- a/test/gst-vaapi/util.py
+++ b/test/gst-vaapi/util.py
@@ -39,6 +39,9 @@ def mapformat_hwup(format):
 
   return mapformatu(fmt)
 
+# alias
+maphwformat = mapformat_hwup
+
 @memoize
 def mapformat(format):
   return {


### PR DESCRIPTION
Decode tests already support optional sw scaling via `scale_output` setting in user config.  Add support to allow user config to optionally use hw scaling instead.

Now `scale_output` can be set to "hw", "sw", True, False where "sw" and True mean the same thing (for backwards compatibility).  Also, for sw scaling mode, ensure ffmpeg sets scale output to specified width and height.