### PR TITLE
test/vpp: move requires to class level

### DIFF
--- a/test/ffmpeg-qsv/vpp/brightness.py
+++ b/test/ffmpeg-qsv/vpp/brightness.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "brightness"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-100.0, 100.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-qsv/vpp/contrast.py
+++ b/test/ffmpeg-qsv/vpp/contrast.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "contrast"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-qsv/vpp/csc.py
+++ b/test/ffmpeg-qsv/vpp/csc.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 
+@slash.requires(*platform.have_caps("vpp", "csc"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "csc"))
   @slash.parametrize(*gen_vpp_csc_parameters(spec))
   def test(self, case, csc):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/vpp/deinterlace.py
+++ b/test/ffmpeg-qsv/vpp/deinterlace.py
@@ -12,6 +12,7 @@ if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(
     "ffmpeg-qsv: vpp deinterlace with raw input is no longer supported")
 
+@slash.requires(*platform.have_caps("vpp", "deinterlace"))
 class DeinterlaceTest(VppTest):
   _default_methods_ = [
     "bob",
@@ -66,14 +67,13 @@ class DeinterlaceTest(VppTest):
     check_metric(**vars(self))
 
 spec_avc = load_test_spec("vpp", "deinterlace", "avc")
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_ffmpeg_decoder("h264_qsv"))
 class avc(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "h264_qsv"
     super(avc, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_ffmpeg_decoder("h264_qsv"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc, DeinterlaceTest._default_modes_))
@@ -82,14 +82,13 @@ class avc(DeinterlaceTest):
     self.vpp()
 
 spec_mpeg2 = load_test_spec("vpp", "deinterlace", "mpeg2")
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
 class mpeg2(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "mpeg2_qsv"
     super(mpeg2, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2_qsv"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2, DeinterlaceTest._default_modes_))
@@ -98,14 +97,13 @@ class mpeg2(DeinterlaceTest):
     self.vpp()
 
 spec_vc1 = load_test_spec("vpp", "deinterlace", "vc1")
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
 class vc1(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "vc1_qsv"
     super(vc1, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_ffmpeg_decoder("vc1_qsv"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1, DeinterlaceTest._default_modes_))

--- a/test/ffmpeg-qsv/vpp/denoise.py
+++ b/test/ffmpeg-qsv/vpp/denoise.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 
+@slash.requires(*platform.have_caps("vpp", "denoise"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "denoise"))
   @slash.parametrize(*gen_vpp_denoise_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/vpp/hue.py
+++ b/test/ffmpeg-qsv/vpp/hue.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "hue"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-180.0, 180.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-qsv/vpp/mirroring.py
+++ b/test/ffmpeg-qsv/vpp/mirroring.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 
+@slash.requires(*platform.have_caps("vpp", "mirroring"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "mirroring"))
   @slash.parametrize(*gen_vpp_mirroring_parameters(spec))
   def test(self, case, method):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/vpp/rotation.py
+++ b/test/ffmpeg-qsv/vpp/rotation.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 
+@slash.requires(*platform.have_caps("vpp", "rotation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "rotation"))
   @slash.parametrize(*gen_vpp_rotation_parameters(spec))
   def test(self, case, degrees):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/vpp/saturation.py
+++ b/test/ffmpeg-qsv/vpp/saturation.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "saturation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-qsv/vpp/scale.py
+++ b/test/ffmpeg-qsv/vpp/scale.py
@@ -11,6 +11,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "scale"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       scale_width   = scale_width,
     )
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec))
   def test(self, case, scale_width, scale_height):
     self.init(spec, case, scale_width, scale_height)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec_r2r))
   def test_r2r(self, case, scale_width, scale_height):
     self.init(spec_r2r, case, scale_width, scale_height)

--- a/test/ffmpeg-qsv/vpp/sharpen.py
+++ b/test/ffmpeg-qsv/vpp/sharpen.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 
+@slash.requires(*platform.have_caps("vpp", "sharpen"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "sharpen"))
   @slash.parametrize(*gen_vpp_sharpen_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-qsv/vpp/transpose.py
+++ b/test/ffmpeg-qsv/vpp/transpose.py
@@ -10,6 +10,7 @@ from ....lib.ffmpeg.qsv.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 
+@slash.requires(*platform.have_caps("vpp", "transpose"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "transpose"))
   @slash.parametrize(*gen_vpp_transpose_parameters(spec))
   def test(self, case, degrees, method):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/brightness.py
+++ b/test/ffmpeg-vaapi/vpp/brightness.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "brightness"))
+@slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,15 +30,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-100.0, 100.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-vaapi/vpp/contrast.py
+++ b/test/ffmpeg-vaapi/vpp/contrast.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "contrast"))
+@slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,15 +30,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-vaapi/vpp/csc.py
+++ b/test/ffmpeg-vaapi/vpp/csc.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 
+@slash.requires(*platform.have_caps("vpp", "csc"))
+@slash.requires(*have_ffmpeg_filter("scale_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,8 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "csc"))
-  @slash.requires(*have_ffmpeg_filter("scale_vaapi"))
   @slash.parametrize(*gen_vpp_csc_parameters(spec))
   def test(self, case, csc):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/deinterlace.py
+++ b/test/ffmpeg-vaapi/vpp/deinterlace.py
@@ -12,6 +12,8 @@ if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(
     "ffmpeg-vaapi: vpp deinterlace with raw input is no longer supported")
 
+@slash.requires(*platform.have_caps("vpp", "deinterlace"))
+@slash.requires(*have_ffmpeg_filter("deinterlace_vaapi"))
 class DeinterlaceTest(VppTest):
   _default_methods_ = [
     "bob",
@@ -64,15 +66,13 @@ class DeinterlaceTest(VppTest):
     check_metric(**vars(self))
 
 spec_avc = load_test_spec("vpp", "deinterlace", "avc")
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_ffmpeg_decoder("h264"))
 class avc(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "h264"
     super(avc, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_ffmpeg_filter("deinterlace_vaapi"))
-  @slash.requires(*have_ffmpeg_decoder("h264"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc, DeinterlaceTest._default_modes_))
@@ -81,15 +81,13 @@ class avc(DeinterlaceTest):
     self.vpp()
 
 spec_mpeg2 = load_test_spec("vpp", "deinterlace", "mpeg2")
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_ffmpeg_decoder("mpeg2video"))
 class mpeg2(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "mpeg2video"
     super(mpeg2, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_ffmpeg_filter("deinterlace_vaapi"))
-  @slash.requires(*have_ffmpeg_decoder("mpeg2video"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2, DeinterlaceTest._default_modes_))
@@ -98,15 +96,13 @@ class mpeg2(DeinterlaceTest):
     self.vpp()
 
 spec_vc1 = load_test_spec("vpp", "deinterlace", "vc1")
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_ffmpeg_decoder("vc1"))
 class vc1(DeinterlaceTest):
   def before(self):
     self.ffdecoder = "vc1"
     super(vc1, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_ffmpeg_filter("deinterlace_vaapi"))
-  @slash.requires(*have_ffmpeg_decoder("vc1"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1, DeinterlaceTest._default_modes_))

--- a/test/ffmpeg-vaapi/vpp/denoise.py
+++ b/test/ffmpeg-vaapi/vpp/denoise.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 
+@slash.requires(*platform.have_caps("vpp", "denoise"))
+@slash.requires(*have_ffmpeg_filter("denoise_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,8 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "denoise"))
-  @slash.requires(*have_ffmpeg_filter("denoise_vaapi"))
   @slash.parametrize(*gen_vpp_denoise_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/hue.py
+++ b/test/ffmpeg-vaapi/vpp/hue.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "hue"))
+@slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,15 +30,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-180.0, 180.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-vaapi/vpp/mirroring.py
+++ b/test/ffmpeg-vaapi/vpp/mirroring.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 
+@slash.requires(*platform.have_caps("vpp", "mirroring"))
+@slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,8 +21,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "mirroring"))
-  @slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
   @slash.parametrize(*gen_vpp_mirroring_parameters(spec))
   def test(self, case, method):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/rotation.py
+++ b/test/ffmpeg-vaapi/vpp/rotation.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 
+@slash.requires(*platform.have_caps("vpp", "rotation"))
+@slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,8 +21,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "rotation"))
-  @slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
   @slash.parametrize(*gen_vpp_rotation_parameters(spec))
   def test(self, case, degrees):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/saturation.py
