### PR TITLE
Added ffmpeg-vaapi hevc-12 422 support

### DIFF
--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -45,6 +45,7 @@ def get_supported_format_map():
     "ARGB"  : "rgb32",
     "BGRA"  : "bgra",
     "Y210"  : "y210",
+    "Y212"  : "y212",
     "Y410"  : "y410",
     "AYUV"  : "0yuv", # 0yuv is same as microsoft AYUV except the alpha channel
   }


### PR DESCRIPTION
ffmpeg-vaapi hevc-12bit 422 decode support

Signed-off-by: Luo Focus <focus.luo@intel.com>