### PR TITLE
encode: add ICQ mode test

### DIFF
--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -54,6 +54,70 @@ def gen_avc_cqp_parameters(spec, profiles):
   params = gen_avc_cqp_variants(spec, profiles)
   return keys, params
 
+def gen_avc_icq_variants(spec, profiles):
+  for case, params in spec.iteritems():
+    for variant in copy.deepcopy(params.get("icq", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      for profile in cprofiles:
+        yield [
+          case, variant["gop"], variant["slices"], variant["bframes"],
+          variant["quality"], variant.get("icq_quality"), profile
+        ]
+
+def gen_avc_icq_parameters( spec, profiles):
+  keys = ("case", "gop", "slices", "bframes", "quality", "icq_quality", "profile")
+  params = gen_avc_icq_variants(spec, profiles)
+  return keys, params
+
+def gen_avc_icq_la_variants(spec, profiles):
+  for case, params in spec.iteritems():
+    for variant in copy.deepcopy(params.get("icq_la", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      for profile in cprofiles:
+        yield [
+          case, variant["gop"], variant["slices"], variant["bframes"],
+          variant["quality"], variant.get("icq_quality"), profile, variant.get("ladepth")
+        ]
+
+def gen_avc_icq_la_parameters( spec, profiles):
+  keys = ("case", "gop", "slices", "bframes", "quality", "icq_quality", "profile", "ladepth")
+  params = gen_avc_icq_la_variants(spec, profiles)
+  return keys, params
+
+def gen_avc_icq_lp_variants(spec, profiles):
+  for case, params in spec.iteritems():
+    for variant in copy.deepcopy(params.get("icq_lp", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      for profile in cprofiles:
+        yield [
+          case, variant["gop"], variant["slices"], variant["bframes"],
+          variant["quality"], variant.get("icq_quality"), profile
+        ]
+
+def gen_avc_icq_lp_parameters( spec, profiles):
+  keys = ("case", "gop", "slices", "bframes", "quality", "icq_quality", "profile")
+  params = gen_avc_icq_lp_variants(spec, profiles)
+  return keys, params
+
+def gen_avc_icq_lpla_variants(spec, profiles):
+  for case, params in spec.iteritems():
+    for variant in copy.deepcopy(params.get("icq_lpla", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      for profile in cprofiles:
+        yield [
+          case, variant["gop"], variant["slices"], variant["bframes"],
+          variant["quality"], variant.get("icq_quality"), profile, variant.get("ladepth")
+        ]
+
+def gen_avc_icq_lpla_parameters( spec, profiles):
+  keys = ("case", "gop", "slices", "bframes", "quality", "icq_quality", "profile", "ladepth")
+  params = gen_avc_icq_lpla_variants(spec, profiles)
+  return keys, params
+
 def gen_avc_cbr_variants(spec, profiles):
   for case, params in spec.iteritems():
     for variant in copy.deepcopy(params.get("cbr", [])):
@@ -187,6 +251,10 @@ gen_hevc_vbr_parameters = gen_avc_vbr_parameters
 gen_hevc_cqp_lp_parameters = gen_avc_cqp_lp_parameters
 gen_hevc_cbr_lp_parameters = gen_avc_cbr_lp_parameters
 gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
+gen_hevc_icq_parameters = gen_avc_icq_parameters
+gen_hevc_icq_la_parameters = gen_avc_icq_la_parameters
+gen_hevc_icq_lp_parameters = gen_avc_icq_lp_parameters
+gen_hevc_icq_lpla_parameters = gen_avc_icq_lpla_parameters
 
 def gen_mpeg2_cqp_variants(spec):
   for case, params in spec.iteritems():

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -88,6 +88,102 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("encode", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("encode", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_la_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("vdenc", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("vdenc", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_lpla_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -88,6 +88,102 @@ class cqp_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("encode", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
+  @slash.parametrize(*gen_avc_icq_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("encode", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
+  @slash.parametrize(*gen_avc_icq_la_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("vdenc", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
+  @slash.parametrize(*gen_avc_icq_lp_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("vdenc", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
+  @slash.parametrize(*gen_avc_icq_lpla_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")

--- a/test/ffmpeg-qsv/encode/encoder.py
+++ b/test/ffmpeg-qsv/encode/encoder.py
@@ -40,6 +40,8 @@ class EncoderTest(slash.Test):
         opts += " -global_quality {quality}"
       else:
         opts += " -preset {quality}"
+    if vars(self).get("icq_quality", None) is not None:
+      opts += " -global_quality {icq_quality}"
     if vars(self).get("slices", None) is not None:
       opts += " -slices {slices}"
     if vars(self).get("bframes", None) is not None:
@@ -134,6 +136,8 @@ class EncoderTest(slash.Test):
 
     self.hwformat = mapformat(self.hwformat)
 
+    self.mlog = maplog(self.rcmode, 1 if vars(self).get("ladepth") else 0)
+
   def encode(self):
     self.validate_caps()
 
@@ -166,9 +170,8 @@ class EncoderTest(slash.Test):
     m = re.search("Initialize MFX session", self.output, re.MULTILINE)
     assert m is not None, "It appears that the QSV plugin did not load"
 
-    if vars(self).get("ladepth", None) is not None:
-      m = re.search("Using the VBR with lookahead \(LA\) ratecontrol method", self.output, re.MULTILINE)
-      assert m is not None, "It appears that the lookahead did not load"
+    m = re.search("Using the "+self.mlog+" ratecontrol method", self.output, re.MULTILINE)
+    assert m is not None, "It appears that the "+self.mlog+" did not load"
 
   def check_metrics(self):
     iopts = "-c:v {ffdecoder} -i {encoded}"

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -88,6 +88,102 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("encode", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      profile   = profile,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("encode", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      profile   = profile,
+      rcmode    = "cqp",
+      slices    = slices,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_la_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("vdenc", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      profile   = profile,
+      rcmode    = "cqp",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("vdenc", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      profile   = profile,
+      rcmode    = "cqp",
+      slices    = slices,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+  @slash.parametrize(*gen_hevc_icq_lpla_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")

--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -95,6 +95,25 @@ def mapprofile(codec, profile):
     },
   }.get(codec, {}).get(profile, None)
 
+@memoize
+def maplog(rcmode, ladepth):
+  return {
+    "icq"   : {
+      1      : "intelligent constant quality with lookahead \(LA_ICQ\)",
+      0      : "intelligent constant quality \(ICQ\)",
+    },
+    "cqp"   : {
+      0      : "constant quantization parameter \(CQP\)",
+    },
+    "cbr"  : {
+      0      : "constant bitrate \(CBR\)",
+    },
+    "vbr"  : {
+      1      : "VBR with lookahead \(LA\)",
+      0      : "variable bitrate \(VBR\)",
+    },
+  }.get(rcmode, {}).get(ladepth, None)
+
 def load_test_spec(*ctx):
   from ...lib import get_media
   import copy

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -88,6 +88,102 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("encode", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("encode", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_la_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "hevc_10")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_lpla_parameters(spec, ['main10']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -90,6 +90,98 @@ class cqp_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("encode", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
+  @slash.parametrize(*gen_avc_icq_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("encode", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
+  @slash.parametrize(*gen_avc_icq_la_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.caps = platform.get_caps("vdenc", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
+  @slash.parametrize(*gen_avc_icq_lp_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(AVCEncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.caps = platform.get_caps("vdenc", "avc")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      icq_quality   = icq_quality,
+      rcmode    = "icq",
+      slices    = slices,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "avc"))
+  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
+  @slash.parametrize(*gen_avc_icq_lpla_parameters(spec, ['high', 'main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")

--- a/test/ffmpeg-vaapi/encode/encoder.py
+++ b/test/ffmpeg-vaapi/encode/encoder.py
@@ -46,6 +46,8 @@ class EncoderTest(slash.Test):
         opts += " -global_quality {quality}"
       else:
         opts += " -quality {quality}"
+    if vars(self).get("icq_quality", None) is not None:
+      opts += " -global_quality {icq_quality}"
     if vars(self).get("slices", None) is not None:
       opts += " -slices {slices}"
     if vars(self).get("bframes", None) is not None:
@@ -65,6 +67,9 @@ class EncoderTest(slash.Test):
     if vars(self).get("level", None) is not None:
       self.level /= 10.0
       opts += " -level {level}"
+    if vars(self).get("ladepth", None) is not None:
+      opts += " -look_ahead 1"
+      opts += " -look_ahead_depth {ladepth}"
 
     opts += " -vframes {frames} -y {encoded}"
 
@@ -204,6 +209,7 @@ class EncoderTest(slash.Test):
         "|RC mode: CQP"
         "|Driver does not report any supported rate control modes: assuming constant-quality"
       ),
+      icq = "RC mode: ICQ",
       cbr = "RC mode: CBR",
       vbr = "RC mode: VBR",
     )

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -88,6 +88,102 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+class icq(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("encode", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "icq",
+      slices    = slices,
+      icq_quality   = icq_quality,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_la(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("encode", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "icq",
+      slices    = slices,
+      icq_quality   = icq_quality,
+      ladepth   = ladepth,
+    )
+
+  @slash.requires(*platform.have_caps("encode", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_la_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
+class icq_lp(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "icq",
+      slices    = slices,
+      icq_quality   = icq_quality,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_lp_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile)
+    self.encode()
+
+class icq_lpla(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    slash.logger.notice("NOTICE: 'icq_quality' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "icq",
+      slices    = slices,
+      icq_quality   = icq_quality,
+      ladepth   = ladepth,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+  @slash.parametrize(*gen_hevc_icq_lpla_parameters(spec, ['main']))
+  def test(self, case, gop, slices, bframes, quality, icq_quality, profile, ladepth):
+    self.init(spec, case, gop, slices, bframes, quality, icq_quality, profile, ladepth)
+    self.encode()
+
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile, level=None):
     self.caps = platform.get_caps("encode", "hevc_8")


### PR DESCRIPTION
add avc/hevc_8bit/hevc_10bit ICQ mode encode
test for ffmpeg-vaapi and ffmpeg-qsv

Signed-off-by: Zhu Qingliang <qingliangx.zhu@intel.com>