+++ b/test/ffmpeg-vaapi/vpp/saturation.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "saturation"))
+@slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,15 +30,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
-  @slash.requires(*have_ffmpeg_filter("procamp_vaapi"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/ffmpeg-vaapi/vpp/scale.py
+++ b/test/ffmpeg-vaapi/vpp/scale.py
@@ -11,6 +11,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "scale"))
+@slash.requires(*have_ffmpeg_filter("scale_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,15 +29,11 @@ class default(VppTest):
       scale_width   = scale_width,
     )
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
-  @slash.requires(*have_ffmpeg_filter("scale_vaapi"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec))
   def test(self, case, scale_width, scale_height):
     self.init(spec, case, scale_width, scale_height)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
-  @slash.requires(*have_ffmpeg_filter("scale_vaapi"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec_r2r))
   def test_r2r(self, case, scale_width, scale_height):
     self.init(spec_r2r, case, scale_width, scale_height)

--- a/test/ffmpeg-vaapi/vpp/sharpen.py
+++ b/test/ffmpeg-vaapi/vpp/sharpen.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 
+@slash.requires(*platform.have_caps("vpp", "sharpen"))
+@slash.requires(*have_ffmpeg_filter("sharpness_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,8 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "sharpen"))
-  @slash.requires(*have_ffmpeg_filter("sharpness_vaapi"))
   @slash.parametrize(*gen_vpp_sharpen_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/ffmpeg-vaapi/vpp/transpose.py
+++ b/test/ffmpeg-vaapi/vpp/transpose.py
@@ -10,6 +10,8 @@ from ....lib.ffmpeg.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 
+@slash.requires(*platform.have_caps("vpp", "transpose"))
+@slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,8 +21,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "transpose"))
-  @slash.requires(*have_ffmpeg_filter("transpose_vaapi"))
   @slash.parametrize(*gen_vpp_transpose_parameters(spec))
   def test(self, case, degrees, method):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/brightness.py
+++ b/test/gst-msdk/vpp/brightness.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "brightness"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-100.0, 100.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-msdk/vpp/contrast.py
+++ b/test/gst-msdk/vpp/contrast.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "contrast"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-msdk/vpp/crop.py
+++ b/test/gst-msdk/vpp/crop.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "crop")
 
+@slash.requires(*platform.have_caps("vpp", "crop"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "crop"))
   @slash.parametrize(*gen_vpp_crop_parameters(spec))
   def test(self, case, left, right, top, bottom):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/csc.py
+++ b/test/gst-msdk/vpp/csc.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 
+@slash.requires(*platform.have_caps("vpp", "csc"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "csc"))
   @slash.parametrize(*gen_vpp_csc_parameters(spec))
   def test(self, case, csc):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/deinterlace.py
+++ b/test/gst-msdk/vpp/deinterlace.py
@@ -12,6 +12,7 @@ if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(
     "gst-msdk: vpp deinterlace with raw input is no longer supported")
 
+@slash.requires(*platform.have_caps("vpp", "deinterlace"))
 class DeinterlaceTest(VppTest):
   _default_methods_ = [
     "bob",
@@ -65,14 +66,13 @@ class DeinterlaceTest(VppTest):
 
 spec_avc      = load_test_spec("vpp", "deinterlace", "avc")
 spec_avc_r2r  = load_test_spec("vpp", "deinterlace", "avc", "r2r")
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_gst_element("msdkh264dec"))
 class avc(DeinterlaceTest):
   def before(self):
     self.gstdecoder = "h264parse ! msdkh264dec"
     super(avc, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc, DeinterlaceTest._default_modes_))
