### PR TITLE
lib/metrics: remove nrmse norm_type parameter

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -184,7 +184,7 @@ def calculate_mse(filename1, filename2, width, height, nframes = 1, fourcc = "I4
 
 def __compare_nrmse(planes):
   a, b = planes
-  return skimage_nrmse(a, b, norm_type = "Euclidean")
+  return skimage_nrmse(a, b)
 
 @timefn("nrmse")
 def calculate_nrmse(filename1, filename2, width, height, nframes = 1, fourcc = "I420"):


### PR DESCRIPTION
The different versions of the skimage nrmse functions
also have different norm_type parameter name.  Both
versions still default to "euclidean" normalization.
Therefore, there is no need to explicitly specify
this parameter.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>