### PR TITLE
Transcode: ffmpeg-vaapi hevc8 vme low delay b support

### DIFF
--- a/test/ffmpeg-vaapi/transcode/transcoder.py
+++ b/test/ffmpeg-vaapi/transcode/transcoder.py
@@ -22,6 +22,10 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
         hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
       ),
+      "hevc-8-vme-ldb" : dict(
+        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
+        hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
+      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
@@ -43,6 +47,10 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
         hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi"),
+      ),
+      "hevc-8-vme-ldb" : dict(
+        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
+        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi -b_strategy 1"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),
@@ -92,11 +100,12 @@ class TranscoderTest(slash.Test):
 
   def get_file_ext(self, codec):
     return {
-      "avc"     : "h264",
-      "hevc"    : "h265",
-      "hevc-8"  : "h265",
-      "mpeg2"   : "m2v",
-      "mjpeg"   : "mjpeg",
+      "avc"            : "h264",
+      "hevc"           : "h265",
+      "hevc-8"         : "h265",
+      "hevc-8-vme-ldb" : "h265",
+      "mpeg2"          : "m2v",
+      "mjpeg"          : "mjpeg",
     }.get(codec, "???")
 
   def validate_caps(self):


### PR DESCRIPTION
Add hevc 8bit vme low delay b support for ffmpeg-vaapi
transcode implementation

Signed-off-by: Luo Focus <focus.luo@intel.com>