@@ -80,9 +80,6 @@ class avc(DeinterlaceTest):
     self.init(spec_avc, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("msdkh264dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc_r2r, DeinterlaceTest._default_modes_))
@@ -93,14 +90,13 @@ class avc(DeinterlaceTest):
 
 spec_mpeg2      = load_test_spec("vpp", "deinterlace", "mpeg2")
 spec_mpeg2_r2r  = load_test_spec("vpp", "deinterlace", "mpeg2", "r2r")
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_gst_element("msdkmpeg2dec"))
 class mpeg2(DeinterlaceTest):
   def before(self):
     self.gstdecoder = "mpegvideoparse ! msdkmpeg2dec"
     super(mpeg2, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2, DeinterlaceTest._default_modes_))
@@ -108,9 +104,6 @@ class mpeg2(DeinterlaceTest):
     self.init(spec_mpeg2, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("msdkmpeg2dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2_r2r, DeinterlaceTest._default_modes_))
@@ -121,15 +114,14 @@ class mpeg2(DeinterlaceTest):
 
 spec_vc1      = load_test_spec("vpp", "deinterlace", "vc1")
 spec_vc1_r2r  = load_test_spec("vpp", "deinterlace", "vc1", "r2r")
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_gst_element("msdkvc1dec"))
 class vc1(DeinterlaceTest):
   def before(self):
     self.gstdecoder  = "'video/x-wmv,profile=(string)advanced',width={width}"
     self.gstdecoder += ",height={height},framerate=14/1 ! msdkvc1dec"
     super(vc1, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("msdkvc1dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1, DeinterlaceTest._default_modes_))
@@ -137,9 +129,6 @@ class vc1(DeinterlaceTest):
     self.init(spec_vc1, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("msdkvc1dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1_r2r, DeinterlaceTest._default_modes_))

--- a/test/gst-msdk/vpp/denoise.py
+++ b/test/gst-msdk/vpp/denoise.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 
+@slash.requires(*platform.have_caps("vpp", "denoise"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "denoise"))
   @slash.parametrize(*gen_vpp_denoise_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/hue.py
+++ b/test/gst-msdk/vpp/hue.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "hue"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-180.0, 180.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-msdk/vpp/mirroring.py
+++ b/test/gst-msdk/vpp/mirroring.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 
+@slash.requires(*platform.have_caps("vpp", "mirroring"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "mirroring"))
   @slash.parametrize(*gen_vpp_mirroring_parameters(spec))
   def test(self, case, method):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/rotation.py
+++ b/test/gst-msdk/vpp/rotation.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 
+@slash.requires(*platform.have_caps("vpp", "rotation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "rotation"))
   @slash.parametrize(*gen_vpp_rotation_parameters(spec))
   def test(self, case, degrees):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/saturation.py
+++ b/test/gst-msdk/vpp/saturation.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "saturation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -28,13 +29,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 10.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-msdk/vpp/scale.py
+++ b/test/gst-msdk/vpp/scale.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 spec = load_test_spec("vpp", "scale")
 spec_r2r = load_test_spec("vpp", "scale", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "scale"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       scale_width   = scale_width,
     )
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec))
   def test(self, case, scale_width, scale_height):
     self.init(spec, case, scale_width, scale_height)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec_r2r))
   def test_r2r(self, case, scale_width, scale_height):
     self.init(spec_r2r, case, scale_width, scale_height)

--- a/test/gst-msdk/vpp/sharpen.py
+++ b/test/gst-msdk/vpp/sharpen.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 
+@slash.requires(*platform.have_caps("vpp", "sharpen"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "sharpen"))
   @slash.parametrize(*gen_vpp_sharpen_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/gst-msdk/vpp/transpose.py
+++ b/test/gst-msdk/vpp/transpose.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.msdk.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 
+@slash.requires(*platform.have_caps("vpp", "transpose"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "transpose"))
   @slash.parametrize(*gen_vpp_transpose_parameters(spec))
   def test(self, case, degrees, method):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/brightness.py
+++ b/test/gst-vaapi/vpp/brightness.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "brightness")
 spec_r2r  = load_test_spec("vpp", "brightness", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "brightness"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-1.0, 1.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "brightness"))
   @slash.parametrize(*gen_vpp_brightness_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-vaapi/vpp/contrast.py
+++ b/test/gst-vaapi/vpp/contrast.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "contrast")
 spec_r2r  = load_test_spec("vpp", "contrast", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "contrast"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 2.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "contrast"))
   @slash.parametrize(*gen_vpp_contrast_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-vaapi/vpp/crop.py
+++ b/test/gst-vaapi/vpp/crop.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "crop")
 
+@slash.requires(*platform.have_caps("vpp", "crop"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "crop"))
   @slash.parametrize(*gen_vpp_crop_parameters(spec))
   def test(self, case, left, right, top, bottom):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/csc.py
+++ b/test/gst-vaapi/vpp/csc.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "csc")
 
+@slash.requires(*platform.have_caps("vpp", "csc"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "csc"))
   @slash.parametrize(*gen_vpp_csc_parameters(spec))
   def test(self, case, csc):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/deinterlace.py
+++ b/test/gst-vaapi/vpp/deinterlace.py
@@ -12,6 +12,7 @@ if len(load_test_spec("vpp", "deinterlace")):
   slash.logger.warn(
     "gst-vaapi: vpp deinterlace with raw input is no longer supported")
 
+@slash.requires(*platform.have_caps("vpp", "deinterlace"))
 class DeinterlaceTest(VppTest):
   _default_methods_ = [
     "bob",
@@ -65,14 +66,13 @@ class DeinterlaceTest(VppTest):
 
 spec_avc      = load_test_spec("vpp", "deinterlace", "avc")
 spec_avc_r2r  = load_test_spec("vpp", "deinterlace", "avc", "r2r")
+@slash.requires(*platform.have_caps("decode", "avc"))
+@slash.requires(*have_gst_element("vaapih264dec"))
 class avc(DeinterlaceTest):
   def before(self):
     self.gstdecoder = "h264parse ! vaapih264dec"
     super(avc, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc, DeinterlaceTest._default_modes_))
@@ -80,9 +80,6 @@ class avc(DeinterlaceTest):
     self.init(spec_avc, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "avc"))
