### PR TITLE
vaapi-fits: added Y412 format map in ffmpeg-qsv

### DIFF
--- a/test/ffmpeg-qsv/util.py
+++ b/test/ffmpeg-qsv/util.py
@@ -49,6 +49,7 @@ def get_supported_format_map():
     "BGRA"  : "bgra",
     "Y210"  : "y210",
     "Y410"  : "y410",
+    "Y412"  : "y412",
     "AYUV"  : "0yuv", # 0yuv is same as microsoft AYUV except the alpha channel
   }
 


### PR DESCRIPTION
added Y412 format map in ffmpeg-qsv to enable 12bit
444 decode

Signed-off-by: Luo Focus <focus.luo@intel.com>