### PR TITLE
gst-msdk/encode: only enable AYUV for hevc-8

### DIFF
--- a/test/gst-msdk/encode/encoder.py
+++ b/test/gst-msdk/encode/encoder.py
@@ -122,6 +122,8 @@ class EncoderTest(slash.Test):
 
   def validate_caps(self):
     ifmts = self.caps["fmts"]
+    if self.codec not in ["hevc-8"]:
+      ifmts = list(set(ifmts) - set(["AYUV"]))
 
     self.hwformat = map_best_hw_format(self.format, ifmts)
     self.mformat  = mapformat(self.format)


### PR DESCRIPTION
AYUV input was enabled for all codecs in:

  commit b56ee2407a0163e57d5174c3d60b3124aa37188b
  Author: Luo Focus <focus.luo@intel.com>
  Date:   Fri Jul 10 01:52:28 2020 +0000

    fixed the ayuv support issue for gst-msdk

...however, only hevc-8 currently supports AYUV input
through and through.

AYUV input should not be enabled for other codecs.
More specifically, msdkmjpegenc element does not
currently support AYUV/VUYA srcpad format.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>