### PR TITLE
Remove low delay B specializations

### DIFF
--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -24,8 +24,8 @@ caps = dict(
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
-    #hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]), #need enabled until VME HEVC P frame encode ready on Gen12+
-    #hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]), #need enabled until VME HEVC P frame encode ready on Gen12+
+    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
@@ -34,10 +34,6 @@ caps = dict(
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-  ),
-  vme_lowdelayb = dict(
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/ICL/iHD
+++ b/lib/caps/ICL/iHD
@@ -36,10 +36,6 @@ caps = dict(
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
-  vme_lowdelayb = dict(
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-  ),
   vpp    = dict(
     # brightness, contrast, hue and saturation
     procamp     = dict(

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -26,8 +26,8 @@ caps = dict(
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
-    #hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]), #need enabled until VME HEVC P frame encode ready on Gen12+
-    #hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]), #need enabled until VME HEVC P frame encode ready on Gen12+
+    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
@@ -36,10 +36,6 @@ caps = dict(
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-  ),
-  vme_lowdelayb = dict(
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -26,8 +26,8 @@ caps = dict(
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
-    #hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]), #need enabled until VME HEVC P frame encode ready on Gen12+
-    #hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]), #need enabled until VME HEVC P frame encode ready on Gen12+
+    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
@@ -36,10 +36,6 @@ caps = dict(
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-  ),
-  vme_lowdelayb = dict(
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -54,8 +54,6 @@ class EncoderTest(slash.Test):
       opts += " -refs {refs}"
     if vars(self).get("lowpower", None) is not None:
       opts += " -low_power {lowpower}"
-    if vars(self).get("lowdelayb", None) is not None:
-      opts += " -gpb {lowdelayb}"
     if vars(self).get("ladepth", None) is not None:
       opts += " -look_ahead 1"
       opts += " -look_ahead_depth {ladepth}"

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -22,10 +22,6 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
         hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc_qsv"), "hevc_qsv"),
       ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
-        hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc_qsv"), "hevc_qsv"),
-      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_ffmpeg_decoder("mpeg2_qsv"), "mpeg2_qsv"),
@@ -47,10 +43,6 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
         hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_qsv"), "hevc_qsv"),
-      ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
-        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_ffmpeg_encoder("hevc_qsv"), "hevc_qsv -gpb 1"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),
@@ -103,7 +95,6 @@ class TranscoderTest(slash.Test):
       "avc"            : "h264",
       "hevc"           : "h265",
       "hevc-8"         : "h265",
-      "hevc-8-vme-ldb" : "h265",
       "mpeg2"          : "m2v",
       "mjpeg"          : "mjpeg",
     }.get(codec, "???")

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -66,6 +66,10 @@ class EncoderTest(slash.Test):
       self.level /= 10.0
       opts += " -level {level}"
 
+    # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
+    if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
+      opts += " -b_strategy 1"
+
     opts += " -vframes {frames} -y {encoded}"
 
     return opts

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -42,7 +42,8 @@ class TranscoderTest(slash.Test):
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
-        hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi"),
+        # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
+        hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi" if get_media()._get_gpu_gen() < 11 else "hevc_vaapi -b_strategy 1"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -22,10 +22,6 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
         hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
       ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
-        hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
-      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
@@ -47,10 +43,6 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
         hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi"),
-      ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
-        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi -b_strategy 1"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),
@@ -103,7 +95,6 @@ class TranscoderTest(slash.Test):
       "avc"            : "h264",
       "hevc"           : "h265",
       "hevc-8"         : "h265",
-      "hevc-8-vme-ldb" : "h265",
       "mpeg2"          : "m2v",
       "mjpeg"          : "mjpeg",
     }.get(codec, "???")

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -23,10 +23,6 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("msdkh265dec"), "h265parse ! msdkh265dec"),
       ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
-        hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("msdkh265dec"), "h265parse ! msdkh265dec"),
-      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avdec_mpeg2video"), "mpegvideoparse ! avdec_mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("msdkmpeg2dec"), "mpegvideoparse ! msdkmpeg2dec"),
@@ -56,10 +52,6 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
-      ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
-        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
@@ -112,7 +104,6 @@ class TranscoderTest(slash.Test):
       "avc"            : "h264",
       "hevc"           : "h265",
       "hevc-8"         : "h265",
-      "hevc-8-vme-ldb" : "h265",
       "mpeg2"          : "m2v",
       "mjpeg"          : "mjpeg",
     }.get(codec, "???")

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -57,8 +57,6 @@ class EncoderTest(slash.Test):
       opts += " tune="
       opts += "low-power" if self.lowpower else "none"
 
-    if vars(self).get("lowdelayb",False):
-      opts += " low-delay-b=1"
     if vars(self).get("loopshp", None) is not None:
       opts += " sharpness-level={loopshp}"
     if vars(self).get("looplvl", None) is not None:

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -22,10 +22,6 @@ class TranscoderTest(slash.Test):
         sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vaapih265dec"), "h265parse ! vaapih265dec"),
       ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("avdec_h265"), "h265parse ! avdec_h265"),
