### PR TITLE
ffmpeg-vaapi and ffmpeg-qsv need to change ayuv format to 0yuv format

### DIFF
--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -46,7 +46,7 @@ def get_supported_format_map():
     "BGRA"  : "bgra",
     "P210"  : "yuv422p10le",
     "P410"  : "yuv444p10le",
-    "AYUV"  : "ayuv",
+    "AYUV"  : "0yuv",
   }
 
 @memoize

--- a/test/ffmpeg-vaapi/util.py
+++ b/test/ffmpeg-vaapi/util.py
@@ -43,7 +43,7 @@ def get_supported_format_map():
     "BGRA"  : "bgra",
     "P210"  : "yuv422p10le",
     "P410"  : "yuv444p10le",
-    "AYUV"  : "ayuv",
+    "AYUV"  : "0yuv",
   }
 
 @memoize


### PR DESCRIPTION
At present, the decoding format of ffmpeg corresponding to ayuv is 0yuv, which has been verified locally that 0yuv can pass.