-  @slash.requires(*have_gst_element("vaapih264dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_avc_r2r, DeinterlaceTest._default_modes_))
@@ -93,14 +90,13 @@ class avc(DeinterlaceTest):
 
 spec_mpeg2      = load_test_spec("vpp", "deinterlace", "mpeg2")
 spec_mpeg2_r2r  = load_test_spec("vpp", "deinterlace", "mpeg2", "r2r")
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+@slash.requires(*have_gst_element("vaapimpeg2dec"))
 class mpeg2(DeinterlaceTest):
   def before(self):
     self.gstdecoder = "mpegvideoparse ! vaapimpeg2dec"
     super(mpeg2, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2, DeinterlaceTest._default_modes_))
@@ -108,9 +104,6 @@ class mpeg2(DeinterlaceTest):
     self.init(spec_mpeg2, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "mpeg2"))
-  @slash.requires(*have_gst_element("vaapimpeg2dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_mpeg2_r2r, DeinterlaceTest._default_modes_))
@@ -121,15 +114,14 @@ class mpeg2(DeinterlaceTest):
 
 spec_vc1      = load_test_spec("vpp", "deinterlace", "vc1")
 spec_vc1_r2r  = load_test_spec("vpp", "deinterlace", "vc1", "r2r")
+@slash.requires(*platform.have_caps("decode", "vc1"))
+@slash.requires(*have_gst_element("vaapivc1dec"))
 class vc1(DeinterlaceTest):
   def before(self):
     self.gstdecoder  = "'video/x-wmv,profile=(string)advanced',width={width}"
     self.gstdecoder += ",height={height},framerate=14/1 ! vaapivc1dec"
     super(vc1, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("vaapivc1dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1, DeinterlaceTest._default_modes_))
@@ -137,9 +129,6 @@ class vc1(DeinterlaceTest):
     self.init(spec_vc1, case, method, rate)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "deinterlace"))
-  @slash.requires(*platform.have_caps("decode", "vc1"))
-  @slash.requires(*have_gst_element("vaapivc1dec"))
   @slash.parametrize(
     *gen_vpp_deinterlace_parameters(
       spec_vc1_r2r, DeinterlaceTest._default_modes_))

--- a/test/gst-vaapi/vpp/denoise.py
+++ b/test/gst-vaapi/vpp/denoise.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "denoise")
 
+@slash.requires(*platform.have_caps("vpp", "denoise"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "denoise"))
   @slash.parametrize(*gen_vpp_denoise_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/hue.py
+++ b/test/gst-vaapi/vpp/hue.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "hue")
 spec_r2r  = load_test_spec("vpp", "hue", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "hue"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [-180.0, 180.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "hue"))
   @slash.parametrize(*gen_vpp_hue_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-vaapi/vpp/mirroring.py
+++ b/test/gst-vaapi/vpp/mirroring.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "mirroring")
 
+@slash.requires(*platform.have_caps("vpp", "mirroring"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "mirroring"))
   @slash.parametrize(*gen_vpp_mirroring_parameters(spec))
   def test(self, case, method):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/rotation.py
+++ b/test/gst-vaapi/vpp/rotation.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "rotation")
 
