### PR TITLE
gst: use eos-after in checksumsink2

### DIFF
--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -21,7 +21,7 @@ class DecoderTest(slash.Test):
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
       " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false"
+      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))
 

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -186,7 +186,7 @@ class EncoderTest(slash.Test):
     oopts = (
       "videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
-      " dump-output=true qos=false dump-location={decoded}")
+      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
 
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -194,7 +194,7 @@ class TranscoderTest(slash.Test):
     self.srcyuv = get_media()._test_artifact(
       "src_{case}.yuv".format(**vars(self)))
     opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
-    opts += " ! checksumsink2 file-checksum=false qos=false"
+    opts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"
 
@@ -222,12 +222,12 @@ class TranscoderTest(slash.Test):
           "{}_{}_{}.yuv".format(self.case, n, channel))
         iopts = "filesrc location={} ! {}"
         oopts = self.get_vpp_scale(self.width, self.height, "hw")
-        oopts += " ! checksumsink2 file-checksum=false qos=false"
+        oopts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
         oopts += " frame-checksum=false plane-checksum=false dump-output=true"
         oopts += " dump-location={}"
         self.call_gst(
           iopts.format(encoded, self.get_decoder(output["codec"], "hw")),
-          oopts.format(yuv))
+          oopts.format(yuv, frames = self.frames))
         self.check_metrics(yuv, refctx = [(n, channel)])
         get_media()._purge_test_artifact(yuv)
 

--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -66,7 +66,7 @@ class VppTest(slash.Test):
       opts += " ! video/x-raw,format={ohwformat}"
 
     opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
-    opts += " plane-checksum=false dump-output=true dump-location={ofile}"
+    opts += " plane-checksum=false dump-output=true dump-location={ofile} eos-after={frames}"
 
     return opts
 

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -20,7 +20,7 @@ class DecoderTest(slash.Test):
       "gst-launch-1.0 -vf filesrc location={source}"
       " ! {gstdecoder}"
       " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false"
+      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
       " frame-checksum=false plane-checksum=false dump-output=true"
       " dump-location={decoded}".format(**vars(self)))
 

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -181,7 +181,7 @@ class EncoderTest(slash.Test):
     oopts = (
       " videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
       " file-checksum=false frame-checksum=false plane-checksum=false"
-      " dump-output=true qos=false dump-location={decoded}")
+      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
 
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -192,7 +192,7 @@ class TranscoderTest(slash.Test):
       "src_{case}.yuv".format(**vars(self)))
     opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
     opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420"
-    opts += " ! checksumsink2 file-checksum=false qos=false"
+    opts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={srcyuv}"
 
@@ -220,13 +220,13 @@ class TranscoderTest(slash.Test):
           "{}_{}_{}.yuv".format(self.case, n, channel))
         iopts = "filesrc location={} ! {}"
         oopts =  "{} ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420"
-        oopts += " ! checksumsink2 file-checksum=false qos=false"
+        oopts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
         oopts += " frame-checksum=false plane-checksum=false dump-output=true"
         oopts += " dump-location={}"
 
         self.call_gst(
           iopts.format(encoded, self.get_decoder(output["codec"], "hw")),
-          oopts.format(self.get_vpp_scale(self.width, self.height, "hw"), yuv))
+          oopts.format(self.get_vpp_scale(self.width, self.height, "hw"), yuv, frames = self.frames))
 
         self.check_metrics(yuv, refctx = [(n, channel)])
         get_media()._purge_test_artifact(yuv)

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -62,7 +62,7 @@ class VppTest(slash.Test):
       opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
 
     opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
-    opts += " plane-checksum=false dump-output=true dump-location={ofile}"
+    opts += " plane-checksum=false dump-output=true dump-location={ofile} eos-after={frames}"
 
     return opts
 


### PR DESCRIPTION
Depends on https://github.com/intel-media-ci/gst-checksumsink/pull/1

This allows us to force pipelines to stop processing more
frames when the input stream contains more frames than requested
by the test case.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>