### PR TITLE
decode: remove scale_output support

### DIFF
--- a/test/ffmpeg-vaapi/decode/decoder.py
+++ b/test/ffmpeg-vaapi/decode/decoder.py
@@ -7,12 +7,6 @@
 from ....lib import *
 from ..util import *
 
-__scalers__ = {
-  "hw"  : lambda: "-vf 'hwupload,scale_vaapi=w={width}:h={height}:mode=fast,hwdownload,format=nv12'",
-  "sw"  : lambda: "-s:v {width}x{height}",
-  True  : lambda: __scalers__["sw"](),
-}
-
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_vaapi_accel)
 class DecoderTest(slash.Test):
@@ -24,7 +18,7 @@ class DecoderTest(slash.Test):
     self.output = call(
       "ffmpeg -hwaccel vaapi -init_hw_device vaapi=hw:/dev/dri/renderD128"
       " -filter_hw_device hw -v verbose"
-      " -i {source} {ffscaler} -pix_fmt {mformat} -f rawvideo -vsync"
+      " -i {source} -pix_fmt {mformat} -f rawvideo -vsync"
       " passthrough -vframes {frames} -y {decoded}".format(**vars(self)))
 
   def gen_name(self):
@@ -41,8 +35,6 @@ class DecoderTest(slash.Test):
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
-    self.ffscaler = __scalers__.get(
-      vars(self).get("scale_output", False), lambda: "")().format(**vars(self))
     name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     self.call_ffmpeg()

--- a/test/gst-msdk/decode/decoder.py
+++ b/test/gst-msdk/decode/decoder.py
@@ -7,12 +7,6 @@
 from ....lib import *
 from ..util import *
 
-__scalers__ = {
-  "hw"  : lambda: "! msdkvpp scaling-mode=1 ! video/x-raw,width={width},height={height},format={hwformat}",
-  "sw"  : lambda: "! videoscale ! video/x-raw,width={width},height={height}",
-  True  : lambda: __scalers__["sw"](),
-}
-
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("msdk"))
 @slash.requires(*have_gst_element("checksumsink2"))
@@ -25,7 +19,7 @@ class DecoderTest(slash.Test):
   def call_gst(self):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder} {gstscaler}"
+      " ! {gstdecoder}"
       " ! videoconvert ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
@@ -45,8 +39,6 @@ class DecoderTest(slash.Test):
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
-    self.gstscaler = __scalers__.get(
-      vars(self).get("scale_output", False), lambda: "")().format(**vars(self))
     name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     self.call_gst()

--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -7,12 +7,6 @@
 from ....lib import *
 from ..util import *
 
-__scalers__ = {
-  "hw"  : lambda: "! vaapipostproc scale-method=fast ! video/x-raw,width={width},height={height},format={hwformat}",
-  "sw"  : lambda: "! videoscale ! video/x-raw,width={width},height={height}",
-  True  : lambda: __scalers__["sw"](),
-}
-
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("vaapi"))
 @slash.requires(*have_gst_element("checksumsink2"))
@@ -24,7 +18,7 @@ class DecoderTest(slash.Test):
   def call_gst(self):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder} {gstscaler}"
+      " ! {gstdecoder}"
       " ! videoconvert ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
@@ -44,8 +38,6 @@ class DecoderTest(slash.Test):
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
-    self.gstscaler = __scalers__.get(
-      vars(self).get("scale_output", False), lambda: "")().format(**vars(self))
     name = self.gen_name().format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     self.call_gst()


### PR DESCRIPTION
scale_output is unnecessary for decoding