### PR TITLE
add param for gst-vaapi cmdline

### DIFF
--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -19,7 +19,7 @@ class DecoderTest(slash.Test):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
-      " ! videoconvert ! video/x-raw,format={mformatu}"
+      " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))


### PR DESCRIPTION
  after add dither=0 for gst-vaapi decode cmdline,
  all hevc-10bitd 444 and 422 cases passed,
  no bad effects on other cases.

Signed-off-by: Wang Zhixin <zhixinx.wang@intel.com>