### PR TITLE
gst-vaapi: add vme low delay b implementation

### DIFF
--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -9,6 +9,7 @@ from ..util import *
 from .encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
+spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class HEVC8EncoderTest(EncoderTest):
@@ -89,6 +90,31 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+#VME Low delay b
+class cqp_ldb(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes      = bframes,
+      case         = case,
+      gop          = gop,
+      qp           = qp,
+      lowdelayb    = 1,
+      quality      = quality,
+      profile      = profile,
+      rcmode       = "cqp",
+      slices       = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
+  @slash.requires(*have_gst_element("vaapih265enc"))
+  @slash.requires(*have_gst_element("vaapih265dec"))
+  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -154,6 +180,33 @@ class cbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
+    self.encode()
+
+#vme cbr mode low delay b encode
+class cbr_ldb(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes      = bframes,
+      bitrate      = bitrate,
+      case         = case,
+      fps          = fps,
+      gop          = gop,
+      lowdelayb    = 1,
+      maxrate      = bitrate,
+      minrate      = bitrate,
+      profile      = profile,
+      rcmode       = "cbr",
+      slices       = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
+  @slash.requires(*have_gst_element("vaapih265enc"))
+  @slash.requires(*have_gst_element("vaapih265dec"))
+  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
@@ -229,4 +282,35 @@ class vbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
+    self.encode()
+
+#VME VBR low delay b encode
+class vbr_ldb(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes      = bframes,
+      bitrate      = bitrate,
+      case         = case,
+      fps          = fps,
+      gop          = gop,
+      lowdelayb    = 1,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate      = int(bitrate / 0.7),
+      minrate      = bitrate,
+      profile      = profile,
+      quality      = quality,
+      rcmode       = "vbr",
+      refs         = refs,
+      slices       = slices,
+    )
+
+  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
+  @slash.requires(*have_gst_element("vaapih265enc"))
+  @slash.requires(*have_gst_element("vaapih265dec"))
+  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()


### PR DESCRIPTION
add vme "low delay b" implementation for hevc 8bit
yuv420 encode for gst-vaapi testing

Signed-off-by: Luo Focus <focus.luo@intel.com>