### PR TITLE
vp9_lp enc: enable vp9_lp encoding for gst-vaapi

### DIFF
--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -18,7 +18,6 @@ class VP9EncoderTest(EncoderTest):
       gstdecoder    = "matroskademux ! vaapivp9dec",
       gstmediatype  = "video/x-vp9",
       gstmuxer      = "matroskamux",
-      lowpower      = False,
     )
     super(VP9EncoderTest, self).before()
 
@@ -26,13 +25,9 @@ class VP9EncoderTest(EncoderTest):
     return "webm"
 
 class cqp(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
-  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = 30 if ipmode != 0 else 1,
@@ -42,17 +37,21 @@ class cqp(VP9EncoderTest):
       quality   = quality,
       rcmode    = "cqp",
       refmode   = refmode,
+      lowpower  = False,
     )
-    self.encode()
 
-class cbr(VP9EncoderTest):
   @slash.requires(*platform.have_caps("encode", "vp9_8"))
   @slash.requires(*have_gst_element("vaapivp9enc"))
   @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -65,17 +64,21 @@ class cbr(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "cbr",
       refmode   = refmode,
+      lowpower  = False,
     )
-    self.encode()
-
-class vbr(VP9EncoderTest):
+ 
   @slash.requires(*platform.have_caps("encode", "vp9_8"))
   @slash.requires(*have_gst_element("vaapivp9enc"))
   @slash.requires(*have_gst_element("vaapivp9dec"))
-  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
+    self.encode()
+
+class vbr(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -91,5 +94,97 @@ class vbr(VP9EncoderTest):
       quality   = quality,
       rcmode    = "vbr",
       refmode   = refmode,
+      lowpower  = False,
     )
+  
+  @slash.requires(*platform.have_caps("encode", "vp9_8"))
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
+    self.encode()
+
+class cqp_lp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      refmode   = refmode,
+      lowpower  = True,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      refmode   = refmode,
+      lowpower  = True,
+    )
+  
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+class vbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate   = int(bitrate / 0.7),
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      refmode   = refmode,
+      lowpower  = True,
+    )
+  
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_gst_element("vaapivp9enc"))
+  @slash.requires(*have_gst_element("vaapivp9dec"))
+  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()


### PR DESCRIPTION
enable vp9 8bit encoding(vdenc) test for gst-vaapi

Signed-off-by: Yuankun Zhang <yuankunx.zhang@intel.com>