### PR TITLE
test: remove method "weave" for gst-msdk.

### DIFF
--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -93,7 +93,6 @@ def map_deinterlace_method(method):
     "advanced"         : "advanced",
     "advanced-no-ref"  : "advanced-no-ref",
     "advanced-scd"     : "advanced-scd",
-    "weave"            : "field-weave",
     "none"             : "none"
   }.get(method, None)
 


### PR DESCRIPTION
 according to iHD driver, it donesn't support method "weave",
 so remove it.

Signed-off-by: Wang Zhixin <zhixinx.wang@intel.com>