### PR TITLE
vp9_lp enc:enable vp9_lp encoding for ffmpeg-vaapi

### DIFF
--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -15,7 +15,6 @@ class VP9EncoderTest(EncoderTest):
     vars(self).update(
       codec   = "vp9",
       ffenc   = "vp9_vaapi",
-      lowpower= 0,
     )
     super(VP9EncoderTest, self).before()
 
@@ -26,14 +25,11 @@ class VP9EncoderTest(EncoderTest):
     return "VAProfileVP9Profile0"
 
 class cqp(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
-  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = 30 if ipmode != 0 else 1,
@@ -41,17 +37,46 @@ class cqp(VP9EncoderTest):
       loopshp   = loopshp,
       qp        = qp,
       rcmode    = "cqp",
+      lowpower  = 0,
     )
-    self.encode()
 
-class cbr(VP9EncoderTest):
   @slash.requires(*platform.have_caps("encode", "vp9_8"))
   @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)  
+    self.encode()
+
+class cqp_lp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      slices    = slices,
+      rcmode    = "cqp",
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.encode()
+
+
+class cbr(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -63,18 +88,49 @@ class cbr(VP9EncoderTest):
       maxrate   = bitrate,
       minrate   = bitrate,
       rcmode    = "cbr",
+      lowpower  = 0,
     )
+
+  @slash.requires(*platform.have_caps("encode", "vp9_8"))
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr(VP9EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     self.caps = platform.get_caps("encode", "vp9_8")
-    vars(self).update(spec[case].copy())
+    vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
@@ -86,5 +142,41 @@ class vbr(VP9EncoderTest):
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
       rcmode    = "vbr",
+      lowpower  = 0,
     )
+
+  @slash.requires(*platform.have_caps("encode", "vp9_8"))
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
+  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
+
+class vbr_lp(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    self.caps = platform.get_caps("vdenc", "vp9_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      loopshp   = loopshp,
+      maxrate   = bitrate * 2, # target percentage 50%
+      minrate   = bitrate,
+      rcmode    = "vbr",
+      slices    = slices,
+      lowpower  = 1,
+    )
+
+  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
+    self.encode()
+


### PR DESCRIPTION
enable vp9 8bit encoding(vdenc) test for ffmpeg-vaapi.

Signed-off-by: Yuankun Zhang <yuankunx.zhang@intel.com>