### PR TITLE
metrics: Use max possible pixel value for PSNR and SSIM

### DIFF
--- a/lib/formats.py
+++ b/lib/formats.py
@@ -32,3 +32,6 @@ def match_best_format(fmt, choices):
   if len(matches) == 0:
     return None
   return list(matches)[0]
+
+def get_bit_depth(fmt):
+  return subsampling[fmt][1]

--- a/lib/framereader.py
+++ b/lib/framereader.py
@@ -85,8 +85,8 @@ def read_frame_P010(fd, width, height):
   size    = width * height
   size2   = width2 * height2 * 2
 
-  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width))
-  uv = numpy.fromfile(fd, dtype=numpy.uint16, count=size2)
+  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width)) >> 6
+  uv = numpy.fromfile(fd, dtype=numpy.uint16, count=size2) >> 6
 
   return y, uv[0::2].reshape((height2, width2)), uv[1::2].reshape((height2, width2))
 
@@ -96,9 +96,9 @@ def read_frame_I010(fd, width, height):
   size    = width * height
   size2   = width2 * height2
 
-  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width))
-  u = numpy.fromfile(fd, dtype=numpy.uint16, count=size2).reshape((height2, width2))
-  v = numpy.fromfile(fd, dtype=numpy.uint16, count=size2).reshape((height2, width2))
+  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width)) >> 6
+  u = numpy.fromfile(fd, dtype=numpy.uint16, count=size2).reshape((height2, width2)) >> 6
+  v = numpy.fromfile(fd, dtype=numpy.uint16, count=size2).reshape((height2, width2)) >> 6
 
   return y, u, v
 
@@ -108,8 +108,8 @@ def read_frame_P012(fd, width, height):
   size    = width * height
   size2   = width2 * height2 * 2
 
-  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width))
-  uv = numpy.fromfile(fd, dtype=numpy.uint16, count=size2)
+  y = numpy.fromfile(fd, dtype=numpy.uint16, count=size).reshape((height, width)) >> 4
+  uv = numpy.fromfile(fd, dtype=numpy.uint16, count=size2) >> 4
 
   return y, uv[0::2].reshape((height2, width2)), uv[1::2].reshape((height2, width2))
 
@@ -189,12 +189,12 @@ def read_frame_Y210(fd, width, height):
   #data:  valid data  ...       0 0 0 0 0 0
   size    = width * height * 2
 
-  y210 = numpy.fromfile(fd, dtype=numpy.uint16, count=size)
+  y210 = numpy.fromfile(fd, dtype=numpy.uint16, count=size) >> 6
   # frames with odd width and height produce an odd number of bytes
   # in uv components and therefore cannot be effectively reshaped
-  y  = y210[0::2].reshape((height, width)) & 0xffc0
-  u  = y210[1::4] & 0xffc0
-  v  = y210[3::4] & 0xffc0
+  y  = y210[0::2].reshape((height, width))
+  u  = y210[1::4]
+  v  = y210[3::4]
 
   return y, u, v
 
@@ -207,13 +207,13 @@ def read_frame_Y212(fd, width, height):
   #V  bit[63:48]
   size    = width * height * 2
 
-  y212 = numpy.fromfile(fd, dtype=numpy.uint16, count=size)
+  y212 = numpy.fromfile(fd, dtype=numpy.uint16, count=size) >> 4
   #bit 0-15
-  y = y212[0::2].reshape((height, width)) & 0xfff0
+  y = y212[0::2].reshape((height, width))
   #bit 16-31
-  u = y212[1::4] & 0xfff0
+  u = y212[1::4]
   #bit 32-47
-  v = y212[3::4] & 0xfff0
+  v = y212[3::4]
 
   return y, u, v
 
@@ -226,11 +226,11 @@ def read_frame_Y410(fd, width, height):
   #A bit[31:30]
   y410 = numpy.fromfile(fd, dtype=numpy.uint32, count=width*height)
   #bit 0-9
-  u = (y410 & 0x3ff).reshape((height, width))
+  u = (y410 & 0x3ff).reshape((height, width)).astype(numpy.uint16)
   #bit 10-19
