### PR TITLE
gst-vaapi/msdk add .av1 file extension support

### DIFF
--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -23,7 +23,7 @@ class default(DecoderTest):
   def test(self, case):
     vars(self).update(spec[case].copy())
 
-    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
+    dxmap = {".ivf" : "ivfparse", ".av1" : "ivfparse", ".webm" : "matroskademux"}
     ext = os.path.splitext(self.source)[1]
     assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
 

--- a/test/gst-vaapi/decode/av1.py
+++ b/test/gst-vaapi/decode/av1.py
@@ -23,7 +23,7 @@ class default(DecoderTest):
   def test(self, case):
     vars(self).update(spec[case].copy())
 
-    dxmap = {".ivf" : "ivfparse", ".webm" : "matroskademux"}
+    dxmap = {".ivf" : "ivfparse", ".av1" : "ivfparse", ".webm" : "matroskademux"}
     ext = os.path.splitext(self.source)[1]
     assert ext in dxmap.keys(), "Unrecognized source file extension {}".format(ext)
 


### PR DESCRIPTION
gst-vaapi/msdk add .av1 file extension support
high resolution av1 decode will include .av1 file extension