### PR TITLE
lib/gstreamer: use chroma-mode=none for videoconvert

### DIFF
--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -20,7 +20,7 @@ class DecoderTest(slash.Test):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
-      " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
+      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -19,7 +19,7 @@ class EncoderTest(slash.Test):
     if vars(self).get("fps", None) is not None:
       opts += " framerate={fps}"
 
-    opts += " ! videoconvert dither=0 ! video/x-raw,format={hwformat}"
+    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
 
     return opts
 
@@ -182,7 +182,7 @@ class EncoderTest(slash.Test):
   def check_metrics(self):
     iopts = "filesrc location={encoded} ! {gstdecoder}"
     oopts = (
-      "videoconvert dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
+      "videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
       " dump-output=true qos=false dump-location={decoded}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -54,11 +54,11 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(

--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -26,7 +26,7 @@ class VppTest(slash.Test):
 
     if self.vpp_element not in ["csc", "deinterlace"]:
       if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert dither=0 ! video/x-raw,format={ihwformat}"
+        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={ihwformat}"
 
     return opts
 
@@ -61,7 +61,7 @@ class VppTest(slash.Test):
         opts += ",width={width},height={height}"
 
       if self.ofmt != self.ohwformat:
-        opts += " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
+        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
     else:
       opts += " ! video/x-raw,format={ohwformat}"
 

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -19,7 +19,7 @@ class DecoderTest(slash.Test):
     call(
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
-      " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
+      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
       " ! checksumsink2 file-checksum=false qos=false"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -18,7 +18,7 @@ class EncoderTest(slash.Test):
     if vars(self).get("fps", None) is not None:
       opts += " framerate={fps}"
 
-    opts += " ! videoconvert dither=0 ! video/x-raw,format={hwformat}"
+    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
 
     return opts
 
@@ -179,7 +179,7 @@ class EncoderTest(slash.Test):
   def check_metrics(self):
     iopts = "filesrc location={encoded} ! {gstdecoder}"
     oopts = (
-      " videoconvert dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
+      " videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
       " dump-output=true qos=false dump-location={decoded}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -53,11 +53,11 @@ class TranscoderTest(slash.Test):
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc tune=none low-delay-b=1 ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
@@ -200,7 +200,7 @@ class TranscoderTest(slash.Test):
     self.srcyuv = get_media()._test_artifact(
       "src_{case}.yuv".format(**vars(self)))
     opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
-    opts += " ! videoconvert dither=0 ! video/x-raw,format=I420"
+    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420"
     opts += " ! checksumsink2 file-checksum=false qos=false"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"
@@ -228,7 +228,7 @@ class TranscoderTest(slash.Test):
         yuv = get_media()._test_artifact(
           "{}_{}_{}.yuv".format(self.case, n, channel))
         iopts = "filesrc location={} ! {}"
-        oopts =  "{} ! videoconvert dither=0 ! video/x-raw,format=I420"
+        oopts =  "{} ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420"
         oopts += " ! checksumsink2 file-checksum=false qos=false"
         oopts += " frame-checksum=false plane-checksum=false dump-output=true"
         oopts += " dump-location={}"

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -25,7 +25,7 @@ class VppTest(slash.Test):
 
     if self.vpp_element not in ["csc", "deinterlace"]:
       if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert dither=0 ! video/x-raw,format={ihwformat}"
+        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={ihwformat}"
 
     return opts
 
@@ -59,7 +59,7 @@ class VppTest(slash.Test):
       opts += ",width={width},height={height}"
 
     if self.ofmt != self.ohwformat and self.vpp_element not in ["csc"]:
-      opts += " ! videoconvert dither=0 ! video/x-raw,format={mformatu}"
+      opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
 
     opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
     opts += " plane-checksum=false dump-output=true dump-location={ofile}"


### PR DESCRIPTION
Since gst-plugins-base@660b5e4a the chroma-site is
no longer assumed by the base decoder.  This changed
the chroma resampling chosen by videoconvert in many
cases because gst-vaapi and gst-msdk decoders no longer
provide chroma-site setting on their src caps.

Thus, disable chroma resampling on videoconvert to
workaround the issues reported here:

https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/-/issues/284
https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/issues/1456

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>