### PR TITLE
baseline: support for custom reference keys

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -122,7 +122,18 @@ class MediaPlugin(slash.plugins.PluginInterface):
       sc = str(c).strip().lower()
       if "driver" == sc:
         sc = "drv.{}".format(self._get_driver_name())
+      elif sc.startswith("key:"):
+        continue
       yield sc
+
+  def _get_ref_addr(self, context):
+    path, case = slash.context.test.__slash__.address.split(':')
+    keyctx = filter(lambda c: c.startswith("key:"), context)
+    if len(keyctx):
+      key = keyctx[0].lstrip("key:")
+    else:
+      key = os.path.relpath(path, self.mypath)
+    return ':'.join([key, case])
 
   def _set_test_details(self, **kwargs):
     for k, v in kwargs.iteritems():

--- a/lib/baseline.py
+++ b/lib/baseline.py
@@ -17,25 +17,22 @@ class Baseline:
   def __init__(self, filename, rebase = False):
     self.filename = filename
     self.references = dict()
-    self.actuals = dict()
     self.rebase = rebase
 
     if self.filename and os.path.exists(self.filename):
       with open(self.filename, "rb") as fd:
         self.references = json.load(fd)
 
-  def __get_reference(self, addr, context = []):
+  def __get_reference(self, context = []):
+    addr = get_media()._get_ref_addr(context)
     reference = self.references.setdefault(addr, dict())
     for c in get_media()._expand_context(context):
       reference = reference.setdefault(c, dict())
     return reference
 
   def check_result(self, compare, context = [], **kwargs):
-    addr = slash.context.test.__slash__.address
-    actual = self.actuals.setdefault(addr, dict())
-    reference = self.__get_reference(addr, context)
+    reference = self.__get_reference(context)
 
-    actual.update(**kwargs)
     if self.rebase:
       reference.update(**kwargs)
 


### PR DESCRIPTION
Allow user to specify a reference key in the
test case's refctx setting.  For example:

  refctx = ["key:vp9.decode.10bit"]

will lookup the test case reference value with
the following key:

  vp9.decode.10bit:<test_function(params...)>

This feature enables the ability to share a single
reference value (e.g. MD5) across different
middleware that implement the same test function for
each defined case (e.g. decode tests).

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>