-        hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vaapih265dec"), "h265parse ! vaapih265dec"),
-      ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avdec_mpeg2video"), "mpegvideoparse ! avdec_mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("vaapimpeg2dec"), "mpegvideoparse ! vaapimpeg2dec"),
@@ -55,10 +51,6 @@ class TranscoderTest(slash.Test):
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
-      ),
-      "hevc-8-vme-ldb" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
-        hw = (platform.get_caps("vme_lowdelayb", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc tune=none low-delay-b=1 ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
@@ -111,7 +103,6 @@ class TranscoderTest(slash.Test):
       "avc"            : "h264",
       "hevc"           : "h265",
       "hevc-8"         : "h265",
-      "hevc-8-vme-ldb" : "h265",
       "mpeg2"          : "m2v",
       "mjpeg"          : "mjpeg",
     }.get(codec, "???")

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -188,55 +188,6 @@ gen_hevc_cqp_lp_parameters = gen_avc_cqp_lp_parameters
 gen_hevc_cbr_lp_parameters = gen_avc_cbr_lp_parameters
 gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
 
-def gen_hevc_cqp_ldb_variants(spec, profiles):
-  for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cqp_ldb", [])):
-      uprofile = variant.get("profile", None)
-      cprofiles = [uprofile] if uprofile else profiles
-      for profile in cprofiles:
-        yield [
-          case, variant["gop"], variant["slices"], variant["bframes"],
-          variant["qp"], variant["quality"], profile
-        ]
-
-def gen_hevc_cqp_ldb_parameters(spec, profiles):
-  keys = ("case", "gop", "slices", "bframes", "qp", "quality", "profile")
-  params = gen_hevc_cqp_ldb_variants(spec, profiles)
-  return keys, params
-
-def gen_hevc_cbr_ldb_variants(spec, profiles):
-  for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cbr_ldb", [])):
-      uprofile = variant.get("profile", None)
-      cprofiles = [uprofile] if uprofile else profiles
-      for profile in cprofiles:
-        yield [
-          case, variant["gop"], variant["slices"], variant["bframes"],
-          variant["bitrate"], variant.get("fps", 30), profile
-        ]
-
-def gen_hevc_cbr_ldb_parameters(spec, profiles):
-  keys = ("case", "gop", "slices", "bframes", "bitrate", "fps", "profile")
-  params = gen_hevc_cbr_ldb_variants(spec, profiles)
-  return keys, params
-
-def gen_hevc_vbr_ldb_variants(spec, profiles):
-  for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("vbr_ldb", [])):
-      uprofile = variant.get("profile", None)
-      cprofiles = [uprofile] if uprofile else profiles
-      for profile in cprofiles:
-        yield [
-          case, variant["gop"], variant["slices"], variant["bframes"],
-          variant["bitrate"], variant.get("fps", 30), variant.get("quality", 4),
-          variant.get("refs", 1), profile
-        ]
-
-def gen_hevc_vbr_ldb_parameters(spec, profiles):
-  keys = ("case", "gop", "slices", "bframes", "bitrate", "fps", "quality", "refs", "profile")
-  params = gen_hevc_vbr_ldb_variants(spec, profiles)
-  return keys, params
-
 def gen_mpeg2_cqp_variants(spec):
   for case, params in spec.items():
     variants = copy.deepcopy(params.get("cqp", None))

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -9,7 +9,6 @@ from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
-spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class HEVC8EncoderTest(EncoderTest):
@@ -89,30 +88,6 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cqp_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      case         = case,
-      gop          = gop,
-      qp           = qp,
-      lowdelayb    = 1,
-      quality      = quality,
-      profile      = profile,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
-    self.encode()
-
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -179,32 +154,6 @@ class cbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-class cbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate,
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
@@ -277,32 +226,4 @@ class vbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-class vbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate * 2, # target percentage 50%
-      minrate      = bitrate,
-      profile      = profile,
-      quality      = quality,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -9,7 +9,6 @@ from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
-spec_ldb  = load_test_spec("hevc", "encode", "10bit", "ldb") #low delay b 10bit spec support
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 class HEVC10EncoderTest(EncoderTest):
@@ -89,30 +88,6 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-#hevc 10bit VME Low delay b cqp encode
-class cqp_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      case         = case,
-      gop          = gop,
-      lowdelayb    = 1,
-      profile      = profile,
-      qp           = qp,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
-    self.encode()
-
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -175,32 +150,6 @@ class cbr_lp(HEVC10EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#hevc 10bit VME Low delay b cbr encode
-class cbr_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      minrate      = bitrate,
-      maxrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC10EncoderTest):
@@ -269,32 +218,4 @@ class vbr_lp(HEVC10EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#hevc 10bit VME Low delay b vbr encode
-class vbr_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate * 2, # target percentage 50%
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -9,7 +9,6 @@ from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
-spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class HEVC8EncoderTest(EncoderTest):
@@ -89,30 +88,6 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-#vme low delay b cqp
-class cqp_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      case         = case,
-      gop          = gop,
-      qp           = qp,
-      lowdelayb    = 1,
-      quality      = quality,
-      profile      = profile,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
-    self.encode()
-
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile, level=None):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -185,32 +160,6 @@ class cbr_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-#vme low delay b cbr
-class cbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate,
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
-    self.encode()
-
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -277,32 +226,4 @@ class vbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#vme low delay b vbr
-class vbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate * 2, # target percentage 50%
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -10,7 +10,6 @@ from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
-spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support
 
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
@@ -89,30 +88,6 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cqp_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      case         = case,
-      gop          = gop,
-      qp           = qp,
-      lowdelayb    = 1,
-      quality      = quality,
-      profile      = profile,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
-    self.encode()
-
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -177,32 +152,6 @@ class cbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-class cbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate,
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
@@ -275,33 +224,4 @@ class vbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-class vbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      # target percentage 50%
-      maxrate      = bitrate * 2,
-      minrate      = bitrate,
-      profile      = profile,
-      quality      = quality,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -9,7 +9,6 @@ from .....lib.gstreamer.vaapi.util import *
 from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
