### PR TITLE
enable more vp9 8bit/10bit vdenc test for ffmpeg-vaapi and gstreamer

### DIFF
--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -338,6 +338,51 @@ def gen_vp9_vbr_parameters(spec):
   params = gen_vp9_vbr_variants(spec)
   return keys, params
 
+def gen_vp9_cqp_lp_variants(spec):
+  for case, params in spec.iteritems():
+    variants = params.get("cqp_lp", [])
+    for variant in variants:
+      yield [
+        case, variant["ipmode"], variant["qp"], variant["quality"], variant["slices"],
+        variant["refmode"], variant["looplvl"], variant["loopshp"]]
+
+def gen_vp9_cqp_lp_parameters(spec):
+  keys = ("case", "ipmode", "qp", "quality", "slices", "refmode", "looplvl", "loopshp")
+  params = gen_vp9_cqp_lp_variants(spec)
+  return keys, params
+
+def gen_vp9_cbr_lp_variants(spec):
+  for case, params in spec.iteritems():
+    for variant in params.get("cbr_lp", []):
+        # Required: bitrate
+        # Optional: gop, fps, refmode, looplvl, loopshp
+        yield [
+          case, variant["gop"], variant["bitrate"], variant.get("fps", 30),
+          variant["slices"], variant.get("refmode", 0),
+          variant.get("looplvl", 0), variant.get("loopshp", 0),
+        ]
+
+def gen_vp9_cbr_lp_parameters(spec):
+  keys = ("case", "gop", "bitrate", "fps", "slices", "refmode", "looplvl", "loopshp")
+  params = gen_vp9_cbr_lp_variants(spec)
+  return keys, params
+
+def gen_vp9_vbr_lp_variants(spec):
+  for case, params in spec.iteritems():
+    for variant in params.get("vbr_lp", []):
+        # Required: bitrate
+        # Optional: gop, fps, refmode, looplvl, loopshp
+        yield [
+          case, variant["gop"], variant["bitrate"], variant.get("fps", 30),
+          variant["slices"], variant["quality"], variant.get("refmode", 0),
+          variant.get("looplvl", 0), variant.get("loopshp", 0),
+        ]
+
+def gen_vp9_vbr_lp_parameters(spec):
+  keys = ("case", "gop", "bitrate", "fps", "slices", "quality", "refmode", "looplvl", "loopshp")
+  params = gen_vp9_vbr_lp_variants(spec)
+  return keys, params
+
 def gen_vpp_sharpen_variants(spec):
   for case, params in spec.iteritems():
     variants = params.get("levels", None) or [0, 1, 20, 50, 59, 99, 100]

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -4,20 +4,20 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from .....lib import *
+from ...util import *
+from ..encoder import EncoderTest
 
-spec = load_test_spec("vp9", "encode", "8bit")
+spec = load_test_spec("vp9", "encode", "10bit")
 
-class VP9EncoderTest(EncoderTest):
+class VP9_10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
       codec    = "vp9",
       ffenc    = "vp9_vaapi",
       lowpower = 1,
     )
