### PR TITLE
Support test skip for missing features in decoder caps (and define SCC feature)

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -11,6 +11,7 @@ from .metrics import *
 from .parameters import *
 from .platform import *
 from .system import *
+from .util import *
 
 import itertools
 import os

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -15,7 +15,11 @@ caps = dict(
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vc1     = dict(maxres = res4k , fmts = ["NV12"]),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "YUY2", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True),
+    ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -15,7 +15,11 @@ caps = dict(
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vc1     = dict(maxres = res4k , fmts = ["NV12"]),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "YUY2", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True),
+    ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -15,7 +15,11 @@ caps = dict(
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vc1     = dict(maxres = res4k , fmts = ["NV12"]),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
-    hevc_8  = dict(maxres = res8k , fmts = ["NV12", "YUY2", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True),
+    ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -41,6 +41,8 @@ class DecoderTest(slash.Test):
         format_value(
           "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
 
+    skip_test_if_missing_features(self)
+
   def decode(self):
     self.validate_caps()
 

--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -44,6 +44,8 @@ class DecoderTest(slash.Test):
       slash.skip_test(
         "ffmpeg.{format} format not supported".format(**vars(self)))
 
+    skip_test_if_missing_features(self)
+
   def decode(self):
     self.validate_caps()
 

--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -48,6 +48,8 @@ class DecoderTest(slash.Test):
       slash.skip_test(
         "gstreamer.{format} not supported".format(**vars(self)))
 
+    skip_test_if_missing_features(self)
+
   def decode(self):
     self.validate_caps()
 

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -47,6 +47,8 @@ class DecoderTest(slash.Test):
       slash.skip_test(
         "gstreamer.{format} not supported".format(**vars(self)))
 
+    skip_test_if_missing_features(self)
+
   def decode(self):
     self.validate_caps()
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,0 +1,16 @@
+###
+### Copyright (C) 2018-2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .parameters import format_value
+import slash
+
+def skip_test_if_missing_features(test):
+  for feature in vars(test).get("features", list()):
+    if not test.caps.get("features", dict()).get(feature, False):
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.feature({feature}) not supported",
+          **vars(test), feature = feature))


### PR DESCRIPTION
    lib: support test skip for missing features in decoders
    
    Some test cases require extra codec features based on platform
    capabilities.
    
    This adds support to decoders to allow test config and
    platform caps to match arbitrary features required for the
    test case to run.  If no match, then the test case can be
    skipped.
    
    For example, in the test case specification the user can define
    "features = ['xyz', 'abc']" to enable the case on platforms
    that only have 'xyz' and 'abc' features defined in the
    platform capabilities file (i.e. in lib/caps/..).
    
    To declare a set of supported/unsupported codec features in the
    platform caps, we can define for example:
    
     "features = dict(xyz = True, abc = True, other = False)"
    
    ...where True means the feature is supported and False means
    the feature is unsupported.  A feature is unsupported by default,
    if the feature is not defined in the dict of features.

    Finally, define scc as supported hevc8 feature on gen12
