### PR TITLE
remove `profile` for gst-msdk mpeg2enc

### DIFF
--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -64,8 +64,11 @@ class EncoderTest(slash.Test):
 #    if vars(self).get("looplvl", None) is not None:
 #      opts += " loop-filter-level={looplvl}"
 
-    if self.codec not in ["jpeg", "vp8", ]:
+    if self.codec not in ["jpeg", "vp8", "mpeg2"]:
       opts += " ! {gstmediatype},profile={mprofile}"
+    
+    if self.codec is "mpeg2":
+      opts += " ! {gstmediatype}"
 
     if vars(self).get("gstparser", None) is not None:
       opts += " ! {gstparser}"


### PR DESCRIPTION
  Gst-msdk mpeg2enc will automatically determine output profile according to
  mpeg2 spec. If the real profile is not equal to the assignment, it will
  cause error.

Signed-off-by: Wang Zhixin <zhixinx.wang@intel.com>