+@slash.requires(*platform.have_caps("vpp", "rotation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "rotation"))
   @slash.parametrize(*gen_vpp_rotation_parameters(spec))
   def test(self, case, degrees):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/saturation.py
+++ b/test/gst-vaapi/vpp/saturation.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "saturation")
 spec_r2r  = load_test_spec("vpp", "saturation", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "saturation"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       mlevel  = mapRange(level, [0, 100], [0.0, 2.0]),
     )
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec))
   def test(self, case, level):
     self.init(spec, case, level)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "saturation"))
   @slash.parametrize(*gen_vpp_saturation_parameters(spec_r2r))
   def test_r2r(self, case, level):
     self.init(spec_r2r, case, level)

--- a/test/gst-vaapi/vpp/scale.py
+++ b/test/gst-vaapi/vpp/scale.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 spec      = load_test_spec("vpp", "scale")
 spec_r2r  = load_test_spec("vpp", "scale", "r2r")
 
+@slash.requires(*platform.have_caps("vpp", "scale"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -27,13 +28,11 @@ class default(VppTest):
       scale_height  = scale_height,
     )
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec))
   def test(self, case, scale_width, scale_height):
     self.init(spec, case, scale_width, scale_height)
     self.vpp()
 
-  @slash.requires(*platform.have_caps("vpp", "scale"))
   @slash.parametrize(*gen_vpp_scale_parameters(spec_r2r))
   def test_r2r(self, case, scale_width, scale_height):
     self.init(spec_r2r, case, scale_width, scale_height)

