### PR TITLE
WIP: test/gst: do not print position progress with gst-launch

### DIFF
--- a/test/gst-msdk/decode/decoder.py
+++ b/test/gst-msdk/decode/decoder.py
@@ -18,7 +18,7 @@ class DecoderTest(slash.Test):
   @timefn("gst")
   def call_gst(self):
     call(
-      "gst-launch-1.0 -vf filesrc location={source}"
+      "gst-launch-1.0 --no-position -vf filesrc location={source}"
       " ! {gstdecoder}"
       " ! videoconvert ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"

--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -114,7 +114,8 @@ class EncoderTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+    self.output = call(
+      "gst-launch-1.0 --no-position -vf {iopts} ! {oopts}".format(
       iopts = iopts, oopts = oopts))
 
   def before(self):

--- a/test/gst-msdk/transcode/transcoder.py
+++ b/test/gst-msdk/transcode/transcoder.py
@@ -202,7 +202,7 @@ class TranscoderTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+    call("gst-launch-1.0 --no-position -vf {iopts} ! {oopts}".format(
       iopts = iopts, oopts = oopts))
 
   def transcode(self):

--- a/test/gst-msdk/vpp/vpp.py
+++ b/test/gst-msdk/vpp/vpp.py
@@ -112,7 +112,9 @@ class VppTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(iopts = iopts, oopts = oopts))
+    call(
+      "gst-launch-1.0 --no-position -vf {iopts} ! {oopts}"
+      "".format(iopts = iopts, oopts = oopts))
 
   def validate_caps(self):
     ifmts         = self.caps.get("ifmts", [])

--- a/test/gst-vaapi/decode/decoder.py
+++ b/test/gst-vaapi/decode/decoder.py
@@ -17,7 +17,7 @@ class DecoderTest(slash.Test):
   @timefn("gst")
   def call_gst(self):
     call(
-      "gst-launch-1.0 -vf filesrc location={source}"
+      "gst-launch-1.0 --no-position -vf filesrc location={source}"
       " ! {gstdecoder}"
       " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"

--- a/test/gst-vaapi/encode/encoder.py
+++ b/test/gst-vaapi/encode/encoder.py
@@ -115,7 +115,8 @@ class EncoderTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+    self.output = call(
+      "gst-launch-1.0 --no-position -vf {iopts} ! {oopts}".format(
       iopts = iopts, oopts = oopts))
 
   def before(self):

--- a/test/gst-vaapi/transcode/transcoder.py
+++ b/test/gst-vaapi/transcode/transcoder.py
@@ -200,7 +200,7 @@ class TranscoderTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+    call("gst-launch-1.0 --no-position -vf {iopts} ! {oopts}".format(
       iopts = iopts, oopts = oopts))
 
   def transcode(self):

--- a/test/gst-vaapi/vpp/vpp.py
+++ b/test/gst-vaapi/vpp/vpp.py
@@ -111,7 +111,7 @@ class VppTest(slash.Test):
 
   @timefn("gst")
   def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+    call("gst-launch-1.0 --no-position -vf {iopts} ! {oopts}".format(
       iopts = iopts, oopts = oopts))
 
   def validate_caps(self):


### PR DESCRIPTION
All test command output is redirected to log files.
"Progress" indicators from commands can often generate
very large log files if every progress update is written
to a new line.  This can have a negative impact on disk
storage if log files are archived for future reference
(e.g. CI).

Gstreamer recently added a position progress indicator
to the gst-launch command and enables it by default
(see gstreamer commit 0505bd76a109).  If stdout/err is
a TTY, then the progress indicator isn't an issue since
carriage-returns ('\r') are used to print the progress
(i.e. no linefeeds).  However, in the case of non-TTY
(e.g. log files), each progress update is written to a
new line.  We can use --no-position to disable this
progress indicator.

Thus, add --no-position command-line option to all
gst-launch commands to avoid printing the pipeline
position progress indicator.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>