### PR TITLE
test/encode: move requires to class level

### DIFF
--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -13,23 +13,38 @@ spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
 @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-class HEVC10EncoderTest(EncoderTest):
+class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec     = "hevc-10",
       ffencoder = "hevc_qsv",
       ffdecoder = "hevc_qsv",
-      lowpower  = 0,
     )
-    super(HEVC10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = 1,
+    )
+
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -53,15 +68,12 @@ class cqp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cqp_lp(HEVC10EncoderTest):
+class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
       gop     = gop,
-      lowpower= 1,
       profile = profile,
       qp      = qp,
       quality = quality,
@@ -80,10 +92,8 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -109,17 +119,14 @@ class cbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cbr_lp(HEVC10EncoderTest):
+class cbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       minrate = bitrate,
       maxrate = bitrate,
       profile = profile,
@@ -138,10 +145,8 @@ class cbr_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -169,17 +174,14 @@ class vbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class vbr_lp(HEVC10EncoderTest):
+class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -11,6 +11,8 @@ from .....lib.ffmpeg.qsv.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class HEVC10EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -39,23 +42,18 @@ class cqp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cqp_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -71,23 +69,18 @@ class cqp_lp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -105,23 +98,18 @@ class cbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -139,23 +127,18 @@ class cbr_lp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -175,23 +158,18 @@ class vbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class vbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -211,17 +189,11 @@ class vbr_lp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -10,18 +10,21 @@ from .....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 
+@slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
-      codec   = "vp9",
-      ffencoder   = "vp9_qsv",
-      ffdecoder  ="vp9_qsv",
+      codec     = "vp9",
+      ffencoder = "vp9_qsv",
+      ffdecoder = "vp9_qsv",
     )
     super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -39,13 +42,12 @@ class cqp_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -66,13 +68,12 @@ class cbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class vbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -94,8 +95,6 @@ class vbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -12,25 +12,32 @@ spec = load_test_spec("vp9", "encode", "10bit")
 
 @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
 @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
-class VP9EncoderTest(EncoderTest):
+class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec     = "vp9",
       ffencoder = "vp9_qsv",
       ffdecoder = "vp9_qsv",
     )
-    super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cqp_lp(VP9EncoderTest):
+class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
+      lowpower  = 1,
+    )
+
+class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -39,7 +46,6 @@ class cqp_lp(VP9EncoderTest):
       slices    = slices,
       rcmode    = "cqp",
       quality   = quality,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
@@ -47,13 +53,11 @@ class cqp_lp(VP9EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -65,7 +69,6 @@ class cbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "cbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
@@ -73,13 +76,11 @@ class cbr_lp(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -92,7 +93,6 @@ class vbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "vbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.qsv.encoder import EncoderTest
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("h264_qsv"))
+@slash.requires(*have_ffmpeg_decoder("h264_qsv"))
 class AVCEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class AVCEncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h264"
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -39,23 +42,18 @@ class cqp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cqp_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -71,23 +69,18 @@ class cqp_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -105,23 +98,18 @@ class cbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -139,23 +127,18 @@ class cbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -175,23 +158,18 @@ class vbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main', 'baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class vbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -211,26 +189,18 @@ class vbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr_la(AVCEncoderTest):
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec, ['high', 'main', 'baseline']))
   def test(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.caps = platform.get_caps("encode", "avc")

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -13,23 +13,38 @@ spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
 @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-class HEVC8EncoderTest(EncoderTest):
+class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec     = "hevc-8",
       ffencoder = "hevc_qsv",
       ffdecoder = "hevc_qsv",
-      lowpower  = 0,
     )
-    super(HEVC8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = 1,
+    )
+
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -53,15 +68,12 @@ class cqp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cqp_lp(HEVC8EncoderTest):
+class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
-      lowpower = 1,
       qp       = qp,
       quality  = quality,
       profile  = profile,
@@ -80,10 +92,8 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -109,17 +119,14 @@ class cbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cbr_lp(HEVC8EncoderTest):
+class cbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,
@@ -138,10 +145,8 @@ class cbr_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -169,17 +174,14 @@ class vbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class vbr_lp(HEVC8EncoderTest):
+class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.qsv.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class HEVC8EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -39,23 +42,18 @@ class cqp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cqp_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -71,23 +69,18 @@ class cqp_lp(HEVC8EncoderTest):
       slices   = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -105,23 +98,18 @@ class cbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -139,23 +127,18 @@ class cbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -175,23 +158,18 @@ class vbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class vbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -211,17 +189,11 @@ class vbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -11,21 +11,24 @@ from ....lib.ffmpeg.qsv.encoder import EncoderTest
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
+@slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
 class JPEGEncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps      = platform.get_caps("vdenc", "jpeg"),
       codec     = "jpeg",
       ffencoder = "mjpeg_qsv",
       ffdecoder = "mjpeg_qsv",
     )
-    super(JPEGEncoderTest, self).before()
 
   def get_file_ext(self):
     return "mjpeg" if self.frames > 1 else "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):
-    self.caps = platform.get_caps("vdenc", "jpeg")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -33,17 +36,11 @@ class cqp(JPEGEncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -11,21 +11,24 @@ from ....lib.ffmpeg.qsv.encoder import EncoderTest
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("mpeg2_qsv"))
+@slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps      = platform.get_caps("encode", "mpeg2"),
       codec     = "mpeg2",
       ffencoder = "mpeg2_qsv",
       ffdecoder = "mpeg2_qsv",
     )
-    super(MPEG2EncoderTest, self).before()
 
   def get_file_ext(self):
     return "m2v"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
