### PR TITLE
ffmpeg-vaapi: detect unsupported AV1d HW accel

### DIFF
--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -77,5 +77,14 @@ class DecoderTest(slash.Test):
       "hwaccel initialisation returned error", self.output, re.MULTILINE)
     assert m is None, "Failed to use hardware decode"
 
+    # AV1d specific (checked here to ensure we cover all bit-depth tests for AV1d,
+    # current and future).
+    #
+    # Don't allow false success if ffmpeg falls back to a SW alternative... it
+    # clearly defeats the purpose of our test.
+    m = re.search(
+      "Your platform doesn't suppport hardware accelerated AV1 decoding", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+
   def check_metrics(self):
     check_metric(**vars(self))


### PR DESCRIPTION
Interestingly, I'm seeing the "unsupported HW accel" in test
case logs on platforms that we expect to do HW AV1d.  This
debug message indicates that we are not getting HW accelerated
AV1d path and that ffmpeg just falls back to SW decode and
succeeds.

Thus, don't allow the test case to pass if HW accel AV1d
can't be achieved!

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>