### PR TITLE
gst-msdk decode added vp9 12bit 420 support

### DIFF
--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -20,6 +20,7 @@ caps = dict(
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012"]),
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
   ),
   encode  = dict(

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -20,6 +20,7 @@ caps = dict(
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012"]),
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
   ),
   encode  = dict(

--- a/test/gst-msdk/decode/12bit/vp9.py
+++ b/test/gst-msdk/decode/12bit/vp9.py
@@ -1,0 +1,34 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from ...util import *
+from ..decoder import DecoderTest
+
+spec = load_test_spec("vp9", "decode", "12bit")
+
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp9_12")
+    super(default, self).before()
+
+  @slash.requires(*platform.have_caps("decode", "vp9_12"))
+  @slash.requires(*have_gst_element("msdkvp9dec"))
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+
+    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux", ".mkv" : "matroskademux"}
+    ext = os.path.splitext(self.source)[1]
+    assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
+
+    vars(self).update(
+      case        = case,
+      gstdecoder  = "{} ! msdkvp9dec".format(dxmap[ext]),
+    )
+    self.decode()

--- a/test/gst-msdk/util.py
+++ b/test/gst-msdk/util.py
@@ -108,6 +108,9 @@ def mapprofile(codec,profile):
     "av1-8"  : {
       "main"                  : "main",
     },
+    "vp9-12" : {
+      "profile3"              : "profile3",
+    },
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):


### PR DESCRIPTION
1, vp9 12bit decode support in lib/caps for TGL/RKL firstly
2, vp9 12bit gst-msdk decode enabling