-  y = ((y410 >> 10) & 0x3ff).reshape((height, width))
+  y = ((y410 >> 10) & 0x3ff).reshape((height, width)).astype(numpy.uint16)
   #bit 20-30
-  v = ((y410 >> 20) & 0x3ff).reshape((height, width))
+  v = ((y410 >> 20) & 0x3ff).reshape((height, width)).astype(numpy.uint16)
 
   return y, u, v
 

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -143,33 +143,42 @@ class RawMetricAggregator:
         self.__append(compare, ((y1, y2), (u1, u2), (v1, v2)))
     return self.__get()
 
-def __compare_ssim(planes):
+class MetricWithDataRange:
+  def __init__(self, func, fourcc):
+    from .formats import get_bit_depth
+    self.func = func
+    self.data_range = pow(2, get_bit_depth(fourcc)) - 1
+
+  def __call__(self, planes):
+    return self.func(planes, self.data_range)
+
+def __compare_ssim(planes, data_range = None):
   a, b = planes
   if a is None or b is None: # handle Y800 case
     return 1.0
-  return skimage_ssim(a, b, win_size = 3)
+  return skimage_ssim(a, b, win_size = 3, data_range = data_range)
 
 @timefn("ssim")
 def calculate_ssim(filename1, filename2, width, height, nframes = 1, fourcc = "I420", fourcc2 = None):
   return RawMetricAggregator(min).calculate(
     RawFile(filename1, width, height, nframes, fourcc),
     RawFile(filename2, width, height, nframes, fourcc2 or fourcc),
-    nframes, __compare_ssim)
+    nframes, MetricWithDataRange(__compare_ssim, fourcc))
 
-def __compare_psnr(planes):
+def __compare_psnr(planes, data_range = None):
   a, b = planes
   if (a == b).all():
     # Avoid "Warning: divide by zero encountered in double_scalars" generated
     # by skimage.measure.compare_psnr when a and b are exactly the same.
     return 100
-  return skimage_psnr(a, b)
+  return skimage_psnr(a, b, data_range = data_range)
 
 @timefn("psnr")
 def calculate_psnr(filename1, filename2, width, height, nframes = 1, fourcc = "I420"):
   return RawMetricAggregator(min).calculate(
     RawFile(filename1, width, height, nframes, fourcc),
     RawFile(filename2, width, height, nframes, fourcc),
-    nframes, __compare_psnr)
+    nframes, MetricWithDataRange(__compare_psnr, fourcc))
 
 def __compare_mse(planes):
   a, b = planes

--- a/test/self/formats.py
+++ b/test/self/formats.py
@@ -95,10 +95,10 @@ def test_frame_reader_Y210(width, height):
   with open(testfile, "rb") as fd:
     y, u, v = read_frame_Y210(fd, width, height)
 
-    y0f = lambda val: val == oy0
-    uf  = lambda val: val == ou
-    y1f = lambda val: val == oy1
-    vf  = lambda val: val == ov
+    y0f = lambda val: val == (oy0 >> 6)
+    uf  = lambda val: val == (ou >> 6)
+    y1f = lambda val: val == (oy1 >> 6)
+    vf  = lambda val: val == (ov >> 6)
 
     y_fd = y.reshape(1, y.size)
     y0_fd = y_fd[:,0::2]


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio#Definition

PSNR and SSIM should be calculated using the correct max possible
pixel value for each bit depth.  For 8 bit, the skimage uses the
correct default of 255.  But for 10 bit and 12 bit, we read the
pixels into 16/32 bit dtype, and skimage will set the default for
those to the max possible value that the "data type" can handle.
However, the max pixel value is less for 10/12 bit formats. It
should be (2^B)-1.  Thus, specify the data_range param to skimage
PSNR and SSIM so that the correct max possible pixel value is used
in the calculation.

Also, the 10/12 bit frame readers must mask or shift away any
insignificant bits (depending on format) so that the pixel value
starts at the lsb and puts it into the correct pixel value range
for proper metrics calculation.

NOTE: I ran the 10bit HEVC encode smoke and sanity tests on KBL and did not see a huge difference in PSNR results (all passed).  However, this will fix a major issue with Y410 used in encode tests (tests haven't been merged, yet).