### PR TITLE
transcode: convert format for x265enc

### DIFF
--- a/test/gst-msdk/transcode/transcoder.py
+++ b/test/gst-msdk/transcode/transcoder.py
@@ -50,7 +50,7 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(

--- a/test/gst-vaapi/transcode/transcoder.py
+++ b/test/gst-vaapi/transcode/transcoder.py
@@ -49,7 +49,7 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(


### PR DESCRIPTION
For HW to SW cases, x265enc can’t accept format NV12,
so we may need to convert format for x265enc

Signed-off-by: Zhu Qingliang <qingliangx.zhu@intel.com>