### PR TITLE
vpp/denoise: add Luma into ICL denoise cap

### DIFF
--- a/lib/caps/ICL/iHD
+++ b/lib/caps/ICL/iHD
@@ -64,6 +64,7 @@ caps = dict(
     denoise     = dict(
       ifmts = ["NV12", "P010", "YUY2"],
       ofmts = ["NV12", "P010", "YUY2"],
+      chroma = False,
     ),
     scale       = dict(
       ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],

--- a/test/ffmpeg-qsv/vpp/denoise.py
+++ b/test/ffmpeg-qsv/vpp/denoise.py
@@ -39,8 +39,12 @@ class default(VppTest):
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-      assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-      assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      if self.caps.get("chroma", True):
+        assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+        assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      else:
+        assert actual[-2] == 100, "Cb(U) changed, but caps don't support DENOISE chroma"
+        assert actual[-1] == 100, "Cr(V) changed, but caps don't support DENOISE chroma"
 
     get_media().baseline.check_result(
       compare = compare, context = self.refctx, psnr = psnr)

--- a/test/ffmpeg-vaapi/vpp/denoise.py
+++ b/test/ffmpeg-vaapi/vpp/denoise.py
@@ -40,8 +40,12 @@ class default(VppTest):
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-      assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-      assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      if self.caps.get("chroma", True):
+        assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+        assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      else:
+        assert actual[-2] == 100, "Cb(U) changed, but caps don't support DENOISE chroma"
+        assert actual[-1] == 100, "Cr(V) changed, but caps don't support DENOISE chroma"
 
     get_media().baseline.check_result(
       compare = compare, context = self.refctx, psnr = psnr)

--- a/test/gst-msdk/vpp/denoise.py
+++ b/test/gst-msdk/vpp/denoise.py
@@ -34,8 +34,12 @@ class default(VppTest):
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-      assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-      assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      if self.caps.get("chroma", True):
+        assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+        assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      else:
+        assert actual[-2] == 100, "Cb(U) changed, but caps don't support DENOISE chroma"
+        assert actual[-1] == 100, "Cr(V) changed, but caps don't support DENOISE chroma"
 
     get_media().baseline.check_result(
       compare = compare, context = vars(self).get("refctx", []), psnr = map(lambda v: round(v, 4), psnr))

--- a/test/gst-vaapi/vpp/denoise.py
+++ b/test/gst-vaapi/vpp/denoise.py
@@ -38,8 +38,12 @@ class default(VppTest):
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
-      assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
-      assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      if self.caps.get("chroma", True):
+        assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+        assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
+      else:
+        assert actual[-2] == 100, "Cb(U) changed, but caps don't support DENOISE chroma"
+        assert actual[-1] == 100, "Cr(V) changed, but caps don't support DENOISE chroma"
 
     get_media().baseline.check_result(
       compare = compare, context = vars(self).get("refctx", []), psnr = map(lambda v: round(v, 4), psnr))


### PR DESCRIPTION
  On ICL, for both gstreamer and ffmpeg,
  denoise will only influence Luma,
  and for the other platforms Luma and Chroma both changed

Signed-off-by: Zhu Qingliang <qingliangx.zhu@intel.com>