-    self.caps = platform.get_caps("encode", "mpeg2")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -37,17 +40,11 @@ class cqp(MPEG2EncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_encoder("mpeg2_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
   def test(self, case, gop, bframes, qp, quality):
     self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_encoder("mpeg2_qsv"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
   def test_r2r(self, case, gop, bframes, qp, quality):
     self.init(spec_r2r, case, gop, bframes, qp, quality)

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -10,18 +10,21 @@ from ....lib.ffmpeg.qsv.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
+@slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
-      codec   = "vp9",
-      ffencoder   = "vp9_qsv",
-      ffdecoder  ="vp9_qsv",
+      codec     = "vp9",
+      ffencoder = "vp9_qsv",
+      ffdecoder = "vp9_qsv",
     )
     super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -39,13 +42,12 @@ class cqp_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -66,13 +68,12 @@ class cbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class vbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -94,8 +95,6 @@ class vbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -12,25 +12,32 @@ spec = load_test_spec("vp9", "encode", "8bit")
 
 @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
 @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
-class VP9EncoderTest(EncoderTest):
+class VP9EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec     = "vp9",
       ffencoder = "vp9_qsv",
       ffdecoder = "vp9_qsv",
     )
-    super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cqp_lp(VP9EncoderTest):
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = 1,
+    )
+
+class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -39,7 +46,6 @@ class cqp_lp(VP9EncoderTest):
       slices    = slices,
       rcmode    = "cqp",
       quality   = quality,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
@@ -47,13 +53,11 @@ class cqp_lp(VP9EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -65,7 +69,6 @@ class cbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "cbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
@@ -73,13 +76,11 @@ class cbr_lp(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -92,7 +93,6 @@ class vbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "vbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -11,6 +11,7 @@ from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -29,6 +30,7 @@ class HEVC10EncoderTest(EncoderTest):
       "main444-10"  : "VAProfileHEVCMain444_10",
     }[self.profile]
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -44,21 +46,18 @@ class cqp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cqp_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -74,21 +73,18 @@ class cqp_lp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -106,21 +102,18 @@ class cbr(HEVC10EncoderTest):
       slices = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -138,21 +131,18 @@ class cbr_lp(HEVC10EncoderTest):
       slices = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -172,21 +162,18 @@ class vbr(HEVC10EncoderTest):
       slices = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class vbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -206,15 +193,11 @@ class vbr_lp(HEVC10EncoderTest):
       slices = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -12,14 +12,13 @@ spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVC10EncoderTest(EncoderTest):
+class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec   = "hevc-10",
       ffenc   = "hevc_vaapi",
-      lowpower= 0,
     )
-    super(HEVC10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
@@ -31,10 +30,26 @@ class HEVC10EncoderTest(EncoderTest):
     }[self.profile]
 
 @slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = 1,
+    )
+
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -57,16 +72,13 @@ class cqp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cqp_lp(HEVC10EncoderTest):
+class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
       gop     = gop,
-      lowpower= 1,
       profile = profile,
       qp      = qp,
       rcmode  = "cqp",
@@ -84,10 +96,8 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -113,17 +123,14 @@ class cbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cbr_lp(HEVC10EncoderTest):
+class cbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case = case,
       fps = fps,
       gop = gop,
-      lowpower= 1,
       minrate = bitrate,
       maxrate = bitrate,
       profile = profile,
@@ -142,11 +149,9 @@ class cbr_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -173,18 +178,15 @@ class vbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class vbr_lp(HEVC10EncoderTest):
+class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case = case,
       fps = fps,
       gop = gop,
-      lowpower= 1,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -10,6 +10,7 @@ from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 
+@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
 class VP9_10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -25,6 +26,7 @@ class VP9_10EncoderTest(EncoderTest):
   def get_vaapi_profile(self):
     return "VAProfileVP9Profile2"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cqp_lp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -41,13 +43,12 @@ class cqp_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -67,13 +68,12 @@ class cbr_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class vbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -94,8 +94,6 @@ class vbr_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -11,14 +11,13 @@ from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec = load_test_spec("vp9", "encode", "10bit")
 
 @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-class VP9_10EncoderTest(EncoderTest):
+class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec    = "vp9",
       ffenc    = "vp9_vaapi",
-      lowpower = 1,
     )
-    super(VP9_10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
@@ -27,11 +26,18 @@ class VP9_10EncoderTest(EncoderTest):
     return "VAProfileVP9Profile2"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cqp_lp(VP9_10EncoderTest):
+class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
+      lowpower  = 1,
+    )
+
+class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -48,12 +54,10 @@ class cqp_lp(VP9_10EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cbr_lp(VP9_10EncoderTest):
+class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -73,13 +77,11 @@ class cbr_lp(VP9_10EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class vbr_lp(VP9_10EncoderTest):
+class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -12,14 +12,13 @@ spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
 @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
-class AVCEncoderTest(EncoderTest):
+class AVCEncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec   = "avc",
       ffenc   = "h264_vaapi",
-      lowpower= 0,
     )
-    super(AVCEncoderTest, self).before()
 
   def get_file_ext(self):
     return "h264"
@@ -32,9 +31,25 @@ class AVCEncoderTest(EncoderTest):
     }[self.profile]
 
 @slash.requires(*platform.have_caps("encode", "avc"))
+class AVCEncoderTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "avc"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "avc"))
+class AVCEncoderLPTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "avc"),
+      lowpower  = 1,
+    )
+
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -58,15 +73,12 @@ class cqp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class cqp_lp(AVCEncoderTest):
+class cqp_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = gop,
-      lowpower  = 1,
       profile   = profile,
       qp        = qp,
       quality   = quality,
