### PR TITLE
test/ffmpeg: disable autoscale for decode tests

### DIFF
--- a/test/ffmpeg-qsv/decode/decoder.py
+++ b/test/ffmpeg-qsv/decode/decoder.py
@@ -21,7 +21,7 @@ class DecoderTest(slash.Test):
       " -v verbose -c:v {ffdecoder} -i {source}"
       " -vf 'hwdownload,format={hwformat}'"
       " -pix_fmt {mformat} -f rawvideo -vsync passthrough"
-      " -vframes {frames} -y {decoded}".format(**vars(self)))
+      " -autoscale 0 -vframes {frames} -y {decoded}".format(**vars(self)))
 
   def gen_name(self):
     name = "{case}_{width}x{height}_{format}"

--- a/test/ffmpeg-vaapi/decode/decoder.py
+++ b/test/ffmpeg-vaapi/decode/decoder.py
@@ -18,8 +18,8 @@ class DecoderTest(slash.Test):
     self.output = call(
       "ffmpeg -hwaccel vaapi -init_hw_device vaapi=hw:/dev/dri/renderD128"
       " -hwaccel_flags allow_profile_mismatch -filter_hw_device hw -v verbose"
-      " -i {source} -pix_fmt {mformat} -f rawvideo -vsync"
-      " passthrough -vframes {frames} -y {decoded}".format(**vars(self)))
+      " -i {source} -pix_fmt {mformat} -f rawvideo -vsync passthrough"
+      " -autoscale 0 -vframes {frames} -y {decoded}".format(**vars(self)))
 
   def gen_name(self):
     name = "{case}_{width}x{height}_{format}"


### PR DESCRIPTION
The autoscale option is added in ffmpeg commit 0b511bd9a548.

For multi resolution clips, we don't want to scale the raw
decoded output since scaling algorithms can produce different
results between various drivers/middleware.  For most codecs,
the decoded result should be the same across different
driver/middleware implementations.  This decoded result can
only be effectively validated and compared when scaling is
disabled.  This also allows us to share a single baseline
reference across all tested drivers/middleware.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>