### PR TITLE
gst-msdk/decode: add a parameter for decode command-line

### DIFF
--- a/test/gst-msdk/decode/decoder.py
+++ b/test/gst-msdk/decode/decoder.py
@@ -20,7 +20,7 @@ class DecoderTest(slash.Test):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
-      " ! videoconvert ! video/x-raw,format={mformatu}"
+      " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))

--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -19,7 +19,7 @@ class EncoderTest(slash.Test):
     if vars(self).get("fps", None) is not None:
       opts += " framerate={fps}"
 
-    opts += " ! videoconvert ! video/x-raw,format={hwformat}"
+    opts += " ! videoconvert dither=0 ! video/x-raw,format={hwformat}"
 
     return opts
 
@@ -187,7 +187,7 @@ class EncoderTest(slash.Test):
   def check_metrics(self):
     iopts = "filesrc location={encoded} ! {gstdecoder}"
     oopts = (
-      "videoconvert ! video/x-raw,format={mformatu} ! checksumsink2"
+      "videoconvert dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
       " dump-output=true qos=false dump-location={decoded}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))

--- a/test/gst-msdk/transcode/transcoder.py
+++ b/test/gst-msdk/transcode/transcoder.py
@@ -50,7 +50,7 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(

--- a/test/gst-msdk/vpp/vpp.py
+++ b/test/gst-msdk/vpp/vpp.py
@@ -26,7 +26,7 @@ class VppTest(slash.Test):
 
     if self.vpp_element not in ["csc", "deinterlace"]:
       if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert ! video/x-raw,format={ihwformat}"
+        opts += " ! videoconvert dither=0 ! video/x-raw,format={ihwformat}"
 
     return opts
 
@@ -61,7 +61,7 @@ class VppTest(slash.Test):
         opts += ",width={width},height={height}"
 
       if self.ofmt != self.ohwformat:
-        opts += " ! videoconvert ! video/x-raw,format={mformatu}"
+        opts += " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
     else:
       opts += " ! video/x-raw,format={ohwformat}"
 

--- a/test/gst-vaapi/encode/encoder.py
+++ b/test/gst-vaapi/encode/encoder.py
@@ -18,7 +18,7 @@ class EncoderTest(slash.Test):
     if vars(self).get("fps", None) is not None:
       opts += " framerate={fps}"
 
-    opts += " ! videoconvert ! video/x-raw,format={hwformat}"
+    opts += " ! videoconvert dither=0 ! video/x-raw,format={hwformat}"
 
     return opts
 
@@ -186,7 +186,7 @@ class EncoderTest(slash.Test):
   def check_metrics(self):
     iopts = "filesrc location={encoded} ! {gstdecoder}"
     oopts = (
-      " videoconvert ! video/x-raw,format={mformatu} ! checksumsink2"
+      " videoconvert dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
       " dump-output=true qos=false dump-location={decoded}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))

--- a/test/gst-vaapi/transcode/transcoder.py
+++ b/test/gst-vaapi/transcode/transcoder.py
@@ -49,7 +49,7 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
@@ -191,7 +191,7 @@ class TranscoderTest(slash.Test):
     self.srcyuv = get_media()._test_artifact(
       "src_{case}.yuv".format(**vars(self)))
     opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
-    opts += " ! videoconvert ! video/x-raw,format=I420"
+    opts += " ! videoconvert dither=0 ! video/x-raw,format=I420"
     opts += " ! checksumsink2 file-checksum=false qos=false"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"
@@ -219,7 +219,7 @@ class TranscoderTest(slash.Test):
         yuv = get_media()._test_artifact(
           "{}_{}_{}.yuv".format(self.case, n, channel))
         iopts = "filesrc location={} ! {}"
-        oopts =  "{} ! videoconvert ! video/x-raw,format=I420"
+        oopts =  "{} ! videoconvert dither=0 ! video/x-raw,format=I420"
         oopts += " ! checksumsink2 file-checksum=false qos=false"
         oopts += " frame-checksum=false plane-checksum=false dump-output=true"
         oopts += " dump-location={}"

--- a/test/gst-vaapi/vpp/vpp.py
+++ b/test/gst-vaapi/vpp/vpp.py
@@ -25,7 +25,7 @@ class VppTest(slash.Test):
 
     if self.vpp_element not in ["csc", "deinterlace"]:
       if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert ! video/x-raw,format={ihwformat}"
+        opts += " ! videoconvert dither=0 ! video/x-raw,format={ihwformat}"
 
     return opts
 
@@ -57,9 +57,9 @@ class VppTest(slash.Test):
       if self.vpp_element not in ["deinterlace"]:
         opts += " ! video/x-raw,format={ohwformat}"
         if self.ofmt != self.ohwformat:
-          opts += " ! videoconvert ! video/x-raw,format={mformatu}"
+          opts += " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
       else:
-        opts += " ! videoconvert ! video/x-raw,format={mformatu}"
+        opts += " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
 
     else:
       opts += " ! video/x-raw,format={ohwformat}"


### PR DESCRIPTION
    Add "dither=0" to allow gst-msdk decode a hevc 10bit file to
    get the same md5 value with others,such as gst-vaapi and
    ffmpeg-vaapi.

Signed-off-by: Zhang Yuankun <yuankunx.zhang@intel.com>