### PR TITLE
test/gst-msdk/vpp: remove YV12 output quirk

### DIFF
--- a/test/gst-msdk/vpp/vpp.py
+++ b/test/gst-msdk/vpp/vpp.py
@@ -122,9 +122,9 @@ class VppTest(slash.Test):
     self.mformat  = mapformat(self.format)
     self.mformatu = mapformatu(self.format)
 
-    # MSDK does not support I420 and YV12 output formats even though
+    # MSDK does not support I420 output formats even though
     # iHD supports it.  Thus, msdkvpp can't output it directly (HW).
-    ofmts = list(set(ofmts) - set(["I420", "YV12"]))
+    ofmts = list(set(ofmts) - set(["I420"]))
 
     if self.mformat is None:
       slash.skip_test("gst.{format} unsupported".format(**vars(self)))


### PR DESCRIPTION
YV12 output is supported in VPP since:

https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1120
https://github.com/Intel-Media-SDK/MediaSDK/pull/2027

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>