### PR TITLE
test/decode: move requires to class level

### DIFF
--- a/test/ffmpeg-qsv/decode/10bit/av1.py
+++ b/test/ffmpeg-qsv/decode/10bit/av1.py
@@ -10,6 +10,8 @@ from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_10"))
+@slash.requires(*have_ffmpeg_decoder("av1_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_10"))
-  @slash.requires(*have_ffmpeg_decoder("av1_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/decode/10bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/decode/10bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_10"))
-  @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/12bit/hevc.py
+++ b/test/ffmpeg-qsv/decode/12bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_12"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_12"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/12bit/vp9.py
+++ b/test/ffmpeg-qsv/decode/12bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_12"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_12"))
-  @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/av1.py
+++ b/test/ffmpeg-qsv/decode/av1.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_8"))
+@slash.requires(*have_ffmpeg_decoder("av1_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_8"))
-  @slash.requires(*have_ffmpeg_decoder("av1_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/avc.py
+++ b/test/ffmpeg-qsv/decode/avc.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_ffmpeg_decoder("h264_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/hevc.py
+++ b/test/ffmpeg-qsv/decode/hevc.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/jpeg.py
+++ b/test/ffmpeg-qsv/decode/jpeg.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 spec      = load_test_spec("jpeg", "decode")
 spec_r2r  = load_test_spec("jpeg", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "jpeg"))
+@slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -25,15 +27,11 @@ class default(DecoderTest):
     vars(self).update(tspec[case].copy())
     vars(self).update(case = case)
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/mpeg2.py
+++ b/test/ffmpeg-qsv/decode/mpeg2.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 spec      = load_test_spec("mpeg2", "decode")
 spec_r2r  = load_test_spec("mpeg2", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -25,15 +27,11 @@ class default(DecoderTest):
     vars(self).update(tspec[case].copy())
     vars(self).update(case = case)
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/vc1.py
+++ b/test/ffmpeg-qsv/decode/vc1.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 spec      = load_test_spec("vc1", "decode")
 spec_r2r  = load_test_spec("vc1", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -25,15 +27,11 @@ class default(DecoderTest):
     vars(self).update(tspec[case].copy())
     vars(self).update(case = case)
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     self.init(spec, case)
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     self.init(spec_r2r, case)

--- a/test/ffmpeg-qsv/decode/vp8.py
+++ b/test/ffmpeg-qsv/decode/vp8.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
+@slash.requires(*platform.have_caps("decode", "vp8"))
+@slash.requires(*have_ffmpeg_decoder("vp8_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp8"))
-  @slash.requires(*have_ffmpeg_decoder("vp8_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/decode/vp9.py
+++ b/test/ffmpeg-qsv/decode/vp9.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.qsv.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class default(DecoderTest):
   def before(self):
     vars(self).update(
@@ -20,8 +22,6 @@ class default(DecoderTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/10bit/av1.py
+++ b/test/ffmpeg-vaapi/decode/10bit/av1.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_10"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_10"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/decode/10bit/hevc.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_10"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/decode/10bit/vp9.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_10"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/12bit/hevc.py
+++ b/test/ffmpeg-vaapi/decode/12bit/hevc.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_12"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_12"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/12bit/vp9.py
+++ b/test/ffmpeg-vaapi/decode/12bit/vp9.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_12"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_12"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/av1.py
+++ b/test/ffmpeg-vaapi/decode/av1.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_8"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_8"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/avc.py
+++ b/test/ffmpeg-vaapi/decode/avc.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
+@slash.requires(*platform.have_caps("decode", "avc"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "avc")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "avc"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/hevc.py
+++ b/test/ffmpeg-vaapi/decode/hevc.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_8"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/jpeg.py
+++ b/test/ffmpeg-vaapi/decode/jpeg.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "jpeg"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,14 +19,12 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "jpeg")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
     self.case = case
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/ffmpeg-vaapi/decode/mpeg2.py
+++ b/test/ffmpeg-vaapi/decode/mpeg2.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,14 +19,12 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "mpeg2")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
     self.case = case
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/ffmpeg-vaapi/decode/vc1.py
+++ b/test/ffmpeg-vaapi/decode/vc1.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "vc1"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,14 +19,12 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vc1")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
     self.case = case
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/ffmpeg-vaapi/decode/vp8.py
+++ b/test/ffmpeg-vaapi/decode/vp8.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
+@slash.requires(*platform.have_caps("decode", "vp8"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp8"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/decode/vp9.py
+++ b/test/ffmpeg-vaapi/decode/vp9.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,7 +18,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_8"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/10bit/av1.py
+++ b/test/gst-msdk/decode/10bit/av1.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_10"))
+@slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_10"))
-  @slash.requires(*have_gst_element("msdkav1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/10bit/hevc.py
+++ b/test/gst-msdk/decode/10bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+@slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/10bit/vp9.py
+++ b/test/gst-msdk/decode/10bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_10"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/12bit/hevc.py
+++ b/test/gst-msdk/decode/12bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_12"))
+@slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_12"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/12bit/vp9.py
+++ b/test/gst-msdk/decode/12bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_12"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_12"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_8"))
+@slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_8"))
-  @slash.requires(*have_gst_element("msdkav1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/avc.py
+++ b/test/gst-msdk/decode/avc.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_gst_element("msdkh264dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "avc")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/hevc.py
+++ b/test/gst-msdk/decode/hevc.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
+@slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/jpeg.py
+++ b/test/gst-msdk/decode/jpeg.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "jpeg"))
+@slash.requires(*have_gst_element("msdkmjpegdec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "jpeg")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_gst_element("msdkmjpegdec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -29,8 +29,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_gst_element("msdkmjpegdec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-msdk/decode/mpeg2.py
+++ b/test/gst-msdk/decode/mpeg2.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_gst_element("msdkmpeg2dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "mpeg2")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -29,8 +29,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-msdk/decode/vc1.py
+++ b/test/gst-msdk/decode/vc1.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_gst_element("msdkvc1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vc1")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("msdkvc1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -31,8 +31,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("msdkvc1dec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-msdk/decode/vp8.py
+++ b/test/gst-msdk/decode/vp8.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
+@slash.requires(*platform.have_caps("decode", "vp8"))
+@slash.requires(*have_gst_element("msdkvp8dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp8"))
-  @slash.requires(*have_gst_element("msdkvp8dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/decode/vp9.py
+++ b/test/gst-msdk/decode/vp9.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_8"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/10bit/av1.py
+++ b/test/gst-vaapi/decode/10bit/av1.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_10"))
+@slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_10"))
-  @slash.requires(*have_gst_element("vaapiav1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/10bit/hevc.py
+++ b/test/gst-vaapi/decode/10bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+@slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_10")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_10"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/12bit/hevc.py
+++ b/test/gst-vaapi/decode/12bit/hevc.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_12"))
+@slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_12"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/12bit/vp9.py
+++ b/test/gst-vaapi/decode/12bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_12"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_12")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_12"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/av1.py
+++ b/test/gst-vaapi/decode/av1.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "av1_8"))
+@slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "av1_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "av1_8"))
-  @slash.requires(*have_gst_element("vaapiav1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/avc.py
+++ b/test/gst-vaapi/decode/avc.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_gst_element("vaapih264dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "avc")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/hevc.py
+++ b/test/gst-vaapi/decode/hevc.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
+@slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "hevc_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/jpeg.py
+++ b/test/gst-vaapi/decode/jpeg.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "jpeg"))
+@slash.requires(*have_gst_element("vaapijpegdec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "jpeg")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_gst_element("vaapijpegdec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -29,8 +29,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "jpeg"))
-  @slash.requires(*have_gst_element("vaapijpegdec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-vaapi/decode/mpeg2.py
+++ b/test/gst-vaapi/decode/mpeg2.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_gst_element("vaapimpeg2dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "mpeg2")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -29,8 +29,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2dec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-vaapi/decode/vc1.py
+++ b/test/gst-vaapi/decode/vc1.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 spec = load_test_spec("vc1", "decode")
 spec_r2r = load_test_spec("vc1", "decode", "r2r")
 
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_gst_element("vaapivc1dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -18,8 +20,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vc1")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("vaapivc1dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
@@ -31,8 +31,6 @@ class default(DecoderTest):
     )
     self.decode()
 
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("vaapivc1dec"))
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())

--- a/test/gst-vaapi/decode/vp8.py
+++ b/test/gst-vaapi/decode/vp8.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
+@slash.requires(*platform.have_caps("decode", "vp8"))
+@slash.requires(*have_gst_element("vaapivp8dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp8"))
-  @slash.requires(*have_gst_element("vaapivp8dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/decode/vp9.py
+++ b/test/gst-vaapi/decode/vp9.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.decoder import DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
     # default metric
@@ -17,8 +19,6 @@ class default(DecoderTest):
     self.caps   = platform.get_caps("decode", "vp9_8")
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("decode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())


### PR DESCRIPTION
Previously, in slash < 1.7.10 using slash.requires
at the class level for derived classes caused the
requirements to leak to all sibling classes.  Thus,
the only workaround was to use slash.requires at
each class test method.  This issue was reported in
https://github.com/getslash/slash/issues/928
~2 years ago.

The issue has been fixed since slash 1.7.10.  Now
slash 1.12.0 has been verified to work with vaapi-fits
and is the latest required slash version.

This change moves common slash.requires to the class
level on derived test classes to remove the duplication
that previously occurred across each class test
method.

The slash.requires fix will also enable us to reduce
code duplication by allowing more levels of inheritance
to be introduced so that more code can be shared across
different components.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>