@@ -85,10 +97,8 @@ class cqp_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -114,17 +124,14 @@ class cbr(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class cbr_lp(AVCEncoderTest):
+class cbr_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = 1,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
@@ -143,10 +150,8 @@ class cbr_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -174,17 +179,14 @@ class vbr(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class vbr_lp(AVCEncoderTest):
+class vbr_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = 1,
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
       profile   = profile,

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
 class AVCEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -30,6 +31,7 @@ class AVCEncoderTest(EncoderTest):
       "constrained-baseline"  : "VAProfileH264ConstrainedBaseline",
     }[self.profile]
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -45,21 +47,18 @@ class cqp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cqp_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -75,21 +74,18 @@ class cqp_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -107,21 +103,18 @@ class cbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -139,21 +132,18 @@ class cbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -173,21 +163,18 @@ class vbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class vbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -207,15 +194,11 @@ class vbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -31,6 +32,7 @@ class HEVC8EncoderTest(EncoderTest):
       "scc-444"  : "VAProfileHEVCSccMain444",
     }[self.profile]
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -46,21 +48,18 @@ class cqp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cqp_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -76,21 +75,18 @@ class cqp_lp(HEVC8EncoderTest):
       slices   = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile, level=None):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -109,28 +105,23 @@ class cbr(HEVC8EncoderTest):
       level   = level,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_level_parameters(spec, ['main']))
   def test_level(self, case, gop, slices, bframes, bitrate, fps, profile, level):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile, level)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -148,21 +139,18 @@ class cbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -182,21 +170,18 @@ class vbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class vbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -216,15 +201,11 @@ class vbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -12,14 +12,13 @@ spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 @slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVC8EncoderTest(EncoderTest):
+class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec   = "hevc-8",
       ffenc   = "hevc_vaapi",
-      lowpower= 0,
     )
-    super(HEVC8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
@@ -33,10 +32,26 @@ class HEVC8EncoderTest(EncoderTest):
     }[self.profile]
 
 @slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = 1,
+    )
+
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -59,16 +74,13 @@ class cqp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cqp_lp(HEVC8EncoderTest):
+class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
-      lowpower = 1,
       qp       = qp,
       profile  = profile,
       rcmode   = "cqp",
@@ -86,10 +98,8 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile, level=None):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -121,17 +131,14 @@ class cbr(HEVC8EncoderTest):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile, level)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cbr_lp(HEVC8EncoderTest):
+class cbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,
@@ -150,11 +157,9 @@ class cbr_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -181,18 +186,15 @@ class vbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class vbr_lp(HEVC8EncoderTest):
+class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= 1,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -11,13 +11,16 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
 class JPEGEncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
-      codec   = "jpeg",
-      ffenc   = "mjpeg_vaapi",
+      caps  = platform.get_caps("vdenc", "jpeg"),
+      codec = "jpeg",
+      ffenc = "mjpeg_vaapi",
     )
-    super(JPEGEncoderTest, self).before()
 
   def get_file_ext(self):
     return "mjpeg" if self.frames > 1 else "jpg"
@@ -27,7 +30,6 @@ class JPEGEncoderTest(EncoderTest):
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):
-    self.caps = platform.get_caps("vdenc", "jpeg")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -35,15 +37,11 @@ class cqp(JPEGEncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -11,13 +11,16 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
 
+@slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
-      codec   = "mpeg2",
-      ffenc   = "mpeg2_vaapi",
+      caps  = platform.get_caps("encode", "mpeg2"),
+      codec = "mpeg2",
+      ffenc = "mpeg2_vaapi",
     )
-    super(MPEG2EncoderTest, self).before()
 
   def get_file_ext(self):
     return "m2v"
@@ -28,7 +31,6 @@ class MPEG2EncoderTest(EncoderTest):
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "mpeg2")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -39,15 +41,11 @@ class cqp(MPEG2EncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
   def test(self, case, gop, bframes, qp, quality):
     self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
   def test_r2r(self, case, gop, bframes, qp, quality):
     self.init(spec_r2r, case, gop, bframes, qp, quality)

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp8", "encode")
 
+@slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
 class VP8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -25,9 +26,8 @@ class VP8EncoderTest(EncoderTest):
   def get_vaapi_profile(self):
     return "VAProfileVP8Version0_3"
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class cqp(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -43,9 +43,8 @@ class cqp(VP8EncoderTest):
     )
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class cbr(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp8")
@@ -64,9 +63,8 @@ class cbr(VP8EncoderTest):
     )
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class vbr(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -11,14 +11,13 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec = load_test_spec("vp8", "encode")
 
 @slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
-class VP8EncoderTest(EncoderTest):
+class VP8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec   = "vp8",
       ffenc   = "vp8_vaapi",
-      lowpower= 0,
     )
-    super(VP8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
@@ -27,11 +26,18 @@ class VP8EncoderTest(EncoderTest):
     return "VAProfileVP8Version0_3"
 
 @slash.requires(*platform.have_caps("encode", "vp8"))
+class VP8EncoderTest(VP8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp8"),
+      lowpower  = 0,
+    )
+
 class cqp(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       case      = case,
@@ -43,11 +49,9 @@ class cqp(VP8EncoderTest):
     )
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp8"))
 class cbr(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -63,12 +67,10 @@ class cbr(VP8EncoderTest):
     )
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp8"))
 class vbr(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
+@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +25,7 @@ class VP9EncoderTest(EncoderTest):
   def get_vaapi_profile(self):
     return "VAProfileVP9Profile0"
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -40,13 +42,12 @@ class cqp(VP9EncoderTest):
       lowpower  = 0,
     )
 
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)  
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -64,14 +65,12 @@ class cqp_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class cbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -91,13 +90,12 @@ class cbr(VP9EncoderTest):
       lowpower  = 0,
     )
 
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -118,13 +116,12 @@ class cbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -145,13 +142,12 @@ class vbr(VP9EncoderTest):
       lowpower  = 0,
     )
 
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class vbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
@@ -173,8 +169,6 @@ class vbr_lp(VP9EncoderTest):
       lowpower  = 1,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -11,13 +11,13 @@ from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 spec = load_test_spec("vp9", "encode", "8bit")
 
 @slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-class VP9EncoderTest(EncoderTest):
