### PR TITLE
ffmpeg/transcode: add "vsync passthrough" in command

### DIFF
--- a/test/ffmpeg-qsv/transcode/transcoder.py
+++ b/test/ffmpeg-qsv/transcode/transcoder.py
@@ -163,7 +163,7 @@ class TranscoderTest(slash.Test):
   def gen_output_opts(self):
     self.goutputs = dict()
 
-    opts = "-an"
+    opts = "-an -vsync passthrough"
 
     for n, output in enumerate(self.outputs):
       codec = output["codec"]

--- a/test/ffmpeg-vaapi/transcode/transcoder.py
+++ b/test/ffmpeg-vaapi/transcode/transcoder.py
@@ -163,7 +163,7 @@ class TranscoderTest(slash.Test):
   def gen_output_opts(self):
     self.goutputs = dict()
 
-    opts = "-an"
+    opts = "-an -vsync passthrough"
 
     for n, output in enumerate(self.outputs):
       codec = output["codec"]


### PR DESCRIPTION
ffmpeg decode commands must have "-vsync passthrough".
Transcode include decode and encode.

Signed-off-by: Zhu Qingliang <qingliangx.zhu@intel.com>