### PR TITLE
use mapRangeInt for int ranges

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -171,3 +171,7 @@ def try_call(command):
 def mapRange(value, srcRange, destRange):
   (smin, smax), (dmin, dmax) = srcRange, destRange
   return dmin + ((value - smin) * (dmax - dmin) / (smax - smin))
+
+def mapRangeInt(value, srcRange, destRange):
+  (smin, smax), (dmin, dmax) = srcRange, destRange
+  return int(dmin + ((value - smin) * (dmax - dmin) // (smax - smin)))

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -31,7 +31,7 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRange(qp, [0, 100], [1, 51]),
+      mqp     = mapRangeInt(qp, [0, 100], [1, 51]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",

--- a/test/ffmpeg-qsv/vpp/denoise.py
+++ b/test/ffmpeg-qsv/vpp/denoise.py
@@ -25,7 +25,7 @@ class default(VppTest):
     vars(self).update(
       case    = case,
       level   = level,
-      mlevel  = mapRange(level, [0, 100], [0, 100]),
+      mlevel  = mapRangeInt(level, [0, 100], [0, 100]),
     )
     self.vpp()
 

--- a/test/ffmpeg-qsv/vpp/sharpen.py
+++ b/test/ffmpeg-qsv/vpp/sharpen.py
@@ -25,7 +25,7 @@ class default(VppTest):
     vars(self).update(
       case    = case,
       level   = level,
-      mlevel  = mapRange(level, [0, 100], [0, 100]),
+      mlevel  = mapRangeInt(level, [0, 100], [0, 100]),
     )
 
     if self.width == 1280 and self.height == 720:

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -35,7 +35,7 @@ class cqp(MPEG2EncoderTest):
       case    = case,
       gop     = gop,
       qp      = qp,
-      mqp     = mapRange(qp, [0, 100], [1, 31]),
+      mqp     = mapRangeInt(qp, [0, 100], [1, 31]),
       rcmode  = "cqp",
     )
 

--- a/test/ffmpeg-vaapi/vpp/denoise.py
+++ b/test/ffmpeg-vaapi/vpp/denoise.py
@@ -26,7 +26,7 @@ class default(VppTest):
     vars(self).update(
       case    = case,
       level   = level,
-      mlevel  = mapRange(level, [0, 100], [0, 64]),
+      mlevel  = mapRangeInt(level, [0, 100], [0, 64]),
     )
     self.vpp()
 

--- a/test/ffmpeg-vaapi/vpp/sharpen.py
+++ b/test/ffmpeg-vaapi/vpp/sharpen.py
@@ -26,7 +26,7 @@ class default(VppTest):
     vars(self).update(
       case    = case,
       level   = level,
-      mlevel  = mapRange(level, [0, 100], [0, 64]),
+      mlevel  = mapRangeInt(level, [0, 100], [0, 64]),
     )
 
     if self.width == 1280 and self.height == 720:

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -33,7 +33,7 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRange(qp, [0, 100], [0, 51]),
+      mqp     = mapRangeInt(qp, [0, 100], [0, 51]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -34,7 +34,7 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRange(qp, [0, 100], [2, 62]),
+      mqp     = mapRangeInt(qp, [0, 100], [2, 62]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",


### PR DESCRIPTION
In python3, the '/' operator no longer takes the
range types into account.  Thus, introduce and use
a mapRangeInt method for tests that expect integer
range mapping.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>