### PR TITLE
Caps: Gen12 platforms added main still dec feature

### DIFF
--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -18,7 +18,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "YUY2", "AYUV"],
-      features  = dict(scc = True),
+      features  = dict(scc = True, mainstill = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -18,7 +18,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "YUY2", "AYUV"],
-      features  = dict(scc = True),
+      features  = dict(scc = True, mainstill = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -18,7 +18,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "YUY2", "AYUV"],
-      features  = dict(scc = True),
+      features  = dict(scc = True, mainstill = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),

--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -18,7 +18,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "YUY2", "AYUV"],
-      features  = dict(scc = True),
+      features  = dict(scc = True, mainstill = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -18,7 +18,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "YUY2", "AYUV"],
-      features  = dict(scc = True),
+      features  = dict(scc = True, mainstill = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),


### PR DESCRIPTION
Gen12 platforms added hevc main still dec feature support

Signed-off-by: Luo Focus <focus.luo@intel.com>