+class VP9EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec   = "vp9",
       ffenc   = "vp9_vaapi",
     )
-    super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "ivf"
@@ -26,11 +26,27 @@ class VP9EncoderTest(EncoderTest):
     return "VAProfileVP9Profile0"
 
 @slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_8"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = 1,
+    )
+
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -39,7 +55,6 @@ class cqp(VP9EncoderTest):
       loopshp   = loopshp,
       qp        = qp,
       rcmode    = "cqp",
-      lowpower  = 0,
     )
 
   @slash.parametrize(*gen_vp9_cqp_parameters(spec))
@@ -47,12 +62,10 @@ class cqp(VP9EncoderTest):
     self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)  
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cqp_lp(VP9EncoderTest):
+class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -62,7 +75,6 @@ class cqp_lp(VP9EncoderTest):
       qp        = qp,
       slices    = slices,
       rcmode    = "cqp",
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
@@ -70,11 +82,9 @@ class cqp_lp(VP9EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class cbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -87,7 +97,6 @@ class cbr(VP9EncoderTest):
       maxrate   = bitrate,
       minrate   = bitrate,
       rcmode    = "cbr",
-      lowpower  = 0,
     )
 
   @slash.parametrize(*gen_vp9_cbr_parameters(spec))
@@ -95,12 +104,10 @@ class cbr(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -113,7 +120,6 @@ class cbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "cbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
@@ -121,12 +127,10 @@ class cbr_lp(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("encode", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -139,7 +143,6 @@ class vbr(VP9EncoderTest):
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
       rcmode    = "vbr",
-      lowpower  = 0,
     )
 
   @slash.parametrize(*gen_vp9_vbr_parameters(spec))
@@ -147,13 +150,11 @@ class vbr(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -166,7 +167,6 @@ class vbr_lp(VP9EncoderTest):
       minrate   = bitrate,
       rcmode    = "vbr",
       slices    = slices,
-      lowpower  = 1,
     )
 
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -11,6 +11,8 @@ from .....lib.gstreamer.msdk.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
+@slash.requires(*have_gst_element("msdkh265enc"))
+@slash.requires(*have_gst_element("msdkh265dec"))
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class HEVC10EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -41,22 +44,18 @@ class cqp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cqp_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -72,22 +71,18 @@ class cqp_lp(HEVC10EncoderTest):
       slices   = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -105,22 +100,18 @@ class cbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -138,22 +129,18 @@ class cbr_lp(HEVC10EncoderTest):
       slices   = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -174,22 +161,18 @@ class vbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class vbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -210,16 +193,11 @@ class vbr_lp(HEVC10EncoderTest):
       slices   = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -13,25 +13,40 @@ spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 @slash.requires(*have_gst_element("msdkh265enc"))
 @slash.requires(*have_gst_element("msdkh265dec"))
-class HEVC10EncoderTest(EncoderTest):
+class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "hevc-10",
       gstencoder    = "msdkh265enc",
       gstdecoder    = "h265parse ! msdkh265dec hardware=true",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
-      lowpower      = False,
     )
-    super(HEVC10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = False,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = True,
+    )
+
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -55,16 +70,13 @@ class cqp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cqp_lp(HEVC10EncoderTest):
+class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
       qp       = qp,
-      lowpower = True,
       quality  = quality,
       profile  = profile,
       rcmode   = "cqp",
@@ -82,10 +94,8 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -111,17 +121,14 @@ class cbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cbr_lp(HEVC10EncoderTest):
+class cbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate  = bitrate,
       case     = case,
       fps      = fps,
       gop      = gop,
-      lowpower = True,
       maxrate  = bitrate,
       minrate  = bitrate,
       profile  = profile,
@@ -140,10 +147,8 @@ class cbr_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -172,17 +177,14 @@ class vbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class vbr_lp(HEVC10EncoderTest):
+class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate  = bitrate,
       case     = case,
       fps      = fps,
       gop      = gop,
-      lowpower = True,
       # target percentage 50%
       maxrate  = bitrate * 2,
       minrate  = bitrate,

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 
+@slash.requires(*have_gst_element("msdkvp9enc"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
 class VP9_10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class VP9_10EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cqp_lp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -40,14 +43,12 @@ class cqp_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -67,14 +68,12 @@ class cbr_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class vbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -96,9 +95,6 @@ class vbr_lp(VP9_10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -12,8 +12,9 @@ spec = load_test_spec("vp9", "encode", "10bit")
 
 @slash.requires(*have_gst_element("msdkvp9enc"))
 @slash.requires(*have_gst_element("msdkvp9dec"))
-class VP9_10EncoderTest(EncoderTest):
+class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "msdkvp9enc",
@@ -21,18 +22,25 @@ class VP9_10EncoderTest(EncoderTest):
       gstmediatype  = "video/x-vp9",
       gstmuxer      = "matroskamux",
     )
-    super(VP9_10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "webm"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cqp_lp(VP9_10EncoderTest):
+class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("vdenc", "vp9_10"),
+      # NOTE: msdkvp9enc does not have lowpower property.
+      # msdkvp9enc lowpower is hardcoded internally
+    )
+
+class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -48,13 +56,11 @@ class cqp_lp(VP9_10EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cbr_lp(VP9_10EncoderTest):
+class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -73,13 +79,11 @@ class cbr_lp(VP9_10EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class vbr_lp(VP9_10EncoderTest):
+class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.msdk.encoder import EncoderTest
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
+@slash.requires(*have_gst_element("msdkh264enc"))
+@slash.requires(*have_gst_element("msdkh264dec"))
 class AVCEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class AVCEncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h264"
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -41,22 +44,18 @@ class cqp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cqp_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -72,22 +71,18 @@ class cqp_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -105,22 +100,18 @@ class cbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -138,22 +129,18 @@ class cbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -174,22 +161,18 @@ class vbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class vbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -210,22 +193,18 @@ class vbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr_la(AVCEncoderTest):
   def init(self, tspec, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.caps = platform.get_caps("encode", "avc")
@@ -245,16 +224,11 @@ class vbr_la(AVCEncoderTest):
       ladepth   = ladepth,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec, ['main', 'high', 'constrained-baseline']))
   def test(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.init(spec, case, bframes, bitrate, fps, quality, refs, profile, ladepth)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264enc"))
   @slash.parametrize(*gen_avc_vbr_la_parameters(spec_r2r, ['main', 'high', 'constrained-baseline']))
   def test_r2r(self, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
     self.init(spec_r2r, case, bframes, bitrate, fps, quality, refs, profile, ladepth)

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -13,25 +13,40 @@ spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
 @slash.requires(*have_gst_element("msdkh264enc"))
 @slash.requires(*have_gst_element("msdkh264dec"))
-class AVCEncoderTest(EncoderTest):
+class AVCEncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "avc",
       gstencoder    = "msdkh264enc",
       gstdecoder    = "h264parse ! msdkh264dec hardware=true",
       gstmediatype  = "video/x-h264",
       gstparser     = "h264parse",
-      lowpower      = False,
     )
-    super(AVCEncoderTest, self).before()
 
   def get_file_ext(self):
     return "h264"
 
 @slash.requires(*platform.have_caps("encode", "avc"))
+class AVCEncoderTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "avc"),
+      lowpower  = False,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "avc"))
+class AVCEncoderLPTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "avc"),
+      lowpower  = True,
+    )
+
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -55,15 +70,12 @@ class cqp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class cqp_lp(AVCEncoderTest):
+class cqp_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = gop,
-      lowpower  = True,
       profile   = profile,
       qp        = qp,
       quality   = quality,
