### PR TITLE
ffmpeg-vaapi added vp9-12bit 444 decode support

### DIFF
--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -20,7 +20,7 @@ caps = dict(
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-    vp9_12  = dict(maxres = res8k , fmts = ["P012"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
   ),
   encode  = dict(

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -20,7 +20,7 @@ caps = dict(
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-    vp9_12  = dict(maxres = res8k , fmts = ["P012"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
   ),
   encode  = dict(

--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -47,6 +47,7 @@ def get_supported_format_map():
     "Y210"  : "y210",
     "Y212"  : "y212",
     "Y410"  : "y410",
+    "Y412"  : "y412",
     "AYUV"  : "0yuv", # 0yuv is same as microsoft AYUV except the alpha channel
   }
 


### PR DESCRIPTION
ffmpeg-vaapi added vp9-12bit 444 decode support