-spec_ldb  = load_test_spec("hevc", "encode", "10bit", "ldb") #low delay b 10bit spec support
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 class HEVC10EncoderTest(EncoderTest):
@@ -67,7 +66,6 @@ class cqp_lp(HEVC10EncoderTest):
       gop       = gop,
       qp        = qp,
       lowpower  = True,
-      lowdelayb = 1,
       quality   = quality,
       profile   = profile,
       rcmode    = "cqp",
@@ -88,31 +86,6 @@ class cqp_lp(HEVC10EncoderTest):
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#hevc 10bit VME Low delay b cqp encode
-class cqp_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes = bframes,
-      case         = case,
-      gop          = gop,
-      qp           = qp,
-      lowdelayb    = 1,
-      quality      = quality,
-      profile      = profile,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
 class cbr(HEVC10EncoderTest):
@@ -158,7 +131,6 @@ class cbr_lp(HEVC10EncoderTest):
       fps       = fps,
       gop       = gop,
       lowpower  = True,
-      lowdelayb = 1,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
@@ -180,33 +152,6 @@ class cbr_lp(HEVC10EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#hevc 8bit vme low delay b encode cbr encode
-class cbr_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate,
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC10EncoderTest):
@@ -256,7 +201,6 @@ class vbr_lp(HEVC10EncoderTest):
       fps       = fps,
       gop       = gop,
       lowpower  = True,
