### PR TITLE
Support for platform and gpu.gen in refctx

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -133,10 +133,15 @@ class MediaPlugin(slash.plugins.PluginInterface):
     for c in context:
       sc = str(c).strip().lower()
       if "driver" == sc:
-        sc = "drv.{}".format(info().get("driver", "unknown"))
+        sc = "drv.{driver}"
+      elif "platform" == sc:
+        sc = "plat.{platform}"
+      elif "gpu.gen" == sc:
+        sc = "gpu.gen.{gpu[gen]}"
       elif sc.startswith("key:"):
         continue
-      yield sc
+
+      yield sc.format(**info())
 
   def _get_ref_addr(self, context):
     path, case = slash.context.test.__slash__.address.split(':')

--- a/.slashrc
+++ b/.slashrc
@@ -129,10 +129,11 @@ class MediaPlugin(slash.plugins.PluginInterface):
     return data.setdefault(key, state_value(default))
 
   def _expand_context(self, context):
+    from lib.platform import info
     for c in context:
       sc = str(c).strip().lower()
       if "driver" == sc:
-        sc = "drv.{}".format(self._get_driver_name())
+        sc = "drv.{}".format(info().get("driver", "unknown"))
       elif sc.startswith("key:"):
         continue
       yield sc

--- a/lib/caps/APL/info
+++ b/lib/caps/APL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9),
+)

--- a/lib/caps/BSW/info
+++ b/lib/caps/BSW/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 8),
+)

--- a/lib/caps/CFL/info
+++ b/lib/caps/CFL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9.5),
+)

--- a/lib/caps/CML/info
+++ b/lib/caps/CML/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9.5),
+)

--- a/lib/caps/EHL/info
+++ b/lib/caps/EHL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 11),
+)

--- a/lib/caps/GLK/info
+++ b/lib/caps/GLK/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9.5),
+)

--- a/lib/caps/ICL/info
+++ b/lib/caps/ICL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 11),
+)

--- a/lib/caps/KBL/info
+++ b/lib/caps/KBL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9.5),
+)

--- a/lib/caps/SKL/info
+++ b/lib/caps/SKL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9),
+)

--- a/lib/caps/TGL/info
+++ b/lib/caps/TGL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 12),
+)

--- a/lib/caps/WHL/info
+++ b/lib/caps/WHL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 9.5),
+)

--- a/lib/platform.py
+++ b/lib/platform.py
@@ -63,6 +63,7 @@ def have_caps(*args):
   )
   return get_caps(*args) is not None, failmsg
 
+@memoize
 def info():
   import platform
   try:
@@ -84,4 +85,6 @@ def info():
     kernel = str(platform.release()),
     dist = str(linux_dist()),
     cpu = cpu,
+    driver = str(get_media()._get_driver_name()),
+    platform = str(get_media()._get_platform_name()),
   )

--- a/lib/platform.py
+++ b/lib/platform.py
@@ -80,6 +80,19 @@ def info():
   except:
     cpu = "unknown"
 
+  from .common import get_media
+  plinfo = dict()
+  infofile = os.path.abspath(
+    os.path.join(
+      os.path.dirname(__file__), "caps",
+      str(get_media()._get_platform_name()),
+      "info"
+    )
+  )
+  if os.path.exists(infofile):
+    with open(infofile, 'rb') as f:
+      exec(f.read(), plinfo)
+
   return dict(
     node = str(platform.node()),
     kernel = str(platform.release()),
@@ -87,4 +100,5 @@ def info():
     cpu = cpu,
     driver = str(get_media()._get_driver_name()),
     platform = str(get_media()._get_platform_name()),
+    **plinfo.get("info", dict()),
   )


### PR DESCRIPTION
Sometimes, references need to be stored in the baseline on a per-platform or per-gpu gen basis.  This adds support for using `"platform"` and/or `"gpu.gen"` keys in the `refctx` user config variable for each test case definition.  The `"platform"` key is expanded at run-time to the platform specified in the `--platform` command-line option.  The `"gpu.gen"` key is expanded at run-time to the gpu gen specified in the `lib/caps/{platform}/info` file.

Some examples (note: `"driver"` key is previously supported):
```python
# the following two examples are equivalent for a nested refctx lookup
refctx = ["driver", "gpu.gen"]
refctx = ["drv.{driver}", "gpu.gen.{gpu[gen]}"]

# the following two examples are also equivalent for a nested refctx lookup
refctx = ["driver", "platform"]
refctx = ["drv.{driver}", "plat.{platform}"]

# example of a flat refctx lookup using multiple expandable variables
refctx = ["drv[{driver}].gpu[{gpu[gen]}]"]
```

In the last example, the baseline entry for each test case would look something like:
```json
"test/gst-vaapi/encode/avc.py:cbr.test ..." : {
  "drv[i965].gpu[9.5]": {
    "psnr": [
      36.5354,
      43.2215,
      42.0764,
      38.0075,
      46.0385,
      45.4124
    ]
  },
  "drv[iHD].gpu[11]": {
    "psnr": [
      36.8901,
      44.6163,
      43.2628,
      38.8528,
      47.9717,
      46.9679
    ]
  },
  "drv[iHD].gpu[9.5]": {
    "psnr": [
      36.5901,
      44.3163,
      42.2628,
      38.4528,
      47.5717,
      45.9679
    ]
   }
}
```