@@ -82,10 +94,8 @@ class cqp_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -111,17 +121,14 @@ class cbr(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class cbr_lp(AVCEncoderTest):
+class cbr_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = True,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
@@ -140,10 +147,8 @@ class cbr_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,
@@ -172,17 +177,14 @@ class vbr(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class vbr_lp(AVCEncoderTest):
+class vbr_lp(AVCEncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = True,
       # target percentage 50%
       maxrate   = bitrate * 2,
       minrate   = bitrate,
@@ -204,10 +206,8 @@ class vbr_lp(AVCEncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr_la(AVCEncoderTest):
   def init(self, tspec, case, bframes, bitrate, fps, quality, refs, profile, ladepth):
-    self.caps = platform.get_caps("encode", "avc")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes   = bframes,

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.msdk.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
+@slash.requires(*have_gst_element("msdkh265enc"))
+@slash.requires(*have_gst_element("msdkh265dec"))
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class HEVC8EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -41,22 +44,18 @@ class cqp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cqp_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -72,22 +71,18 @@ class cqp_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -105,22 +100,18 @@ class cbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -138,22 +129,18 @@ class cbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -174,22 +161,18 @@ class vbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class vbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -210,16 +193,11 @@ class vbr_lp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
-  @slash.requires(*have_gst_element("msdkh265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("msdkh265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -13,25 +13,40 @@ spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 @slash.requires(*have_gst_element("msdkh265enc"))
 @slash.requires(*have_gst_element("msdkh265dec"))
-class HEVC8EncoderTest(EncoderTest):
+class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "hevc-8",
       gstencoder    = "msdkh265enc",
       gstdecoder    = "h265parse ! msdkh265dec hardware=true",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
-      lowpower      = False,
     )
-    super(HEVC8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = False,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = True,
+    )
+
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -55,16 +70,13 @@ class cqp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cqp_lp(HEVC8EncoderTest):
+class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
       gop     = gop,
       qp      = qp,
-      lowpower= True,
       quality = quality,
       profile = profile,
       rcmode  = "cqp",
@@ -82,10 +94,8 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -111,17 +121,14 @@ class cbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cbr_lp(HEVC8EncoderTest):
+class cbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= True,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,
@@ -140,10 +147,8 @@ class cbr_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -172,17 +177,14 @@ class vbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class vbr_lp(HEVC8EncoderTest):
+class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
       case    = case,
       fps     = fps,
       gop     = gop,
-      lowpower= True,
       # target percentage 50%
       maxrate = bitrate * 2,
       minrate = bitrate,

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -8,26 +8,29 @@ from ....lib import *
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
-spec = load_test_spec("jpeg", "encode")
-spec_r2r = load_test_spec("jpeg", "encode", "r2r")
+spec      = load_test_spec("jpeg", "encode")
+spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
 
+@slash.requires(*have_gst_element("msdkmjpegenc"))
+@slash.requires(*have_gst_element("msdkmjpegdec"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
 class JPEGEncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps          = platform.get_caps("vdenc", "jpeg"),
       codec         = "jpeg",
       gstencoder    = "msdkmjpegenc",
       gstdecoder    = "jpegparse ! msdkmjpegdec hardware=true",
       gstmediatype  = "image/jpeg",
       gstparser     = "jpegparse",
     )
-    super(JPEGEncoderTest, self).before()
 
   def get_file_ext(self):
     return "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):
-    self.caps = platform.get_caps("vdenc", "jpeg")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -35,16 +38,11 @@ class cqp(JPEGEncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_gst_element("msdkmjpegenc"))
-  @slash.requires(*have_gst_element("msdkmjpegdec"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_gst_element("msdkmjpegenc"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -8,26 +8,29 @@ from ....lib import *
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
-spec = load_test_spec("mpeg2", "encode")
-spec_r2r = load_test_spec("mpeg2", "encode", "r2r")
+spec      = load_test_spec("mpeg2", "encode")
+spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
 
+@slash.requires(*have_gst_element("msdkmpeg2enc"))
+@slash.requires(*have_gst_element("msdkmpeg2dec"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps          = platform.get_caps("encode", "mpeg2"),
       codec         = "mpeg2",
       gstencoder    = "msdkmpeg2enc",
       gstdecoder    = "mpegvideoparse ! msdkmpeg2dec hardware=true",
       gstmediatype  = "video/mpeg,mpegversion=2",
       gstparser     = "mpegvideoparse",
     )
-    super(MPEG2EncoderTest, self).before()
 
   def get_file_ext(self):
     return "mpg"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
-    self.caps = platform.get_caps("encode", "mpeg2")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -39,16 +42,11 @@ class cqp(MPEG2EncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2enc"))
-  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
   def test(self, case, gop, bframes, qp, quality):
     self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2enc"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
   def test_r2r(self, case, gop, bframes, qp, quality):
     self.init(spec_r2r, case, gop, bframes, qp, quality)

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.msdk.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
+@slash.requires(*have_gst_element("msdkvp9enc"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class VP9EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -40,14 +43,12 @@ class cqp_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -67,14 +68,12 @@ class cbr_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class vbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
@@ -96,9 +95,6 @@ class vbr_lp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("msdkvp9enc"))
-  @slash.requires(*have_gst_element("msdkvp9dec"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -12,8 +12,9 @@ spec = load_test_spec("vp9", "encode", "8bit")
 
 @slash.requires(*have_gst_element("msdkvp9enc"))
 @slash.requires(*have_gst_element("msdkvp9dec"))
-class VP9EncoderTest(EncoderTest):
+class VP9EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "msdkvp9enc",
@@ -21,18 +22,25 @@ class VP9EncoderTest(EncoderTest):
       gstmediatype  = "video/x-vp9",
       gstmuxer      = "matroskamux",
     )
-    super(VP9EncoderTest, self).before()
 
   def get_file_ext(self):
     return "webm"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cqp_lp(VP9EncoderTest):
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("vdenc", "vp9_8"),
+      # NOTE: msdkvp9enc does not have lowpower property.
+      # msdkvp9enc lowpower is hardcoded internally
+    )
+
+class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -48,13 +56,11 @@ class cqp_lp(VP9EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class cbr_lp(VP9EncoderTest):
+class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -73,13 +79,11 @@ class cbr_lp(VP9EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class vbr_lp(VP9EncoderTest):
+class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -13,25 +13,40 @@ spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
 @slash.requires(*have_gst_element("vaapih265enc"))
 @slash.requires(*have_gst_element("vaapih265dec"))
-class HEVC10EncoderTest(EncoderTest):
+class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "hevc-10",
       gstencoder    = "vaapih265enc",
       gstdecoder    = "h265parse ! vaapih265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
-      lowpower      = False,
     )
-    super(HEVC10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = False,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = True,
+    )
+
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -55,16 +70,13 @@ class cqp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cqp_lp(HEVC10EncoderTest):
+class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
       gop       = gop,
       qp        = qp,
-      lowpower  = True,
       quality   = quality,
       profile   = profile,
       rcmode    = "cqp",
@@ -82,10 +94,8 @@ class cqp_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -111,17 +121,14 @@ class cbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class cbr_lp(HEVC10EncoderTest):
+class cbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = True,
       maxrate   = bitrate,
       minrate   = bitrate,
       profile   = profile,
@@ -140,10 +147,8 @@ class cbr_lp(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -173,17 +178,14 @@ class vbr(HEVC10EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class vbr_lp(HEVC10EncoderTest):
+class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
       case      = case,
       fps       = fps,
       gop       = gop,
-      lowpower  = True,
       ## target percentage 70% (hard-coded in gst-vaapi)
       ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate   = int(bitrate / 0.7),

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -11,6 +11,8 @@ from .....lib.gstreamer.vaapi.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
 
+@slash.requires(*have_gst_element("vaapih265enc"))
+@slash.requires(*have_gst_element("vaapih265dec"))
 class HEVC10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class HEVC10EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -41,22 +44,18 @@ class cqp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cqp_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -72,22 +71,18 @@ class cqp_lp(HEVC10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class cbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -105,22 +100,18 @@ class cbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class cbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -138,22 +129,18 @@ class cbr_lp(HEVC10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_10")
@@ -175,22 +162,18 @@ class vbr(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class vbr_lp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_10")
@@ -212,16 +195,11 @@ class vbr_lp(HEVC10EncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -10,6 +10,8 @@ from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
 
+@slash.requires(*have_gst_element("vaapivp9enc"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
 class VP9_10EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -25,6 +27,7 @@ class VP9_10EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cqp_lp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -41,14 +44,12 @@ class cqp_lp(VP9_10EncoderTest):
       refmode   = refmode,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class cbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -68,14 +69,12 @@ class cbr_lp(VP9_10EncoderTest):
       refmode   = refmode,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class vbr_lp(VP9_10EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -98,9 +97,6 @@ class vbr_lp(VP9_10EncoderTest):
       refmode   = refmode,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -12,26 +12,32 @@ spec = load_test_spec("vp9", "encode", "10bit")
 
 @slash.requires(*have_gst_element("vaapivp9enc"))
 @slash.requires(*have_gst_element("vaapivp9dec"))
-class VP9_10EncoderTest(EncoderTest):
+class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "vaapivp9enc",
       gstdecoder    = "matroskademux ! vaapivp9dec",
       gstmediatype  = "video/x-vp9",
       gstmuxer      = "matroskamux",
-      lowpower      = True,
     )
-    super(VP9_10EncoderTest, self).before()
 
   def get_file_ext(self):
     return "webm"
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cqp_lp(VP9_10EncoderTest):
+class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
+      lowpower  = True,
+    )
+
+class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -49,11 +55,9 @@ class cqp_lp(VP9_10EncoderTest):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class cbr_lp(VP9_10EncoderTest):
+class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -74,11 +78,9 @@ class cbr_lp(VP9_10EncoderTest):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class vbr_lp(VP9_10EncoderTest):
+class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
-    self.caps = platform.get_caps("vdenc", "vp9_10")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
+@slash.requires(*have_gst_element("vaapih264enc"))
+@slash.requires(*have_gst_element("vaapih264dec"))
 class AVCEncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class AVCEncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h264"
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -41,22 +44,18 @@ class cqp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec, ['main', 'high']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_cqp_parameters(spec_r2r, ['main', 'high']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cqp_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -72,22 +71,18 @@ class cqp_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec, ['high', 'main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_cqp_lp_parameters(spec_r2r, ['high', 'main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -105,22 +100,18 @@ class cbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec, ['main', 'high']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_cbr_parameters(spec_r2r, ['main', 'high']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class cbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -138,22 +129,18 @@ class cbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec, ['main', 'high']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_cbr_lp_parameters(spec_r2r, ['main', 'high']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "avc"))
 class vbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "avc")
@@ -175,22 +162,18 @@ class vbr(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec, ['main', 'high']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_vbr_parameters(spec_r2r, ['main', 'high']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "avc"))
 class vbr_lp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "avc")
@@ -212,16 +195,11 @@ class vbr_lp(AVCEncoderTest):
       slices    = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec, ['main', 'high']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "avc"))
-  @slash.requires(*have_gst_element("vaapih264enc"))
   @slash.parametrize(*gen_avc_vbr_lp_parameters(spec_r2r, ['main', 'high']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -13,25 +13,40 @@ spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
 @slash.requires(*have_gst_element("vaapih265enc"))
 @slash.requires(*have_gst_element("vaapih265dec"))
-class HEVC8EncoderTest(EncoderTest):
+class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "hevc-8",
       gstencoder    = "vaapih265enc",
       gstdecoder    = "h265parse ! vaapih265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
-      lowpower      = False,
     )
-    super(HEVC8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "h265"
 
 @slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = False,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = True,
+    )
+
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -55,16 +70,13 @@ class cqp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cqp_lp(HEVC8EncoderTest):
+class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case         = case,
       gop          = gop,
       qp           = qp,
-      lowpower     = True,
       quality      = quality,
       profile      = profile,
       rcmode       = "cqp",
@@ -82,10 +94,8 @@ class cqp_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -111,17 +121,14 @@ class cbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class cbr_lp(HEVC8EncoderTest):
+class cbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate      = bitrate,
       case         = case,
       fps          = fps,
       gop          = gop,
-      lowpower     = True,
       maxrate      = bitrate,
       minrate      = bitrate,
       profile      = profile,
@@ -140,10 +147,8 @@ class cbr_lp(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("encode", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -173,17 +178,14 @@ class vbr(HEVC8EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class vbr_lp(HEVC8EncoderTest):
+class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.caps = platform.get_caps("vdenc", "hevc_8")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate      = bitrate,
       case         = case,
       fps          = fps,
       gop          = gop,
-      lowpower     = True,
       ## target percentage 70% (hard-coded in gst-vaapi)
       ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate      = int(bitrate / 0.7),

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -11,6 +11,8 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
 
+@slash.requires(*have_gst_element("vaapih265enc"))
+@slash.requires(*have_gst_element("vaapih265dec"))
 class HEVC8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -26,6 +28,7 @@ class HEVC8EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -41,22 +44,18 @@ class cqp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cqp_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -72,22 +71,18 @@ class cqp_lp(HEVC8EncoderTest):
       slices       = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class cbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -105,22 +100,18 @@ class cbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class cbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -138,22 +129,18 @@ class cbr_lp(HEVC8EncoderTest):
       slices       = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec, case, gop, slices, bitrate, fps, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_cbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("encode", "hevc_8")
@@ -175,22 +162,18 @@ class vbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class vbr_lp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.caps = platform.get_caps("vdenc", "hevc_8")
@@ -212,16 +195,11 @@ class vbr_lp(HEVC8EncoderTest):
       slices       = slices,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
-  @slash.requires(*have_gst_element("vaapih265dec"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-  @slash.requires(*have_gst_element("vaapih265enc"))
   @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -11,9 +11,14 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
 
+@slash.requires(*have_gst_element("vaapijpegenc"))
+@slash.requires(*have_gst_element("vaapijpegdec"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
 class JPEGEncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps          = platform.get_caps("vdenc", "jpeg"),
       codec         = "jpeg",
       gstencoder    = "vaapijpegenc",
       gstdecoder    = "jpegparse ! vaapijpegdec",
@@ -27,7 +32,6 @@ class JPEGEncoderTest(EncoderTest):
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):
-    self.caps = platform.get_caps("vdenc", "jpeg")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -35,16 +39,11 @@ class cqp(JPEGEncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_gst_element("vaapijpegenc"))
-  @slash.requires(*have_gst_element("vaapijpegdec"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec))
   def test(self, case, quality):
     self.init(spec, case, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("vdenc", "jpeg"))
-  @slash.requires(*have_gst_element("vaapijpegenc"))
   @slash.parametrize(*gen_jpeg_cqp_parameters(spec_r2r))
   def test_r2r(self, case, quality):
     self.init(spec_r2r, case, quality)

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -11,24 +11,26 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
 
+@slash.requires(*have_gst_element("vaapimpeg2enc"))
+@slash.requires(*have_gst_element("vaapimpeg2dec"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
 class MPEG2EncoderTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
+      caps          = platform.get_caps("encode", "mpeg2"),
       codec         = "mpeg2",
       gstencoder    = "vaapimpeg2enc",
       gstdecoder    = "mpegvideoparse ! vaapimpeg2dec",
       gstmediatype  = "video/mpeg",
       gstparser     = "mpegvideoparse",
-      lowpower      = False,
     )
-    super(MPEG2EncoderTest, self).before()
 
   def get_file_ext(self):
     return "m2v"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
-    self.caps = platform.get_caps("encode", "mpeg2")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -40,16 +42,11 @@ class cqp(MPEG2EncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2enc"))
-  @slash.requires(*have_gst_element("vaapimpeg2dec"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
   def test(self, case, gop, bframes, qp, quality):
     self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @slash.requires(*platform.have_caps("encode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2enc"))
   @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
   def test_r2r(self, case, gop, bframes, qp, quality):
     self.init(spec_r2r, case, gop, bframes, qp, quality)

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -12,26 +12,32 @@ spec = load_test_spec("vp8", "encode")
 
 @slash.requires(*have_gst_element("vaapivp8enc"))
 @slash.requires(*have_gst_element("vaapivp8dec"))
-class VP8EncoderTest(EncoderTest):
+class VP8EncoderBaseTest(EncoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       codec         = "vp8",
       gstencoder    = "vaapivp8enc",
       gstdecoder    = "matroskademux ! vaapivp8dec",
       gstmediatype  = "video/x-vp8",
       gstmuxer      = "matroskamux",
-      lowpower      = False,
     )
-    super(VP8EncoderTest, self).before()
 
   def get_file_ext(self):
     return "webm"
 
 @slash.requires(*platform.have_caps("encode", "vp8"))
+class VP8EncoderTest(VP8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp8"),
+      lowpower  = False,
+    )
+
 class cqp(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       case      = case,
@@ -44,11 +50,9 @@ class cqp(VP8EncoderTest):
     )
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp8"))
 class cbr(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -64,11 +68,9 @@ class cbr(VP8EncoderTest):
     )
     self.encode()
 
-@slash.requires(*platform.have_caps("encode", "vp8"))
 class vbr(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
-    self.caps = platform.get_caps("encode", "vp8")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp8", "encode")
 
+@slash.requires(*have_gst_element("vaapivp8enc"))
+@slash.requires(*have_gst_element("vaapivp8dec"))
 class VP8EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -25,10 +27,8 @@ class VP8EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class cqp(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_gst_element("vaapivp8enc"))
-  @slash.requires(*have_gst_element("vaapivp8dec"))
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp8")
@@ -44,10 +44,8 @@ class cqp(VP8EncoderTest):
     )
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class cbr(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_gst_element("vaapivp8enc"))
-  @slash.requires(*have_gst_element("vaapivp8dec"))
   @slash.parametrize(*gen_vp8_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp8")
@@ -66,10 +64,8 @@ class cbr(VP8EncoderTest):
     )
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp8"))
 class vbr(VP8EncoderTest):
-  @slash.requires(*platform.have_caps("encode", "vp8"))
-  @slash.requires(*have_gst_element("vaapivp8enc"))
-  @slash.requires(*have_gst_element("vaapivp8dec"))
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp8")

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -10,6 +10,8 @@ from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
+@slash.requires(*have_gst_element("vaapivp9enc"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
 class VP9EncoderTest(EncoderTest):
   def before(self):
     vars(self).update(
@@ -24,6 +26,7 @@ class VP9EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
@@ -40,14 +43,12 @@ class cqp(VP9EncoderTest):
       lowpower  = False,
     )
 
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class cbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
@@ -67,14 +68,12 @@ class cbr(VP9EncoderTest):
       lowpower  = False,
     )
  
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
 class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     self.caps = platform.get_caps("encode", "vp9_8")
@@ -97,14 +96,12 @@ class vbr(VP9EncoderTest):
       lowpower  = False,
     )
   
-  @slash.requires(*platform.have_caps("encode", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cqp_lp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -122,14 +119,12 @@ class cqp_lp(VP9EncoderTest):
       lowpower  = True,
     )
 
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class cbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -150,14 +145,12 @@ class cbr_lp(VP9EncoderTest):
       lowpower  = True,
     )
   
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class vbr_lp(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
@@ -181,9 +174,6 @@ class vbr_lp(VP9EncoderTest):
       lowpower  = True,
     )
   
-  @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-  @slash.requires(*have_gst_element("vaapivp9enc"))
-  @slash.requires(*have_gst_element("vaapivp9dec"))
   @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)


### PR DESCRIPTION
This change moves common slash.requires to the class
level on derived test classes to remove the duplication
that previously occurred across each class test method.
The class-level slash.requires on subclasses are supported
since slash 1.7.10.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>