-      lowdelayb = 1,
       ## target percentage 70% (hard-coded in gst-vaapi)
       ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate   = int(bitrate / 0.7),
@@ -282,35 +226,4 @@ class vbr_lp(HEVC10EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#hevc 10bit vme low delay b vbr encode
-class vbr_ldb(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_10")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      ## target percentage 70% (hard-coded in gst-vaapi)
-      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
-      maxrate      = int(bitrate / 0.7),
-      minrate      = bitrate,
-      profile      = profile,
-      quality      = quality,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main10']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -9,7 +9,6 @@ from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
-spec_ldb  = load_test_spec("hevc", "encode", "8bit", "ldb") #low delay b spec support
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 class HEVC8EncoderTest(EncoderTest):
@@ -67,7 +66,6 @@ class cqp_lp(HEVC8EncoderTest):
       gop          = gop,
       qp           = qp,
       lowpower     = True,
-      lowdelayb    = 1,
       quality      = quality,
       profile      = profile,
       rcmode       = "cqp",
@@ -88,31 +86,6 @@ class cqp_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#VME Low delay b
-class cqp_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      case         = case,
-      gop          = gop,
-      qp           = qp,
-      lowdelayb    = 1,
-      quality      = quality,
-      profile      = profile,
-      rcmode       = "cqp",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cqp_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
 class cbr(HEVC8EncoderTest):
@@ -158,7 +131,6 @@ class cbr_lp(HEVC8EncoderTest):
       fps          = fps,
       gop          = gop,
       lowpower     = True,
-      lowdelayb    = 1,
       maxrate      = bitrate,
       minrate      = bitrate,
       profile      = profile,
@@ -180,33 +152,6 @@ class cbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#vme cbr mode low delay b encode
-class cbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      maxrate      = bitrate,
-      minrate      = bitrate,
-      profile      = profile,
-      rcmode       = "cbr",
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_cbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
 class vbr(HEVC8EncoderTest):
@@ -256,7 +201,6 @@ class vbr_lp(HEVC8EncoderTest):
       fps          = fps,
       gop          = gop,
       lowpower     = True,
-      lowdelayb    = 1,
       ## target percentage 70% (hard-coded in gst-vaapi)
       ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate      = int(bitrate / 0.7),
@@ -282,35 +226,4 @@ class vbr_lp(HEVC8EncoderTest):
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
-    self.encode()
-
-#VME VBR low delay b encode
-class vbr_ldb(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vme_lowdelayb", "hevc_8")
-    vars(self).update(tspec[case].copy())
-    vars(self).update(
-      bframes      = bframes,
-      bitrate      = bitrate,
-      case         = case,
-      fps          = fps,
-      gop          = gop,
-      lowdelayb    = 1,
-      ## target percentage 70% (hard-coded in gst-vaapi)
-      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
-      maxrate      = int(bitrate / 0.7),
-      minrate      = bitrate,
-      profile      = profile,
-      quality      = quality,
-      rcmode       = "vbr",
-      refs         = refs,
-      slices       = slices,
-    )
-
-  @slash.requires(*platform.have_caps("vme_lowdelayb", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
-  @slash.parametrize(*gen_hevc_vbr_ldb_parameters(spec_ldb, ['main']))
-  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_ldb, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()


### PR DESCRIPTION
HEVCe LDB is/will be the default for all
vaapi/msdk plugins.

NOTE: HEVCe LDB for ffmpeg-vaapi is only in cartwheel
at the moment.  It doesn't select LDB by default
yet, but a patch will be submitted to enable it as
the default soon.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>