### PR TITLE
baseline: add type judgement for keys of baseline

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -128,7 +128,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
 
   def _get_ref_addr(self, context):
     path, case = slash.context.test.__slash__.address.split(':')
-    keyctx = filter(lambda c: c.startswith("key:"), context)
+    keyctx = filter(lambda c: isinstance(c,str) and c.startswith("key:"), context)
     if len(keyctx):
       key = keyctx[0].lstrip("key:")
     else:

--- a/.slashrc
+++ b/.slashrc
@@ -128,7 +128,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
 
   def _get_ref_addr(self, context):
     path, case = slash.context.test.__slash__.address.split(':')
-    keyctx = filter(lambda c: isinstance(c,str) and c.startswith("key:"), context)
+    keyctx = filter(lambda c: str(c).startswith("key:"), context)
     if len(keyctx):
       key = keyctx[0].lstrip("key:")
     else:


### PR DESCRIPTION
  if the keys is not string, such as "tuple", then
  it can not use method "startswith".

Signed-off-by: Wang Zhanjun <zhanjunx.wang@intel.com>