### PR TITLE
hevc-8 lp 444: added gst-vaapi profile map

### DIFF
--- a/test/gst-vaapi/util.py
+++ b/test/gst-vaapi/util.py
@@ -95,6 +95,7 @@ def mapprofile(codec, profile):
     },
     "hevc-8"   : {
       "main"                  : "main",
+      "main444"                  : "main-444",
     },
     "hevc-10"  : {
       "main10"                : "main-10",


### PR DESCRIPTION
added gst-vaapi profile map for hevc 8bit vdenc
444 encode

Signed-off-by: Luo Focus <focus.luo@intel.com>