### PR TITLE
Caps: add vp8 dec support define on TGL and TGL relative platforms

### DIFF
--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -22,6 +22,7 @@ caps = dict(
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
+    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -22,6 +22,7 @@ caps = dict(
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
+    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),


### PR DESCRIPTION
Only TGL and TGL relative refresh platforms (Such as TGL/RKL and ADL) support vp8 dec features.
Based on iHD side, google requires the VP8 dec feature support, so iHD add vp8 dec feature back on TGL relative platforms.