### PR TITLE
plugin: support function/lambda in refctx

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -193,6 +193,10 @@ class MediaPlugin(slash.plugins.PluginInterface):
   def _get_platform_name(self):
     return self.platform
 
+  def _get_gpu_gen(self):
+    from lib.platform import info
+    return info()["gpu"]["gen"]
+
   def _get_call_timeout(self):
     if self.test_call_timeout > 0:
        return self.test_call_timeout

--- a/.slashrc
+++ b/.slashrc
@@ -130,7 +130,12 @@ class MediaPlugin(slash.plugins.PluginInterface):
 
   def _expand_context(self, context):
     from lib.platform import info
+    import types
     for c in context:
+      if type(c) is types.FunctionType:
+        c = c()
+        if c is None: continue
+
       sc = str(c).strip().lower()
       if "driver" == sc:
         sc = "drv.{driver}"


### PR DESCRIPTION
The user config may want to set the refctx based
on some command-line option.  However, the command-line
is not parsed until after the user config is loaded.

Thus, allow a function/lambda in refctx so the user
config can delay evaluation until the refctx is expanded
during test runtime.

For example, user config may want to use the platform
command-line value to determine an appropriate refctx.
But, media._get_platform_name() is not resolved until
after the user config is loaded.  Thus, the user config
can delay the evaluation based on platform when the
refctx is expanded during test runtime like so:

```python
 refctx = [
  "driver",
  lambda: "gpu.gen" if media._get_platform_name() in ["XYZ"] else None
 ]
```

...this will produce ["driver", "gpu.gen"] only when the
platform name is "XYZ".  Otherwise, it produces ["driver"].
Finally, this result will be expanded as usual
(e.g. [drv.iHD, gpu.gen.12] or [drv.iHD], respectively).

The function/lambda should return a string or None.  If
None is returned, then it is ignored.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>