### PR TITLE
transcode: set queue buffer size to zero

### DIFF
--- a/test/gst-msdk/transcode/transcoder.py
+++ b/test/gst-msdk/transcode/transcoder.py
@@ -184,7 +184,7 @@ class TranscoderTest(slash.Test):
           "{}_{}_{}.{}".format(self.case, n, channel, ext))
         self.goutputs.setdefault(n, list()).append(ofile)
 
-        opts += " ! queue"
+        opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
         if vppscale is not None:
           opts += "! {}".format(vppscale)
         opts += " ! {}".format(encoder)
@@ -193,7 +193,8 @@ class TranscoderTest(slash.Test):
     # dump decoded source to yuv for reference comparison
     self.srcyuv = get_media()._test_artifact(
       "src_{case}.yuv".format(**vars(self)))
-    opts += " ! queue ! checksumsink2 file-checksum=false qos=false"
+    opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
+    opts += " ! checksumsink2 file-checksum=false qos=false"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"
 

--- a/test/gst-vaapi/transcode/transcoder.py
+++ b/test/gst-vaapi/transcode/transcoder.py
@@ -181,7 +181,7 @@ class TranscoderTest(slash.Test):
           "{}_{}_{}.{}".format(self.case, n, channel, ext))
         self.goutputs.setdefault(n, list()).append(ofile)
 
-        opts += " ! queue"
+        opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
         if vppscale is not None:
           opts += " ! {}".format(vppscale)
         opts += " ! {}".format(encoder)
@@ -190,7 +190,8 @@ class TranscoderTest(slash.Test):
     # dump decoded source to yuv for reference comparison
     self.srcyuv = get_media()._test_artifact(
       "src_{case}.yuv".format(**vars(self)))
-    opts += " ! queue ! videoconvert ! video/x-raw,format=I420"
+    opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
+    opts += " ! videoconvert ! video/x-raw,format=I420"
     opts += " ! checksumsink2 file-checksum=false qos=false"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"


### PR DESCRIPTION
For 4k clip, the queue is not able to contain
a whole frame with the default value, so set
queue buffer size to zero to fix this issue.

Signed-off-by: Zhu Qingliang <qingliangx.zhu@intel.com>