### PR TITLE
Move common middleware code to lib

### DIFF
--- a/lib/ffmpeg/__init__.py
+++ b/lib/ffmpeg/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/ffmpeg/qsv/__init__.py
+++ b/lib/ffmpeg/qsv/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_qsv_accel)

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_qsv_accel)

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 import os
 
 @slash.requires(have_ffmpeg)

--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -4,8 +4,8 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ...lib.common import memoize, try_call, get_media
-from ...lib.formats import match_best_format
+from ....lib.common import memoize, try_call, get_media
+from ....lib.formats import match_best_format
 
 def using_compatible_driver():
   return get_media()._get_driver_name() == "iHD"
@@ -112,7 +112,7 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ...lib import get_media
+  from ....lib import get_media
   import copy
 
   # get copy of general ctx entries

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_qsv_accel)

--- a/lib/ffmpeg/vaapi/__init__.py
+++ b/lib/ffmpeg/vaapi/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_vaapi_accel)

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_vaapi_accel)

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 import os
 
 @slash.requires(have_ffmpeg)

--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -4,8 +4,8 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ...lib.common import memoize, try_call
-from ...lib.formats import match_best_format
+from ....lib.common import memoize, try_call
+from ....lib.formats import match_best_format
 
 @memoize
 def have_ffmpeg():
@@ -60,7 +60,7 @@ def map_best_hw_format(format, hwformats):
 
 @memoize
 def map_deinterlace_method(method):
-  from ...lib import get_media
+  from ....lib import get_media
   return {
     "iHD" : {
       "bob"               : "bob",
@@ -125,7 +125,7 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ...lib import get_media
+  from ....lib import get_media
   import copy
 
   # get copy of general ctx entries

--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_ffmpeg)
 @slash.requires(have_ffmpeg_vaapi_accel)

--- a/lib/gstreamer/__init__.py
+++ b/lib/gstreamer/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/gstreamer/msdk/__init__.py
+++ b/lib/gstreamer/msdk/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("msdk"))

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("msdk"))

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 import os
 
 @slash.requires(have_gst)

--- a/lib/gstreamer/msdk/util.py
+++ b/lib/gstreamer/msdk/util.py
@@ -4,8 +4,8 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ...lib.common import memoize, try_call, get_media
-from ...lib.formats import match_best_format
+from ....lib.common import memoize, try_call, get_media
+from ....lib.formats import match_best_format
 
 def using_compatible_driver():
   return get_media()._get_driver_name() == "iHD"
@@ -114,7 +114,7 @@ def mapprofile(codec,profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ...lib import get_media
+  from ....lib import get_media
   import copy
 
   # get copy of general ctx entries

--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("msdk"))

--- a/lib/gstreamer/vaapi/__init__.py
+++ b/lib/gstreamer/vaapi/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("vaapi"))

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("vaapi"))

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 import os
 
 @slash.requires(have_gst)

--- a/lib/gstreamer/vaapi/util.py
+++ b/lib/gstreamer/vaapi/util.py
@@ -4,8 +4,8 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ...lib.common import memoize, try_call
-from ...lib.formats import match_best_format
+from ....lib.common import memoize, try_call
+from ....lib.formats import match_best_format
 
 @memoize
 def have_gst():
@@ -53,7 +53,7 @@ def map_best_hw_format(format, hwformats):
 
 @memoize
 def map_deinterlace_method(method):
