### PR TITLE
Caps: VP8 dec only support on TGL of Gen12

### DIFF
--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -22,7 +22,6 @@ caps = dict(
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
-    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -22,7 +22,6 @@ caps = dict(
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
     hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
-    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),


### PR DESCRIPTION
For Gen12: the latest iHD only support vp8 dec
on TGL platform
https://github.com/intel/media-driver

Signed-off-by: Luo Focus <focus.luo@intel.com>