### PR TITLE
Caps: fixed not support res8K enc issue on Gen10-

### DIFF
--- a/lib/caps/APL/iHD
+++ b/lib/caps/APL/iHD
@@ -22,7 +22,7 @@ caps = dict(
   ),
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12"]),
+    hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"], cbr = False, vbr = False),

--- a/lib/caps/CFL/iHD
+++ b/lib/caps/CFL/iHD
@@ -26,8 +26,8 @@ caps = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vp8     = dict(maxres = res4k , fmts = ["NV12"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
+    hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
+    hevc_10 = dict(maxres = res4k , fmts = ["P010"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),

--- a/lib/caps/KBL/iHD
+++ b/lib/caps/KBL/iHD
@@ -27,8 +27,8 @@ caps = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vp8     = dict(maxres = res4k , fmts = ["NV12"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
+    hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
+    hevc_10 = dict(maxres = res4k , fmts = ["P010"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),

--- a/lib/caps/SKL/iHD
+++ b/lib/caps/SKL/iHD
@@ -21,7 +21,7 @@ caps = dict(
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12"]),
+    hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"], cbr = False, vbr = False),

--- a/lib/caps/WHL/iHD
+++ b/lib/caps/WHL/iHD
@@ -25,8 +25,8 @@ caps = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vp8     = dict(maxres = res4k , fmts = ["NV12"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
+    hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
+    hevc_10 = dict(maxres = res4k , fmts = ["P010"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),


### PR DESCRIPTION
iHD only support res4K encode on Gen10- platforms,
iHD team will update its feature summary on github

Fixes #142 

Signed-off-by: Luo Focus <focus.luo@intel.com>