-  from ...lib import get_media
+  from ....lib import get_media
   return {
     "iHD" : {
       "bob"               : "bob",
@@ -108,7 +108,7 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ...lib import get_media
+  from ....lib import get_media
   import copy
 
   # get copy of general ctx entries

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ..util import *
+from .util import *
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("vaapi"))

--- a/test/ffmpeg-qsv/decode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/decode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 

--- a/test/ffmpeg-qsv/decode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/decode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 

--- a/test/ffmpeg-qsv/decode/12bit/hevc.py
+++ b/test/ffmpeg-qsv/decode/12bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 

--- a/test/ffmpeg-qsv/decode/av1.py
+++ b/test/ffmpeg-qsv/decode/av1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 

--- a/test/ffmpeg-qsv/decode/avc.py
+++ b/test/ffmpeg-qsv/decode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 

--- a/test/ffmpeg-qsv/decode/hevc.py
+++ b/test/ffmpeg-qsv/decode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 

--- a/test/ffmpeg-qsv/decode/jpeg.py
+++ b/test/ffmpeg-qsv/decode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec      = load_test_spec("jpeg", "decode")
 spec_r2r  = load_test_spec("jpeg", "decode", "r2r")

--- a/test/ffmpeg-qsv/decode/mpeg2.py
+++ b/test/ffmpeg-qsv/decode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec      = load_test_spec("mpeg2", "decode")
 spec_r2r  = load_test_spec("mpeg2", "decode", "r2r")

--- a/test/ffmpeg-qsv/decode/vc1.py
+++ b/test/ffmpeg-qsv/decode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec      = load_test_spec("vc1", "decode")
 spec_r2r  = load_test_spec("vc1", "decode", "r2r")

--- a/test/ffmpeg-qsv/decode/vp8.py
+++ b/test/ffmpeg-qsv/decode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 

--- a/test/ffmpeg-qsv/decode/vp9.py
+++ b/test/ffmpeg-qsv/decode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 

--- a/test/ffmpeg-qsv/transcode/avc.py
+++ b/test/ffmpeg-qsv/transcode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
 
 spec = load_test_spec("avc", "transcode")
 

--- a/test/ffmpeg-qsv/transcode/hevc.py
+++ b/test/ffmpeg-qsv/transcode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
 
 spec = load_test_spec("hevc", "transcode")
 

--- a/test/ffmpeg-qsv/transcode/mpeg2.py
+++ b/test/ffmpeg-qsv/transcode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
 
 spec = load_test_spec("mpeg2", "transcode")
 

--- a/test/ffmpeg-qsv/transcode/vc1.py
+++ b/test/ffmpeg-qsv/transcode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
 
 spec = load_test_spec("vc1", "transcode")
 

--- a/test/ffmpeg-qsv/vpp/brightness.py
+++ b/test/ffmpeg-qsv/vpp/brightness.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")

--- a/test/ffmpeg-qsv/vpp/contrast.py
+++ b/test/ffmpeg-qsv/vpp/contrast.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")

--- a/test/ffmpeg-qsv/vpp/csc.py
+++ b/test/ffmpeg-qsv/vpp/csc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 

--- a/test/ffmpeg-qsv/vpp/deinterlace.py
+++ b/test/ffmpeg-qsv/vpp/deinterlace.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(

--- a/test/ffmpeg-qsv/vpp/denoise.py
+++ b/test/ffmpeg-qsv/vpp/denoise.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 

--- a/test/ffmpeg-qsv/vpp/hue.py
+++ b/test/ffmpeg-qsv/vpp/hue.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")

--- a/test/ffmpeg-qsv/vpp/mirroring.py
+++ b/test/ffmpeg-qsv/vpp/mirroring.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 

--- a/test/ffmpeg-qsv/vpp/rotation.py
+++ b/test/ffmpeg-qsv/vpp/rotation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 

--- a/test/ffmpeg-qsv/vpp/saturation.py
+++ b/test/ffmpeg-qsv/vpp/saturation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")

--- a/test/ffmpeg-qsv/vpp/scale.py
+++ b/test/ffmpeg-qsv/vpp/scale.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")

--- a/test/ffmpeg-qsv/vpp/sharpen.py
+++ b/test/ffmpeg-qsv/vpp/sharpen.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 

--- a/test/ffmpeg-qsv/vpp/transpose.py
+++ b/test/ffmpeg-qsv/vpp/transpose.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 

--- a/test/ffmpeg-vaapi/decode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/decode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 

--- a/test/ffmpeg-vaapi/decode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/decode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 

--- a/test/ffmpeg-vaapi/decode/12bit/hevc.py
+++ b/test/ffmpeg-vaapi/decode/12bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 

--- a/test/ffmpeg-vaapi/decode/av1.py
+++ b/test/ffmpeg-vaapi/decode/av1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 

--- a/test/ffmpeg-vaapi/decode/avc.py
+++ b/test/ffmpeg-vaapi/decode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 

--- a/test/ffmpeg-vaapi/decode/hevc.py
+++ b/test/ffmpeg-vaapi/decode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 

--- a/test/ffmpeg-vaapi/decode/jpeg.py
+++ b/test/ffmpeg-vaapi/decode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")

--- a/test/ffmpeg-vaapi/decode/mpeg2.py
+++ b/test/ffmpeg-vaapi/decode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")

--- a/test/ffmpeg-vaapi/decode/vc1.py
+++ b/test/ffmpeg-vaapi/decode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")

--- a/test/ffmpeg-vaapi/decode/vp8.py
+++ b/test/ffmpeg-vaapi/decode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 

--- a/test/ffmpeg-vaapi/decode/vp9.py
+++ b/test/ffmpeg-vaapi/decode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_ldb  = load_test_spec("hevc", "encode", "10bit", "ldb") #low delay b 10bit spec support

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp8", "encode")
 

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 

--- a/test/ffmpeg-vaapi/transcode/avc.py
+++ b/test/ffmpeg-vaapi/transcode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("avc", "transcode")
 

--- a/test/ffmpeg-vaapi/transcode/hevc.py
+++ b/test/ffmpeg-vaapi/transcode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("hevc", "transcode")
 

--- a/test/ffmpeg-vaapi/transcode/mpeg2.py
+++ b/test/ffmpeg-vaapi/transcode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("mpeg2", "transcode")
 

--- a/test/ffmpeg-vaapi/transcode/vc1.py
+++ b/test/ffmpeg-vaapi/transcode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("vc1", "transcode")
 

--- a/test/ffmpeg-vaapi/vpp/brightness.py
+++ b/test/ffmpeg-vaapi/vpp/brightness.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")

--- a/test/ffmpeg-vaapi/vpp/contrast.py
+++ b/test/ffmpeg-vaapi/vpp/contrast.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")

--- a/test/ffmpeg-vaapi/vpp/csc.py
+++ b/test/ffmpeg-vaapi/vpp/csc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 

--- a/test/ffmpeg-vaapi/vpp/deinterlace.py
+++ b/test/ffmpeg-vaapi/vpp/deinterlace.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(

--- a/test/ffmpeg-vaapi/vpp/denoise.py
+++ b/test/ffmpeg-vaapi/vpp/denoise.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 

--- a/test/ffmpeg-vaapi/vpp/hue.py
+++ b/test/ffmpeg-vaapi/vpp/hue.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")

--- a/test/ffmpeg-vaapi/vpp/mirroring.py
+++ b/test/ffmpeg-vaapi/vpp/mirroring.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 

--- a/test/ffmpeg-vaapi/vpp/rotation.py
+++ b/test/ffmpeg-vaapi/vpp/rotation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 

--- a/test/ffmpeg-vaapi/vpp/saturation.py
+++ b/test/ffmpeg-vaapi/vpp/saturation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")

--- a/test/ffmpeg-vaapi/vpp/scale.py
+++ b/test/ffmpeg-vaapi/vpp/scale.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")

--- a/test/ffmpeg-vaapi/vpp/sharpen.py
+++ b/test/ffmpeg-vaapi/vpp/sharpen.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 

--- a/test/ffmpeg-vaapi/vpp/transpose.py
+++ b/test/ffmpeg-vaapi/vpp/transpose.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.ffmpeg.vaapi.util import *
+from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 

--- a/test/gst-msdk/decode/10bit/hevc.py
+++ b/test/gst-msdk/decode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 

--- a/test/gst-msdk/decode/10bit/vp9.py
+++ b/test/gst-msdk/decode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 

--- a/test/gst-msdk/decode/12bit/hevc.py
+++ b/test/gst-msdk/decode/12bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 

--- a/test/gst-msdk/decode/12bit/vp9.py
+++ b/test/gst-msdk/decode/12bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
 

--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 

--- a/test/gst-msdk/decode/avc.py
+++ b/test/gst-msdk/decode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 

--- a/test/gst-msdk/decode/hevc.py
+++ b/test/gst-msdk/decode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 

--- a/test/gst-msdk/decode/jpeg.py
+++ b/test/gst-msdk/decode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")

--- a/test/gst-msdk/decode/mpeg2.py
+++ b/test/gst-msdk/decode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")

--- a/test/gst-msdk/decode/vc1.py
+++ b/test/gst-msdk/decode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")

--- a/test/gst-msdk/decode/vp8.py
+++ b/test/gst-msdk/decode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 

--- a/test/gst-msdk/decode/vp9.py
+++ b/test/gst-msdk/decode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("jpeg", "encode")
 spec_r2r = load_test_spec("jpeg", "encode", "r2r")

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("mpeg2", "encode")
 spec_r2r = load_test_spec("mpeg2", "encode", "r2r")

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 

--- a/test/gst-msdk/transcode/avc.py
+++ b/test/gst-msdk/transcode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
 spec = load_test_spec("avc", "transcode")
 

--- a/test/gst-msdk/transcode/hevc.py
+++ b/test/gst-msdk/transcode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
 spec = load_test_spec("hevc", "transcode")
 

--- a/test/gst-msdk/transcode/mpeg2.py
+++ b/test/gst-msdk/transcode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
 spec = load_test_spec("mpeg2", "transcode")
 

--- a/test/gst-msdk/transcode/vc1.py
+++ b/test/gst-msdk/transcode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
 spec = load_test_spec("vc1", "transcode")
 

--- a/test/gst-msdk/vpp/brightness.py
+++ b/test/gst-msdk/vpp/brightness.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")

--- a/test/gst-msdk/vpp/contrast.py
+++ b/test/gst-msdk/vpp/contrast.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")

--- a/test/gst-msdk/vpp/crop.py
+++ b/test/gst-msdk/vpp/crop.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "crop")
 

--- a/test/gst-msdk/vpp/csc.py
+++ b/test/gst-msdk/vpp/csc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 

--- a/test/gst-msdk/vpp/deinterlace.py
+++ b/test/gst-msdk/vpp/deinterlace.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(

--- a/test/gst-msdk/vpp/denoise.py
+++ b/test/gst-msdk/vpp/denoise.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 

--- a/test/gst-msdk/vpp/hue.py
+++ b/test/gst-msdk/vpp/hue.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")

--- a/test/gst-msdk/vpp/mirroring.py
+++ b/test/gst-msdk/vpp/mirroring.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 

--- a/test/gst-msdk/vpp/rotation.py
+++ b/test/gst-msdk/vpp/rotation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 

--- a/test/gst-msdk/vpp/saturation.py
+++ b/test/gst-msdk/vpp/saturation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")

--- a/test/gst-msdk/vpp/scale.py
+++ b/test/gst-msdk/vpp/scale.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "scale")
 spec_r2r = load_test_spec("vpp", "scale", "r2r")

--- a/test/gst-msdk/vpp/sharpen.py
+++ b/test/gst-msdk/vpp/sharpen.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 

--- a/test/gst-msdk/vpp/transpose.py
+++ b/test/gst-msdk/vpp/transpose.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.msdk.util import *
+from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 

--- a/test/gst-vaapi/decode/10bit/hevc.py
+++ b/test/gst-vaapi/decode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 

--- a/test/gst-vaapi/decode/12bit/hevc.py
+++ b/test/gst-vaapi/decode/12bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..decoder import DecoderTest
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 

--- a/test/gst-vaapi/decode/avc.py
+++ b/test/gst-vaapi/decode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 

--- a/test/gst-vaapi/decode/hevc.py
+++ b/test/gst-vaapi/decode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 

--- a/test/gst-vaapi/decode/jpeg.py
+++ b/test/gst-vaapi/decode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")

--- a/test/gst-vaapi/decode/mpeg2.py
+++ b/test/gst-vaapi/decode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")

--- a/test/gst-vaapi/decode/vc1.py
+++ b/test/gst-vaapi/decode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")

--- a/test/gst-vaapi/decode/vp8.py
+++ b/test/gst-vaapi/decode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 

--- a/test/gst-vaapi/decode/vp9.py
+++ b/test/gst-vaapi/decode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .decoder import DecoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_ldb  = load_test_spec("hevc", "encode", "10bit", "ldb") #low delay b 10bit spec support

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from .....lib import *
-from ...util import *
-from ..encoder import EncoderTest
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp8", "encode")
 

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .encoder import EncoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 

--- a/test/gst-vaapi/transcode/avc.py
+++ b/test/gst-vaapi/transcode/avc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("avc", "transcode")
 

--- a/test/gst-vaapi/transcode/hevc.py
+++ b/test/gst-vaapi/transcode/hevc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("hevc", "transcode")
 

--- a/test/gst-vaapi/transcode/mpeg2.py
+++ b/test/gst-vaapi/transcode/mpeg2.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("mpeg2", "transcode")
 

--- a/test/gst-vaapi/transcode/vc1.py
+++ b/test/gst-vaapi/transcode/vc1.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .transcoder import TranscoderTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
 spec = load_test_spec("vc1", "transcode")
 

--- a/test/gst-vaapi/vpp/brightness.py
+++ b/test/gst-vaapi/vpp/brightness.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")

--- a/test/gst-vaapi/vpp/contrast.py
+++ b/test/gst-vaapi/vpp/contrast.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")

--- a/test/gst-vaapi/vpp/crop.py
+++ b/test/gst-vaapi/vpp/crop.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "crop")
 

--- a/test/gst-vaapi/vpp/csc.py
+++ b/test/gst-vaapi/vpp/csc.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 

--- a/test/gst-vaapi/vpp/deinterlace.py
+++ b/test/gst-vaapi/vpp/deinterlace.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(

--- a/test/gst-vaapi/vpp/denoise.py
+++ b/test/gst-vaapi/vpp/denoise.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 

--- a/test/gst-vaapi/vpp/hue.py
+++ b/test/gst-vaapi/vpp/hue.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")

--- a/test/gst-vaapi/vpp/mirroring.py
+++ b/test/gst-vaapi/vpp/mirroring.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 

--- a/test/gst-vaapi/vpp/rotation.py
+++ b/test/gst-vaapi/vpp/rotation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 

--- a/test/gst-vaapi/vpp/saturation.py
+++ b/test/gst-vaapi/vpp/saturation.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")

--- a/test/gst-vaapi/vpp/scale.py
+++ b/test/gst-vaapi/vpp/scale.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")

--- a/test/gst-vaapi/vpp/sharpen.py
+++ b/test/gst-vaapi/vpp/sharpen.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 

--- a/test/gst-vaapi/vpp/transpose.py
+++ b/test/gst-vaapi/vpp/transpose.py
@@ -5,8 +5,8 @@
 ###
 
 from ....lib import *
-from ..util import *
-from .vpp import VppTest
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 


### PR DESCRIPTION
Moved common middleware code to top-level lib to allow for better code reuse (e.g. external extensions).