### PR TITLE
Transcode: gst-vaapi hevc8 vme low delay b support

### DIFF
--- a/test/gst-vaapi/transcode/transcoder.py
+++ b/test/gst-vaapi/transcode/transcoder.py
@@ -22,6 +22,10 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vaapih265dec"), "h265parse ! vaapih265dec"),
       ),
+      "hevc-8-vme-ldb" : dict(
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
+        hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vaapih265dec"), "h265parse ! vaapih265dec"),
+      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avdec_mpeg2video"), "mpegvideoparse ! avdec_mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("vaapimpeg2dec"), "mpegvideoparse ! vaapimpeg2dec"),
@@ -51,6 +55,10 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
+      ),
+      "hevc-8-vme-ldb" : dict(
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc tune=none low-delay-b=1 ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
@@ -100,11 +108,12 @@ class TranscoderTest(slash.Test):
 
   def get_file_ext(self, codec):
     return {
-      "avc"     : "h264",
-      "hevc"    : "h265",
-      "hevc-8"  : "h265",
-      "mpeg2"   : "m2v",
-      "mjpeg"   : "mjpeg",
+      "avc"            : "h264",
+      "hevc"           : "h265",
+      "hevc-8"         : "h265",
+      "hevc-8-vme-ldb" : "h265",
+      "mpeg2"          : "m2v",
+      "mjpeg"          : "mjpeg",
     }.get(codec, "???")
 
   def validate_caps(self):


### PR DESCRIPTION
Add hevc 8bit vme low delay b support for gst-vaapi
transcode implementation

Signed-off-by: Luo Focus <focus.luo@intel.com>