### PR TITLE
gst-msdk: fix hevc low-power type changed

### DIFF
--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -56,7 +56,7 @@ class EncoderTest(slash.Test):
       opts += " ref-frames={refs}"
     if vars(self).get("lowpower", None) is not None:
       opts += " low-power="
-      opts += "true" if self.lowpower else "false"
+      opts += "1" if self.lowpower else "0"
     if vars(self).get("ladepth", None) is not None:
       opts += " rc-lookahead={ladepth}"
 


### PR DESCRIPTION
The low-power property type changed in upstream for
hevc plugin:

https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/merge_requests/1405

Thus, adjust accordingly.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>