--- a/test/gst-vaapi/vpp/sharpen.py
+++ b/test/gst-vaapi/vpp/sharpen.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "sharpen")
 
+@slash.requires(*platform.have_caps("vpp", "sharpen"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -18,7 +19,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "sharpen"))
   @slash.parametrize(*gen_vpp_sharpen_parameters(spec))
   def test(self, case, level):
     vars(self).update(spec[case].copy())

--- a/test/gst-vaapi/vpp/transpose.py
+++ b/test/gst-vaapi/vpp/transpose.py
@@ -10,6 +10,7 @@ from ....lib.gstreamer.vaapi.vpp import VppTest
 
 spec = load_test_spec("vpp", "transpose")
 
+@slash.requires(*platform.have_caps("vpp", "transpose"))
 class default(VppTest):
   def before(self):
     vars(self).update(
@@ -19,7 +20,6 @@ class default(VppTest):
     )
     super(default, self).before()
 
-  @slash.requires(*platform.have_caps("vpp", "transpose"))
   @slash.parametrize(*gen_vpp_transpose_parameters(spec))
   def test(self, case, degrees, method):
     vars(self).update(spec[case].copy())


### PR DESCRIPTION
This change moves common slash.requires to the class
level on derived test classes to avoid duplicating
at class test methods.

The class-level slash.requires on subclasses are supported
since slash 1.7.10.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>