### PR TITLE
ffmpeg-qsv: use '-hwaccel_output_format qsv' for decode

### DIFF
--- a/test/ffmpeg-qsv/decode/decoder.py
+++ b/test/ffmpeg-qsv/decode/decoder.py
@@ -18,7 +18,7 @@ class DecoderTest(slash.Test):
   def call_ffmpeg(self):
     self.output = call(
       "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
-      " -v verbose -c:v {ffdecoder} -i {source}"
+      " -hwaccel_output_format qsv -v verbose -c:v {ffdecoder} -i {source}"
       " -vf 'hwdownload,format={hwformat}'"
       " -pix_fmt {mformat} -f rawvideo -vsync passthrough"
       " -autoscale 0 -vframes {frames} -y {decoded}".format(**vars(self)))

--- a/test/ffmpeg-qsv/encode/encoder.py
+++ b/test/ffmpeg-qsv/encode/encoder.py
@@ -100,7 +100,8 @@ class EncoderTest(slash.Test):
   def call_ffmpeg(self, iopts, oopts):
     self.output = call(
       "ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv"
-      " -v verbose {iopts} {oopts}".format(iopts = iopts, oopts = oopts))
+      " -hwaccel_output_format qsv -v verbose"
+      " {iopts} {oopts}".format(iopts = iopts, oopts = oopts))
 
   def validate_caps(self):
     self.hwformat = map_best_hw_format(self.format, self.caps["fmts"])


### PR DESCRIPTION
Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>