### PR TITLE
test/gst-msdk/encode/vp9.py: Add muxer in command line

### DIFF
--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -15,12 +15,14 @@ class VP9EncoderTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "msdkvp9enc",
-      gstdecoder    = "ivfparse ! msdkvp9dec hardware=true",
+      gstdecoder    = "matroskademux ! msdkvp9dec hardware=true",
+      gstmediatype  = "video/x-vp9",
+      gstmuxer      = "matroskamux",
     )
     super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
-    return "ivf"
+    return "webm"
 
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):


### PR DESCRIPTION
The src caps of msdkvp9enc is video/x-vp9 which means raw VP9 stream, so
a muxer is required if we want to get a stream file.
