### PR TITLE
gst-msdk: added main444-10 to main-444-10 map

### DIFF
--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -100,6 +100,7 @@ def mapprofile(codec,profile):
     },
     "hevc-10" : {
       "main10"                : "main-10",
+      "main444-10"            : "main-444-10",
     },
     "hevc-12" : {
       "main12"                : "main-12",


### PR DESCRIPTION
added main444-10 to main-444-10 map for gst-msdk
for hevc 10bit 444 encode

Signed-off-by: Luo Focus <focus.luo@intel.com>