-    super(VP9EncoderTest, self).before()
+    super(VP9_10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
@@ -25,11 +25,11 @@ class VP9EncoderTest(EncoderTest):
   def get_vaapi_profile(self):
     return "VAProfileVP9Profile0"
 
-class cqp_lp(VP9EncoderTest):
+class cqp_lp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(spec[case].copy())
     vars(self).update(
       case      = case,
@@ -41,17 +41,17 @@ class cqp_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
   @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -67,18 +67,18 @@ class cbr_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
   @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -94,7 +94,7 @@ class vbr_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
   @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -4,98 +4,99 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from .....lib import *
+from ...util import *
+from ..encoder import EncoderTest
 
-spec = load_test_spec("vp9", "encode", "8bit")
+spec = load_test_spec("vp9", "encode", "10bit")
 
-class VP9EncoderTest(EncoderTest):
+class VP9_10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
-      codec    = "vp9",
-      ffenc    = "vp9_vaapi",
-      lowpower = 1,
+      codec         = "vp9",
+      gstencoder    = "msdkvp9enc",
+      gstdecoder    = "ivfparse ! msdkvp9dec hardware=true",
     )
-    super(VP9EncoderTest, self).before()
+    super(VP9_1EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
 
-  def get_vaapi_profile(self):
-    return "VAProfileVP9Profile0"
-
-class cqp_lp(VP9EncoderTest):
+class cqp_lp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
-    vars(self).update(spec[case].copy())
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = 30 if ipmode != 0 else 1,
-      looplvl   = looplvl,
-      loopshp   = loopshp,
       qp        = qp,
+      quality   = quality,
       rcmode    = "cqp",
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
-    vars(self).update(spec[case].copy())
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       frames    = vars(self).get("brframes", self.frames),
       gop       = gop,
-      looplvl   = looplvl,
-      loopshp   = loopshp,
       maxrate   = bitrate,
       minrate   = bitrate,
       rcmode    = "cbr",
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
-    vars(self).update(spec[case].copy())
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_10")
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       frames    = vars(self).get("brframes", self.frames),
       gop       = gop,
-      looplvl   = looplvl,
-      loopshp   = loopshp,
-      maxrate   = bitrate * 2, # target percentage 50%
+      # target percentage 50%
+      maxrate   = bitrate * 2,
       minrate   = bitrate,
+      quality   = quality,
       rcmode    = "vbr",
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)

--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -60,9 +60,10 @@ class EncoderTest(slash.Test):
     if vars(self).get("ladepth", None) is not None:
       opts += " rc-lookahead={ladepth}"
 
-    opts += " ! {gstmediatype}"
-    if vars(self).get("profile", None) is not None:
-      opts += ",profile={mprofile}"
+    if vars(self).get("gstmediatype", None) is not None:
+      opts += " ! {gstmediatype}"
+      if vars(self).get("profile", None) is not None:
+        opts += ",profile={mprofile}"
 
     if vars(self).get("gstparser", None) is not None:
       opts += " ! {gstparser}"

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -1,0 +1,103 @@
+###
+### Copyright (C) 2018-2019 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ..util import *
+from .encoder import EncoderTest
+
+spec = load_test_spec("vp9", "encode", "8bit")
+
+class VP9EncoderTest(EncoderTest):
+  def before(self):
+    vars(self).update(
+      codec         = "vp9",
+      gstencoder    = "msdkvp9enc",
+      gstdecoder    = "ivfparse ! msdkvp9dec hardware=true",
+    )
+    super(VP9EncoderTest, self).before()
+
+  def get_file_ext(self):
+    return "ivf"
+
+class cqp_lp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
+  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
+  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class vbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      # target percentage 50%
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      slices    = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("msdkvp9enc"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
+  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
+    self.encode()

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -15,24 +15,20 @@ class VP9EncoderTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "vaapivp9enc",
-      gstdecoder    = "matroskademux ! vaapivp9dec",
+      gstdecoder    = "vaapivp9dec",
       gstmediatype  = "video/x-vp9",
-      gstmuxer      = "matroskamux",
-      lowpower      = False,
+      lowpower      = True,
     )
     super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "webm"
 
-class cqp(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
-  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+class cqp_lp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = 30 if ipmode != 0 else 1,
@@ -43,16 +39,20 @@ class cqp(VP9EncoderTest):
       rcmode    = "cqp",
       refmode   = refmode,
     )
-    self.encode()
 
-class cbr(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
   @slash.requires(*have_gst_element("vaapivp9enc"))
   @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -66,15 +66,19 @@ class cbr(VP9EncoderTest):
       rcmode    = "cbr",
       refmode   = refmode,
     )
-    self.encode()
 
-class vbr(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
   @slash.requires(*have_gst_element("vaapivp9enc"))
   @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp9_8")
+  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class vbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -92,4 +96,11 @@ class vbr(VP9EncoderTest):
       rcmode    = "vbr",
       refmode   = refmode,
     )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()


### PR DESCRIPTION
this PR is based on https://github.com/intel/vaapi-fits/pull/129