### PR TITLE
transcode: prioritize low res inputs before high res

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -12,6 +12,10 @@ import subprocess
 import threading
 import time
 
+def sorted_by_resolution(cases):
+  size = lambda kv: kv[1]["width"] * kv[1]["height"]
+  return [kv[0] for kv in sorted(cases.items(), key = size)]
+
 def timefn(label):
   def count(function):
     # Keep track of the number of times this function was called from the

--- a/test/ffmpeg-qsv/transcode/avc.py
+++ b/test/ffmpeg-qsv/transcode/avc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("avc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-qsv/transcode/hevc.py
+++ b/test/ffmpeg-qsv/transcode/hevc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("hevc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-qsv/transcode/mpeg2.py
+++ b/test/ffmpeg-qsv/transcode/mpeg2.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("mpeg2", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-qsv/transcode/vc1.py
+++ b/test/ffmpeg-qsv/transcode/vc1.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("vc1", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-vaapi/transcode/avc.py
+++ b/test/ffmpeg-vaapi/transcode/avc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("avc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-vaapi/transcode/hevc.py
+++ b/test/ffmpeg-vaapi/transcode/hevc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("hevc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-vaapi/transcode/mpeg2.py
+++ b/test/ffmpeg-vaapi/transcode/mpeg2.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("mpeg2", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-vaapi/transcode/vc1.py
+++ b/test/ffmpeg-vaapi/transcode/vc1.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("vc1", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/transcode/avc.py
+++ b/test/gst-msdk/transcode/avc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("avc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/transcode/hevc.py
+++ b/test/gst-msdk/transcode/hevc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("hevc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/transcode/mpeg2.py
+++ b/test/gst-msdk/transcode/mpeg2.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("mpeg2", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/transcode/vc1.py
+++ b/test/gst-msdk/transcode/vc1.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("vc1", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-vaapi/transcode/avc.py
+++ b/test/gst-vaapi/transcode/avc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("avc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-vaapi/transcode/hevc.py
+++ b/test/gst-vaapi/transcode/hevc.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("hevc", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-vaapi/transcode/mpeg2.py
+++ b/test/gst-vaapi/transcode/mpeg2.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("mpeg2", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(

--- a/test/gst-vaapi/transcode/vc1.py
+++ b/test/gst-vaapi/transcode/vc1.py
@@ -11,7 +11,7 @@ from .transcoder import TranscoderTest
 spec = load_test_spec("vc1", "transcode")
 
 class default(TranscoderTest):
-  @slash.parametrize(("case"), sorted(spec.keys()))
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
   def test(self, case):
     vars(self).update(spec[case].copy())
     vars(self).update(


### PR DESCRIPTION
Higher resolution input cases tend to take longer to
execute and are more likely to timeout.  If several
higher resolution cases use up the ctapt limit, then
any pending cases will be denied execution when they
would otherwise finish before a call timeout.

Thus, sort the test case parameters such that lower
resolution input cases execute before higher
resolution cases.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>