### PR TITLE
ffmpeg-qsv/ffmpeg-vaapi: add "AYUV" for format map

### DIFF
--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -46,6 +46,7 @@ def get_supported_format_map():
     "BGRA"  : "bgra",
     "P210"  : "yuv422p10le",
     "P410"  : "yuv444p10le",
+    "AYUV"  : "ayuv",
   }
 
 @memoize

--- a/test/ffmpeg-vaapi/util.py
+++ b/test/ffmpeg-vaapi/util.py
@@ -43,6 +43,7 @@ def get_supported_format_map():
     "BGRA"  : "bgra",
     "P210"  : "yuv422p10le",
     "P410"  : "yuv444p10le",
+    "AYUV"  : "ayuv",
   }
 
 @memoize


### PR DESCRIPTION
    add format "AYUV" for ffmpeg-qsv and ffmpeg vaapi,
    because command-line need "ayuv".

Signed-off-by: Yuankun Zhang <yuankunx.zhang@intel.com>