### PR TITLE
Update the command  for av1 decoding.

### DIFF
--- a/test/gst-msdk/decode/10bit/av1.py
+++ b/test/gst-msdk/decode/10bit/av1.py
@@ -29,6 +29,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkav1dec".format(dxmap[ext]),
+      gstdecoder  = "{} ! av1parse ! msdkav1dec".format(dxmap[ext]),
     )
     self.decode()

--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -29,6 +29,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkav1dec".format(dxmap[ext]),
+      gstdecoder  = "{} ! av1parse ! msdkav1dec".format(dxmap[ext]),
     )
     self.decode()

--- a/test/gst-vaapi/decode/10bit/av1.py
+++ b/test/gst-vaapi/decode/10bit/av1.py
@@ -29,6 +29,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapiav1dec".format(dxmap[ext]),
+      gstdecoder  = "{} ! av1parse ! vaapiav1dec".format(dxmap[ext]),
     )
     self.decode()

--- a/test/gst-vaapi/decode/av1.py
+++ b/test/gst-vaapi/decode/av1.py
@@ -29,6 +29,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapiav1dec".format(dxmap[ext]),
+      gstdecoder  = "{} ! av1parse ! vaapiav1dec".format(dxmap[ext]),
     )
     self.decode()


### PR DESCRIPTION
ivfparse is actually a demuxer, and av1parse is required after ivfparse.