### PR TITLE
gstreamer: common base classes

### DIFF
--- a/lib/gstreamer/decoderbase.py
+++ b/lib/gstreamer/decoderbase.py
@@ -1,0 +1,86 @@
+###
+### Copyright (C) 2018-2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ...lib.common import timefn, get_media, call
+from ...lib.formats import match_best_format
+from ...lib.gstreamer.util import have_gst, have_gst_element
+from ...lib.parameters import format_value
+from ...lib.util import skip_test_if_missing_features
+from ...lib.metrics import md5, check_metric
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("checksumsink2"))
+class BaseDecoderTest(slash.Test):
+  def before(self):
+    self.refctx = []
+
+  def map_formatu(self):
+    raise NotImplementedError
+
+  @timefn("gst")
+  def call_gst(self):
+    call(
+      "gst-launch-1.0 -vf filesrc location={source}"
+      " ! {gstdecoder}"
+      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
+      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
+      " frame-checksum=false plane-checksum=false dump-output=true"
+      " dump-location={decoded}".format(**vars(self)))
+
+  def gen_name(self):
+    name = "{case}_{width}x{height}_{format}"
+    if vars(self).get("r2r", None) is not None:
+      name += "_r2r"
+    return name
+
+  def validate_caps(self):
+    if match_best_format(self.format, self.caps["fmts"]) is None:
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.{format} not supported", **vars(self)))
+
+    maxw, maxh = self.caps["maxres"]
+    if self.width > maxw or self.height > maxh:
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
+
+    self.mformatu = self.map_formatu()
+    if self.mformatu is None:
+      slash.skip_test(
+        "gstreamer.{format} not supported".format(**vars(self)))
+
+    skip_test_if_missing_features(self)
+
+  def decode(self):
+    self.validate_caps()
+
+    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
+
+    name = self.gen_name().format(**vars(self))
+    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_gst()
+
+    if vars(self).get("r2r", None) is not None:
+      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
+      md5ref = md5(self.decoded)
+      get_media()._set_test_details(md5_ref = md5ref)
+      for i in range(1, self.r2r):
+        self.decoded = get_media()._test_artifact(
+          "{}_{}.yuv".format(name, i))
+        self.call_gst()
+        result = md5(self.decoded)
+        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
+        assert result == md5ref, "r2r md5 mismatch"
+        # delete decoded file after each iteration
+        get_media()._purge_test_artifact(self.decoded)
+    else:
+      self.check_metrics()
+
+  def check_metrics(self):
+    check_metric(**vars(self))

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -1,0 +1,198 @@
+###
+### Copyright (C) 2018-2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+import slash
+
+from ...lib.common import timefn, get_media, call
+from ...lib.gstreamer.util import have_gst, have_gst_element
+from ...lib.metrics import md5, calculate_psnr
+from ...lib.parameters import format_value
+from ...lib.util import skip_test_if_missing_features
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("checksumsink2"))
+class BaseEncoderTest(slash.Test):
+  def before(self):
+    self.refctx = []
+
+  def map_profile(self):
+    raise NotImplementedError
+
+  def map_best_hw_format(self):
+    raise NotImplementedError
+
+  def map_format(self):
+    raise NotImplementedError
+
+  def map_formatu(self):
+    raise NotImplementedError
+
+  def gen_encoder_opts(self):
+    raise NotImplementedError
+
+  def get_file_ext(self):
+    raise NotImplementedError
+
+  def gen_input_opts(self):
+    opts = "filesrc location={source} num-buffers={frames}"
+    opts += " ! rawvideoparse format={mformat} width={width} height={height}"
+    if vars(self).get("fps", None) is not None:
+      opts += " framerate={fps}"
+    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
+
+    return opts
+
+  def gen_output_opts(self):
+    opts = "{gstencoder} "
+    opts += self.gen_encoder_opts()
+    opts += " ! {gstmediatype}"
+    if vars(self).get("profile", None) is not None:
+      opts += ",profile={mprofile}"
+    if vars(self).get("gstparser", None) is not None:
+      opts += " ! {gstparser}"
+    if vars(self).get("gstmuxer", None) is not None:
+      opts += " ! {gstmuxer}"
+    opts += " ! filesink location={encoded}"
+
+    return opts
+
+  def gen_name(self):
+    name = "{case}-{rcmode}"
+    if vars(self).get("profile", None) is not None:
+      name += "-{profile}"
+    if vars(self).get("fps", None) is not None:
+      name += "-{fps}"
+    if vars(self).get("gop", None) is not None:
+      name += "-{gop}"
+    if vars(self).get("qp", None) is not None:
+      name += "-{qp}"
+    if vars(self).get("slices", None) is not None:
+      name += "-{slices}"
+    if vars(self).get("quality", None) is not None:
+      name += "-{quality}"
+    if vars(self).get("bframes", None) is not None:
+      name += "-{bframes}"
+    if vars(self).get("minrate", None) is not None:
+      name += "-{minrate}k"
+    if vars(self).get("maxrate", None) is not None:
+      name += "-{maxrate}k"
+    if vars(self).get("refmode", None) is not None:
+      name += "-{refmode}"
+    if vars(self).get("refs", None) is not None:
+      name += "-{refs}"
+    if vars(self).get("lowpower", False):
+      name += "-low-power"
+    if vars(self).get("loopshp", None) is not None:
+      name += "-{loopshp}"
+    if vars(self).get("looplvl", None) is not None:
+      name += "-{looplvl}"
+    if vars(self).get("ladepth", None) is not None:
+      name += "-{ladepth}"
+    if vars(self).get("r2r", None) is not None:
+      name += "-r2r"
+
+    return name
+
+  @timefn("gst")
+  def call_gst(self, iopts, oopts):
+    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
+      iopts = iopts, oopts = oopts))
+
+  def validate_caps(self):
+    skip_test_if_missing_features(self)
+
+    self.hwformat = self.map_best_hw_format()
+    self.mformat  = self.map_format()
+    self.mformatu = self.map_formatu()
+
+    if None in [self.hwformat, self.mformatu]:
+      slash.skip_test("{format} format not supported".format(**vars(self)))
+
+    maxw, maxh = self.caps["maxres"]
+    if self.width > maxw or self.height > maxh:
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
+
+    if vars(self).get("slices", 1) > 1 and not self.caps.get("multislice", True):
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.slice > 1 unsupported in this mode", **vars(self)))
+
+    if not self.caps.get(self.rcmode, True):
+      slash.skip_test(
+        format_value(
+          "{platform}.{driver}.{rcmode} unsupported in this mode", **vars(self)))
+
+    if vars(self).get("profile", None) is not None:
+      self.mprofile = self.map_profile()
+      if self.mprofile is None:
+        slash.skip_test("{profile} profile is not supported".format(**vars(self)))
+
+  def encode(self):
+    self.validate_caps()
+
+    iopts = self.gen_input_opts()
+    oopts = self.gen_output_opts()
+    name  = self.gen_name().format(**vars(self))
+    ext   = self.get_file_ext()
+
+    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
+    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+
+    if vars(self).get("r2r", None) is not None:
+      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
+      md5ref = md5(self.encoded)
+      get_media()._set_test_details(md5_ref = md5ref)
+      for i in range(1, self.r2r):
+        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
+        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+        result = md5(self.encoded)
+        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
+        assert md5ref == result, "r2r md5 mismatch"
+        # delete encoded file after each iteration
+        get_media()._purge_test_artifact(self.encoded)
+    else:
+      self.check_bitrate()
+      self.check_metrics()
+
+  def check_metrics(self):
+    iopts = "filesrc location={encoded} ! {gstdecoder}"
+    oopts = (
+      "videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
+      " file-checksum=false frame-checksum=false plane-checksum=false"
+      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
+    name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
+
+    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+
+    get_media().baseline.check_psnr(
+      psnr = calculate_psnr(
+        self.source, self.decoded,
+        self.width, self.height,
+        self.frames, self.format),
+      context = self.refctx,
+    )
+
+  def check_bitrate(self):
+    encsize = os.path.getsize(self.encoded)
+    bitrate_actual = encsize * 8 * vars(self).get("fps", 25) / 1024.0 / self.frames
+    get_media()._set_test_details(
+      size_encoded = encsize,
+      bitrate_actual = "{:-.2f}".format(bitrate_actual))
+
+    if "cbr" == self.rcmode:
+      bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
+      get_media()._set_test_details(bitrate_gap = "{:.2%}".format(bitrate_gap))
+
+      # acceptable bitrate within 10% of bitrate
+      assert(bitrate_gap <= 0.10)
+
+    elif self.rcmode in ["vbr", "la_vbr"]:
+      # acceptable bitrate within 25% of minrate and 10% of maxrate
+      assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)

--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -1,81 +1,23 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.common import get_media
+from ....lib.gstreamer.decoderbase import BaseDecoderTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.msdk.util import mapformatu, using_compatible_driver
+
 @slash.requires(*have_gst_element("msdk"))
-@slash.requires(*have_gst_element("checksumsink2"))
 @slash.requires(using_compatible_driver)
-class DecoderTest(slash.Test):
+class DecoderTest(BaseDecoderTest):
   def before(self):
-    self.refctx = []
+    super().before()
     os.environ["GST_MSDK_DRM_DEVICE"] = get_media().render_device
 
-  @timefn("gst")
-  def call_gst(self):
-    call(
-      "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder}"
-      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
-      " frame-checksum=false plane-checksum=false dump-output=true"
-      " dump-location={decoded}".format(**vars(self)))
-
-  def gen_name(self):
-    name = "{case}_{width}x{height}_{format}"
-    if vars(self).get("r2r", None) is not None:
-      name += "_r2r"
-    return name
-
-  def validate_caps(self):
-    if match_best_format(self.format, self.caps["fmts"]) is None:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{format} not supported", **vars(self)))
-
-    maxw, maxh = self.caps["maxres"]
-    if self.width > maxw or self.height > maxh:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
-
-    self.mformatu = mapformatu(self.format)
-    if self.mformatu is None:
-      slash.skip_test(
-        "gstreamer.{format} not supported".format(**vars(self)))
-
-    skip_test_if_missing_features(self)
-
-  def decode(self):
-    self.validate_caps()
-
-    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
-
-    name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst()
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.decoded)
-      get_media()._set_test_details(md5_ref = md5ref)
-      for i in range(1, self.r2r):
-        self.decoded = get_media()._test_artifact(
-          "{}_{}.yuv".format(name, i))
-        self.call_gst()
-        result = md5(self.decoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
-        assert result == md5ref, "r2r md5 mismatch"
-        # delete decoded file after each iteration
-        get_media()._purge_test_artifact(self.decoded)
-    else:
-      self.check_metrics()
-
-  def check_metrics(self):
-    check_metric(**vars(self))
+  def map_formatu(self):
+    return mapformatu(self.format)

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -1,36 +1,44 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.gstreamer.encoderbase import BaseEncoderTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.msdk.util import using_compatible_driver, mapprofile, map_best_hw_format, mapformat, mapformatu
+from ....lib.common import get_media
+
 @slash.requires(*have_gst_element("msdk"))
-@slash.requires(*have_gst_element("checksumsink2"))
 @slash.requires(using_compatible_driver)
-class EncoderTest(slash.Test):
-  def gen_input_opts(self):
-    opts = "filesrc location={source} num-buffers={frames}"
-    opts += " ! rawvideoparse format={mformat} width={width} height={height}"
+class EncoderTest(BaseEncoderTest):
+  def before(self):
+    super().before()
+    os.environ["GST_MSDK_DRM_DEVICE"] = get_media().render_device
 
-    if vars(self).get("fps", None) is not None:
-      opts += " framerate={fps}"
+  def map_profile(self):
+    return mapprofile(self.codec, self.profile)
 
-    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
+  def map_best_hw_format(self):
+    ifmts = self.caps["fmts"]
+    if self.codec not in ["hevc-8", "vp9"]:
+      ifmts = list(set(ifmts) - set(["AYUV"]))
+    return map_best_hw_format(self.format, ifmts)
 
-    return opts
+  def map_format(self):
+    return mapformat(self.format)
 
-  def gen_output_opts(self):
-    opts = "{gstencoder}"
+  def map_formatu(self):
+    return mapformatu(self.format)
 
+  def gen_encoder_opts(self):
+    opts = ""
     if self.codec not in ["jpeg",]:
       opts += " rate-control={rcmode}"
       opts += " hardware=true"
-
     if vars(self).get("gop", None) is not None:
       opts += " gop-size={gop}"
     if vars(self).get("qp", None) is not None:
@@ -61,161 +69,4 @@ class EncoderTest(slash.Test):
     if vars(self).get("ladepth", None) is not None:
       opts += " rc-lookahead={ladepth}"
 
-    if vars(self).get("gstmediatype", None) is not None:
-      opts += " ! {gstmediatype}"
-      if vars(self).get("profile", None) is not None:
-        opts += ",profile={mprofile}"
-
-    if vars(self).get("gstparser", None) is not None:
-      opts += " ! {gstparser}"
-
-    if vars(self).get("gstmuxer", None) is not None:
-      opts += " ! {gstmuxer}"
-
-    opts += " ! filesink location={encoded}"
-
     return opts
-
-  def gen_name(self):
-    name = "{case}-{rcmode}"
-    if vars(self).get("profile", None) is not None:
-      name += "-{profile}"
-    if vars(self).get("fps", None) is not None:
-      name += "-{fps}"
-    if vars(self).get("gop", None) is not None:
-      name += "-{gop}"
-    if vars(self).get("qp", None) is not None:
-      name += "-{qp}"
-    if vars(self).get("slices", None) is not None:
-      name += "-{slices}"
-    if vars(self).get("quality", None) is not None:
-      name += "-{quality}"
-    if vars(self).get("bframes", None) is not None:
-      name += "-{bframes}"
-    if vars(self).get("minrate", None) is not None:
-      name += "-{minrate}k"
-    if vars(self).get("maxrate", None) is not None:
-      name += "-{maxrate}k"
-    if vars(self).get("refmode", None) is not None:
-      name += "-{refmode}"
-    if vars(self).get("refs", None) is not None:
-      name += "-{refs}"
-    if vars(self).get("lowpower", False):
-      name += "-low-power"
-    if vars(self).get("loopshp", None) is not None:
-      name += "-{loopshp}"
-    if vars(self).get("looplvl", None) is not None:
-      name += "-{looplvl}"
-    if vars(self).get("ladepth", None) is not None:
-      name += "-{ladepth}"
-    if vars(self).get("r2r", None) is not None:
-      name += "-r2r"
-
-    return name
-
-  @timefn("gst")
-  def call_gst(self, iopts, oopts):
-    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
-      iopts = iopts, oopts = oopts))
-
-  def before(self):
-    self.refctx = []
-    os.environ["GST_MSDK_DRM_DEVICE"] = get_media().render_device
-
-  def validate_caps(self):
-    ifmts = self.caps["fmts"]
-    if self.codec not in ["hevc-8", "vp9"]:
-      ifmts = list(set(ifmts) - set(["AYUV"]))
-
-    self.hwformat = map_best_hw_format(self.format, ifmts)
-    self.mformat  = mapformat(self.format)
-    self.mformatu = mapformatu(self.format)
-    if None in [self.hwformat, self.mformatu]:
-      slash.skip_test("{format} format not supported".format(**vars(self)))
-
-    skip_test_if_missing_features(self)
-
-    maxw, maxh = self.caps["maxres"]
-    if self.width > maxw or self.height > maxh:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
-
-    if vars(self).get("slices", 1) > 1 and not self.caps.get("multislice", True):
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.slice > 1 unsupported in this mode", **vars(self)))
-
-    if not self.caps.get(self.rcmode, True):
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{rcmode} unsupported in this mode", **vars(self)))
-
-    if vars(self).get("profile", None) is not None:
-      self.mprofile = mapprofile(self.codec, self.profile)
-      if self.mprofile is None:
-        slash.skip_test("{profile} profile is not supported".format(**vars(self)))
-
-  def encode(self):
-    self.validate_caps()
-
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
-    name  = self.gen_name().format(**vars(self))
-    ext   = self.get_file_ext()
-
-    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.encoded)
-      get_media()._set_test_details(md5_ref = md5ref)
-      for i in range(1, self.r2r):
-        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
-        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.encoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
-        assert md5ref == result, "r2r md5 mismatch"
-        # delete encoded file after each iteration
-        get_media()._purge_test_artifact(self.encoded)
-    else:
-      self.check_bitrate()
-      self.check_metrics()
-
-  def check_metrics(self):
-    iopts = "filesrc location={encoded} ! {gstdecoder}"
-    oopts = (
-      "videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
-      " file-checksum=false frame-checksum=false plane-checksum=false"
-      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
-    name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
-
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    get_media().baseline.check_psnr(
-      psnr = calculate_psnr(
-        self.source, self.decoded,
-        self.width, self.height,
-        self.frames, self.format),
-      context = self.refctx,
-    )
-
-  def check_bitrate(self):
-    encsize = os.path.getsize(self.encoded)
-    bitrate_actual = encsize * 8 * vars(self).get("fps", 25) / 1024.0 / self.frames
-    get_media()._set_test_details(
-      size_encoded = encsize,
-      bitrate_actual = "{:-.2f}".format(bitrate_actual))
-
-    if "cbr" == self.rcmode:
-      bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
-      get_media()._set_test_details(bitrate_gap = "{:.2%}".format(bitrate_gap))
-
-      # acceptable bitrate within 10% of bitrate
-      assert(bitrate_gap <= 0.10)
-
-    elif self.rcmode in ["vbr", "la_vbr"]:
-      # acceptable bitrate within 25% of minrate and 10% of maxrate
-      assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)

--- a/lib/gstreamer/msdk/util.py
+++ b/lib/gstreamer/msdk/util.py
@@ -4,20 +4,12 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib.common import memoize, try_call, get_media
+from ....lib.common import memoize, get_media
 from ....lib.formats import match_best_format
+from ....lib.gstreamer.util import *
 
 def using_compatible_driver():
   return get_media()._get_driver_name() == "iHD"
-
-@memoize
-def have_gst():
-  return try_call("which gst-launch-1.0") and try_call("which gst-inspect-1.0")
-
-@memoize
-def have_gst_element(element):
-  result = try_call("gst-inspect-1.0 {}".format(element))
-  return result, element
 
 def get_supported_format_map():
   #The map first entry is for gst element properties;the second entry is for gst caps filters

--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -1,170 +1,63 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.gstreamer.vppbase import BaseVppTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.msdk.util import using_compatible_driver
+from ....lib.gstreamer.msdk.util import map_best_hw_format, mapformat, mapformatu
+from ....lib.common import get_media
+
 @slash.requires(*have_gst_element("msdk"))
 @slash.requires(*have_gst_element("msdkvpp"))
-@slash.requires(*have_gst_element("checksumsink2"))
 @slash.requires(using_compatible_driver)
-class VppTest(slash.Test):
+class VppTest(BaseVppTest):
   def before(self):
-    self.refctx = []
+    super().before()
     os.environ["GST_MSDK_DRM_DEVICE"] = get_media().render_device
+    vars(self).update(gstvpp = "msdkvpp")
 
-  def gen_input_opts(self):
-    if self.vpp_element not in ["deinterlace"]:
-      opts = "filesrc location={source} num-buffers={frames}"
-      opts += " ! rawvideoparse format={mformat} width={width} height={height}"
-    else:
-      opts = "filesrc location={source}"
-      opts += " ! {gstdecoder}"
-
-    if self.vpp_element not in ["csc", "deinterlace"]:
-      if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={ihwformat}"
-
-    return opts
-
-  def gen_output_opts(self):
-    opts = "msdkvpp hardware=true"
-    if self.vpp_element not in ["csc"]:
-      if self.vpp_element in ["scale"]:
-        opts += " scaling-mode=1"
-      elif self.vpp_element in ["deinterlace"]:
-        opts += " deinterlace-mode=1 deinterlace-method={mmethod}"
-      elif self.vpp_element in ["brightness"]:
-        opts += " brightness={mlevel}"
-      elif self.vpp_element in ["contrast"]:
-        opts += " contrast={mlevel}"
-      elif self.vpp_element in ["denoise"]:
-        opts += " denoise={level}"
-      elif  self.vpp_element in ["hue"]:
-        opts += " hue={mlevel}"
-      elif  self.vpp_element in ["saturation"]:
-        opts += " saturation={mlevel}"
-      elif  self.vpp_element in ["sharpen"]:
-        opts += " detail={level}"
-      elif  self.vpp_element in ["transpose"]:
-        opts += " video-direction={direction}"
-      elif self.vpp_element in ["crop"]:
-        opts += " crop-left={left} crop-right={right} crop-top={top} crop-bottom={bottom}"
-
-      opts += " ! video/x-raw,format={ohwformat}"
-      if self.vpp_element in ["scale"]:
-        opts += ",width={scale_width},height={scale_height}"
-      elif self.vpp_element in ["deinterlace"]:
-        opts += ",width={width},height={height}"
-
-      if self.ofmt != self.ohwformat:
-        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-    else:
-      opts += " ! video/x-raw,format={ohwformat}"
-
-    opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
-    opts += " plane-checksum=false dump-output=true dump-location={ofile} eos-after={frames}"
-
-    return opts
-
-  def gen_name(self):
-    name = "{case}"
-
-    if self.vpp_element in ["scale"]:
-      name += "_{scale_width}x{scale_height}"
-    elif self.vpp_element in ["crop"]:
-      name += "_{crop_width}x{crop_height}"
-    else:
-      name += "_{width}x{height}"
-
-    if self.vpp_element in ["contrast"]:
-      name += "_contrast_{level}"
-    elif self.vpp_element in ["saturation"]:
-      name += "_saturation_{level}"
-    elif self.vpp_element in ["hue"]:
-      name += "_hue_{level}"
-    elif self.vpp_element in ["brightness"]:
-      name += "_brightness_{level}"
-    elif self.vpp_element in ["denoise"]:
-      name += "_denoise_{level}"
-    elif self.vpp_element in ["sharpen"]:
-      name += "_sharpen_{level}"
-    elif self.vpp_element in ["scale"]:
-      name += "_scaled"
-    elif self.vpp_element in ["csc"]:
-      name += "_csc_{csc}"
-    elif self.vpp_element in ["deinterlace"]:
-      name += "_deinterlace_{method}_{rate}"
-    elif  self.vpp_element in ["transpose"]:
-      name += "_transpose_{degrees}_{method}"
-    elif self.vpp_element in ["crop"]:
-      name += "_crop_{left}_{right}_{top}_{bottom}"
-
-    if vars(self).get("r2r", None) is not None:
-      name += "_r2r"
-
-    name += "_{format}"
-
-    return name
-
-  @timefn("gst")
-  def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(iopts = iopts, oopts = oopts))
-
-  def validate_caps(self):
-    ifmts         = self.caps.get("ifmts", [])
-    ofmts         = self.caps.get("ofmts", [])
-    self.ifmt     = self.format
-    self.ofmt     = self.format if "csc" != self.vpp_element else self.csc
-    self.mformat  = mapformat(self.format)
-    self.mformatu = mapformatu(self.format)
-
+  def get_output_formats(self):
     # MSDK does not support I420 output formats even though
     # iHD supports it.  Thus, msdkvpp can't output it directly (HW).
-    ofmts = list(set(ofmts) - set(["I420"]))
+    return list(set(super().get_output_formats()) - set(["I420"]))
 
-    if self.mformat is None:
-      slash.skip_test("gst.{format} unsupported".format(**vars(self)))
+  def map_best_hw_format(self, format, hwformats):
+    return map_best_hw_format(format, hwformats)
 
-    if self.vpp_element in ["csc"]:
-      self.ihwformat = mapformatu(self.ifmt if self.ifmt in ifmts else None)
-      self.ohwformat = mapformatu(self.ofmt if self.ofmt in ofmts else None)
-    else:
-      self.ihwformat = map_best_hw_format(self.ifmt, ifmts)
-      self.ohwformat = map_best_hw_format(self.ofmt, ofmts)
+  def map_format(self, format):
+    return mapformat(format)
 
-    if self.ihwformat is None:
-      slash.skip_test("{ifmt} unsupported".format(**vars(self)))
-    if self.ohwformat is None:
-      slash.skip_test("{ofmt} unsupported".format(**vars(self)))
+  def map_formatu(self, format):
+    return mapformatu(format)
 
-  def vpp(self):
-    self.validate_caps()
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
-    name  = self.gen_name().format(**vars(self))
+  def gen_vpp_opts(self):
+    opts = "hardware=true"
+    if self.vpp_element in ["scale"]:
+      opts += " scaling-mode=1"
+    elif self.vpp_element in ["deinterlace"]:
+      opts += " deinterlace-mode=1 deinterlace-method={mmethod}"
+    elif self.vpp_element in ["brightness"]:
+      opts += " brightness={mlevel}"
+    elif self.vpp_element in ["contrast"]:
+      opts += " contrast={mlevel}"
+    elif self.vpp_element in ["denoise"]:
+      opts += " denoise={level}"
+    elif self.vpp_element in ["hue"]:
+      opts += " hue={mlevel}"
+    elif self.vpp_element in ["saturation"]:
+      opts += " saturation={mlevel}"
+    elif self.vpp_element in ["sharpen"]:
+      opts += " detail={level}"
+    elif self.vpp_element in ["transpose"]:
+      opts += " video-direction={direction}"
+    elif self.vpp_element in ["crop"]:
+      opts += " crop-left={left} crop-right={right}"
+      opts += " crop-top={top} crop-bottom={bottom}"
 
-    self.ofile = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.ofile)
-      get_media()._set_test_details(md5_ref = md5ref)
-
-      for i in range(1, self.r2r):
-        self.ofile = get_media()._test_artifact(
-          "{}_{}.yuv".format(name, i))
-        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.ofile)
-        get_media()._set_test_details(**{ "md5_{:03}".format(i) : result})
-        assert result == md5ref, "r2r md5 mismatch"
-        #delete output file after each iteration
-        get_media()._purge_test_artifact(self.ofile)
-    else:
-      self.check_metrics()
+    return opts

--- a/lib/gstreamer/util.py
+++ b/lib/gstreamer/util.py
@@ -1,0 +1,16 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ...lib.common import memoize, try_call
+
+@memoize
+def have_gst():
+  return try_call("which gst-launch-1.0") and try_call("which gst-inspect-1.0")
+
+@memoize
+def have_gst_element(element):
+  result = try_call("gst-inspect-1.0 {}".format(element))
+  return result, element

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -1,80 +1,22 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.common import get_media
+from ....lib.gstreamer.decoderbase import BaseDecoderTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.vaapi.util import mapformatu
+
 @slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("checksumsink2"))
-class DecoderTest(slash.Test):
+class DecoderTest(BaseDecoderTest):
   def before(self):
-    self.refctx = []
+    super().before()
     os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
 
-  @timefn("gst")
-  def call_gst(self):
-    call(
-      "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder}"
-      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
-      " frame-checksum=false plane-checksum=false dump-output=true"
-      " dump-location={decoded}".format(**vars(self)))
-
-  def gen_name(self):
-    name = "{case}_{width}x{height}_{format}"
-    if vars(self).get("r2r", None) is not None:
-      name += "_r2r"
-    return name
-
-  def validate_caps(self):
-    if match_best_format(self.format, self.caps["fmts"]) is None:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{format} not supported", **vars(self)))
-
-    maxw, maxh = self.caps["maxres"]
-    if self.width > maxw or self.height > maxh:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
-
-    self.mformatu = mapformatu(self.format)
-    if self.mformatu is None:
-      slash.skip_test(
-        "gstreamer.{format} not supported".format(**vars(self)))
-
-    skip_test_if_missing_features(self)
-
-  def decode(self):
-    self.validate_caps()
-
-    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
-
-    name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst()
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.decoded)
-      get_media()._set_test_details(md5_ref = md5ref)
-      for i in range(1, self.r2r):
-        self.decoded = get_media()._test_artifact(
-          "{}_{}.yuv".format(name, i))
-        self.call_gst()
-        result = md5(self.decoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
-        assert result == md5ref, "r2r md5 mismatch"
-        # delete decoded file after each iteration
-        get_media()._purge_test_artifact(self.decoded)
-    else:
-      self.check_metrics()
-
-  def check_metrics(self):
-    check_metric(**vars(self))
+  def map_formatu(self):
+    return mapformatu(self.format)

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -1,34 +1,39 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.gstreamer.encoderbase import BaseEncoderTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.vaapi.util import mapprofile, map_best_hw_format, mapformat, mapformatu
+from ....lib.common import get_media
+
 @slash.requires(*have_gst_element("vaapi"))
-@slash.requires(*have_gst_element("checksumsink2"))
-class EncoderTest(slash.Test):
-  def gen_input_opts(self):
-    opts = "filesrc location={source} num-buffers={frames}"
-    opts += " ! rawvideoparse format={mformat} width={width} height={height}"
+class EncoderTest(BaseEncoderTest):
+  def before(self):
+    super().before()
+    os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
 
-    if vars(self).get("fps", None) is not None:
-      opts += " framerate={fps}"
+  def map_profile(self):
+    return mapprofile(self.codec, self.profile)
 
-    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
+  def map_best_hw_format(self):
+    return map_best_hw_format(self.format, self.caps["fmts"])
 
-    return opts
+  def map_format(self):
+    return mapformat(self.format)
 
-  def gen_output_opts(self):
-    opts = "{gstencoder}"
+  def map_formatu(self):
+    return mapformatu(self.format)
 
+  def gen_encoder_opts(self):
+    opts = ""
     if self.codec not in ["jpeg",]:
       opts += " rate-control={rcmode}"
-
     if vars(self).get("gop", None) is not None:
       opts += " keyframe-period={gop}"
     if vars(self).get("qp", None) is not None:
@@ -53,164 +58,12 @@ class EncoderTest(slash.Test):
       opts += " ref-pic-mode={refmode}"
     if vars(self).get("refs", None) is not None:
       opts += " refs={refs}"
-
     if vars(self).get("lowpower", None) is not None:
       opts += " tune="
       opts += "low-power" if self.lowpower else "none"
-
     if vars(self).get("loopshp", None) is not None:
       opts += " sharpness-level={loopshp}"
     if vars(self).get("looplvl", None) is not None:
       opts += " loop-filter-level={looplvl}"
 
-    opts += " ! {gstmediatype}"
-    if vars(self).get("profile", None) is not None:
-      opts += ",profile={mprofile}"
-
-    if vars(self).get("gstparser", None) is not None:
-      opts += " ! {gstparser}"
-
-    if vars(self).get("gstmuxer", None) is not None:
-      opts += " ! {gstmuxer}"
-
-    opts += " ! filesink location={encoded}"
-
     return opts
-
-  def gen_name(self):
-    name = "{case}-{rcmode}"
-    if vars(self).get("profile", None) is not None:
-      name += "-{profile}"
-    if vars(self).get("fps", None) is not None:
-      name += "-{fps}"
-    if vars(self).get("gop", None) is not None:
-      name += "-{gop}"
-    if vars(self).get("qp", None) is not None:
-      name += "-{qp}"
-    if vars(self).get("slices", None) is not None:
-      name += "-{slices}"
-    if vars(self).get("quality", None) is not None:
-      name += "-{quality}"
-    if vars(self).get("bframes", None) is not None:
-      name += "-{bframes}"
-    if vars(self).get("minrate", None) is not None:
-      name += "-{minrate}k"
-    if vars(self).get("maxrate", None) is not None:
-      name += "-{maxrate}k"
-    if vars(self).get("refmode", None) is not None:
-      name += "-{refmode}"
-    if vars(self).get("refs", None) is not None:
-      name += "-{refs}"
-    if vars(self).get("lowpower", False):
-      name += "-low-power"
-    if vars(self).get("loopshp", None) is not None:
-      name += "-{loopshp}"
-    if vars(self).get("looplvl", None) is not None:
-      name += "-{looplvl}"
-    if vars(self).get("r2r", None) is not None:
-      name += "-r2r"
-
-    return name
-
-  @timefn("gst")
-  def call_gst(self, iopts, oopts):
-    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
-      iopts = iopts, oopts = oopts))
-
-  def before(self):
-    self.refctx = []
-    os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
-
-  def validate_caps(self):
-    self.hwformat = map_best_hw_format(self.format, self.caps["fmts"])
-    self.mformat  = mapformat(self.format)
-    self.mformatu = mapformatu(self.format)
-    if None in [self.hwformat, self.mformatu]:
-      slash.skip_test("{format} format not supported".format(**vars(self)))
-
-    skip_test_if_missing_features(self)
-
-    maxw, maxh = self.caps["maxres"]
-    if self.width > maxw or self.height > maxh:
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
-
-    if vars(self).get("slices", 1) > 1 and not self.caps.get("multislice", True):
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.slice > 1 unsupported in this mode", **vars(self)))
-
-    if not self.caps.get(self.rcmode, True):
-      slash.skip_test(
-        format_value(
-          "{platform}.{driver}.{rcmode} unsupported in this mode", **vars(self)))
-
-    if vars(self).get("profile", None) is not None:
-      self.mprofile = mapprofile(self.codec, self.profile)
-      if self.mprofile is None:
-        slash.skip_test("{profile} profile is not supported".format(**vars(self)))
-
-  def encode(self):
-    self.validate_caps()
-
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
-    name  = self.gen_name().format(**vars(self))
-    ext   = self.get_file_ext()
-
-    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.encoded)
-      get_media()._set_test_details(md5_ref = md5ref)
-      for i in range(1, self.r2r):
-        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
-        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.encoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i): result})
-        assert md5ref == result, "r2r md5 mismatch"
-        # delete encoded file after each iteration
-        get_media()._purge_test_artifact(self.encoded)
-    else:
-      self.check_bitrate()
-      self.check_metrics()
-
-  def check_metrics(self):
-    iopts = "filesrc location={encoded} ! {gstdecoder}"
-    oopts = (
-      " videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
-      " file-checksum=false frame-checksum=false plane-checksum=false"
-      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
-    name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
-
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    get_media().baseline.check_psnr(
-      psnr = calculate_psnr(
-        self.source, self.decoded,
-        self.width, self.height,
-        self.frames, self.format),
-      context = self.refctx,
-    )
-
-  def check_bitrate(self):
-    encsize = os.path.getsize(self.encoded)
-    bitrate_actual = encsize * 8 * vars(self).get("fps", 25) / 1024.0 / self.frames
-    get_media()._set_test_details(
-      size_encoded = encsize,
-      bitrate_actual = "{:-.2f}".format(bitrate_actual))
-
-    if "cbr" == self.rcmode:
-      bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
-      get_media()._set_test_details(bitrate_gap = "{:.2%}".format(bitrate_gap))
-
-      # acceptable bitrate within 10% of bitrate
-      assert(bitrate_gap <= 0.10)
-
-    elif "vbr" == self.rcmode:
-      # acceptable bitrate within 25% of minrate and 10% of maxrate
-      assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)

--- a/lib/gstreamer/vaapi/util.py
+++ b/lib/gstreamer/vaapi/util.py
@@ -4,17 +4,9 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib.common import memoize, try_call
+from ....lib.common import memoize
 from ....lib.formats import match_best_format
-
-@memoize
-def have_gst():
-  return try_call("which gst-launch-1.0") and try_call("which gst-inspect-1.0")
-
-@memoize
-def have_gst_element(element):
-  result = try_call("gst-inspect-1.0 {}".format(element))
-  return result, element
+from ....lib.gstreamer.util import *
 
 def get_supported_format_map():
   #The map first entry is for gst element properties;the second entry is for gst caps filters

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -1,39 +1,36 @@
 ###
-### Copyright (C) 2018-2019 Intel Corporation
+### Copyright (C) 2018-2021 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ....lib import *
-from .util import *
 import os
+import slash
 
-@slash.requires(have_gst)
+from ....lib.gstreamer.vppbase import BaseVppTest
+from ....lib.gstreamer.util import have_gst_element
+from ....lib.gstreamer.vaapi.util import map_best_hw_format, mapformat, mapformatu
+from ....lib.common import get_media
+
 @slash.requires(*have_gst_element("vaapi"))
 @slash.requires(*have_gst_element("vaapipostproc"))
-@slash.requires(*have_gst_element("checksumsink2"))
-class VppTest(slash.Test):
+class VppTest(BaseVppTest):
   def before(self):
-    self.refctx = []
+    super().before()
     os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
+    vars(self).update(gstvpp = "vaapipostproc")
 
-  def gen_input_opts(self):
-    if self.vpp_element not in ["deinterlace"]:
-      opts =  "filesrc location={source} num-buffers={frames}"
-      opts += " ! rawvideoparse format={mformat} width={width} height={height}"
-    else:
-      opts =  "filesrc location={source}"
-      opts += " ! {gstdecoder}"
+  def map_best_hw_format(self, format, hwformats):
+    return map_best_hw_format(format, hwformats)
 
-    if self.vpp_element not in ["csc", "deinterlace"]:
-      if self.ifmt != self.ihwformat:
-        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={ihwformat}"
+  def map_format(self, format):
+    return mapformat(format)
 
-    return opts
+  def map_formatu(self, format):
+    return mapformatu(format)
 
-  def gen_output_opts(self):
-    opts = "vaapipostproc"
-
+  def gen_vpp_opts(self):
+    opts = ""
     if self.vpp_element in ["contrast"]:
       opts += " contrast={mlevel}"
     elif self.vpp_element in ["saturation"]:
@@ -53,112 +50,4 @@ class VppTest(slash.Test):
     elif self.vpp_element in ["crop"]:
       opts += " crop-left={left} crop-right={right} crop-top={top} crop-bottom={bottom}"
 
-    opts += " ! video/x-raw,format={ohwformat}"
-
-    if self.vpp_element in ["scale"]:
-      opts += ",width={scale_width},height={scale_height}"
-    elif self.vpp_element in ["deinterlace"]:
-      opts += ",width={width},height={height}"
-
-    if self.ofmt != self.ohwformat and self.vpp_element not in ["csc"]:
-      opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-
-    opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
-    opts += " plane-checksum=false dump-output=true dump-location={ofile} eos-after={frames}"
-
     return opts
-
-  def gen_name(self):
-    name = "{case}"
-
-    if self.vpp_element in ["scale"]:
-      name += "_{scale_width}x{scale_height}"
-    elif self.vpp_element in ["crop"]:
-      name += "_{crop_width}x{crop_height}"
-    else:
-      name += "_{width}x{height}"
-
-    if self.vpp_element in ["contrast"]:
-      name += "_contrast_{level}"
-    elif self.vpp_element in ["saturation"]:
-      name += "_saturation_{level}"
-    elif self.vpp_element in ["hue"]:
-      name += "_hue_{level}"
-    elif self.vpp_element in ["brightness"]:
-      name += "_brightness_{level}"
-    elif self.vpp_element in ["denoise"]:
-      name += "_denoise_{level}"
-    elif self.vpp_element in ["sharpen"]:
-      name += "_sharpen_{level}"
-    elif self.vpp_element in ["scale"]:
-      name += "_scaled"
-    elif self.vpp_element in ["csc"]:
-      name += "_csc_{csc}"
-    elif self.vpp_element in ["deinterlace"]:
-      name += "_deinterlace_{method}_{rate}"
-    elif self.vpp_element in ["transpose"]:
-      name += "_transpose_{degrees}_{method}"
-    elif self.vpp_element in ["crop"]:
-      name += "_crop_{left}_{right}_{top}_{bottom}"
-
-    if vars(self).get("r2r", None) is not None:
-      name += "_r2r"
-
-    name += "_{format}"
-
-    return name
-
-  @timefn("gst")
-  def call_gst(self, iopts, oopts):
-    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
-      iopts = iopts, oopts = oopts))
-
-  def validate_caps(self):
-    ifmts         = self.caps.get("ifmts", [])
-    ofmts         = self.caps.get("ofmts", [])
-    self.ifmt     = self.format
-    self.ofmt     = self.format if "csc" != self.vpp_element else self.csc
-    self.mformat  = mapformat(self.format)
-    self.mformatu = mapformatu(self.format)
-
-    if self.mformat is None:
-      slash.skip_test("gst-vaapi.{format} unsupported".format(**vars(self)))
-
-    if "csc" == self.vpp_element:
-      self.ihwformat = mapformatu(self.ifmt if self.ifmt in ifmts else None)
-      self.ohwformat = mapformatu(self.ofmt if self.ofmt in ofmts else None)
-    else:
-      self.ihwformat = map_best_hw_format(self.ifmt, ifmts)
-      self.ohwformat = map_best_hw_format(self.ofmt, ofmts)
-
-    if self.ihwformat is None:
-      slash.skip_test("{ifmt} unsupported".format(**vars(self)))
-    if self.ohwformat is None:
-      slash.skip_test("{ofmt} unsupported".format(**vars(self)))
-
-  def vpp(self):
-    self.validate_caps()
-
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
-    name  = self.gen_name().format(**vars(self))
-
-    self.ofile = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-
-    if vars(self).get("r2r", None) is not None:
-      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.ofile)
-      get_media()._set_test_details(md5_ref = md5ref)
-
-      for i in range(1, self.r2r):
-        self.ofile = get_media()._test_artifact(
-          "{}_{}.yuv".format(name, i))
-        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.ofile)
-        get_media()._set_test_details(**{ "md5_{:03}".format(i) : result})
-        assert result == md5ref, "r2r md5 mismatch"
-        #delete output file after each iteration
-        get_media()._purge_test_artifact(self.ofile)
-    else:
-      self.check_metrics()

--- a/lib/gstreamer/vppbase.py
+++ b/lib/gstreamer/vppbase.py
@@ -1,0 +1,155 @@
+###
+### Copyright (C) 2018-2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ...lib.common import timefn, get_media, call
+from ...lib.gstreamer.util import have_gst, have_gst_element
+from ...lib.metrics import md5
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("checksumsink2"))
+class BaseVppTest(slash.Test):
+  def before(self):
+    self.refctx = []
+
+  def get_input_formats(self):
+    return self.caps.get("ifmts", [])
+
+  def get_output_formats(self):
+    return self.caps.get("ofmts", [])
+
+  def map_best_hw_format(self, format, hwformats):
+    raise NotImplementedError
+
+  def map_format(self, format):
+    raise NotImplementedError
+
+  def map_formatu(self, format):
+    raise NotImplementedError
+
+  def check_metrics(self):
+    raise NotImplementedError
+
+  def gen_vpp_opts(self):
+    raise NotImplementedError
+
+  def gen_input_opts(self):
+    if self.vpp_element not in ["deinterlace"]:
+      opts =  "filesrc location={source} num-buffers={frames}"
+      opts += " ! rawvideoparse format={mformat} width={width} height={height}"
+    else:
+      opts =  "filesrc location={source}"
+      opts += " ! {gstdecoder}"
+    if self.vpp_element not in ["csc", "deinterlace"]:
+      if self.ifmt != self.ihwformat:
+        opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={ihwformat}"
+
+    return opts
+
+  def gen_output_opts(self):
+    opts = "{gstvpp} " + self.gen_vpp_opts()
+    opts += " ! video/x-raw,format={ohwformat}"
+    if self.vpp_element in ["scale"]:
+      opts += ",width={scale_width},height={scale_height}"
+    elif self.vpp_element in ["deinterlace"]:
+      opts += ",width={width},height={height}"
+    if self.ofmt != self.ohwformat and self.vpp_element not in ["csc"]:
+      opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
+    opts += " ! checksumsink2 file-checksum=false qos=false frame-checksum=false"
+    opts += " plane-checksum=false dump-output=true dump-location={ofile} eos-after={frames}"
+
+    return opts
+
+  def gen_name(self):
+    name = "{case}"
+    if self.vpp_element in ["scale"]:
+      name += "_{scale_width}x{scale_height}"
+    elif self.vpp_element in ["crop"]:
+      name += "_{crop_width}x{crop_height}"
+    else:
+      name += "_{width}x{height}"
+    if self.vpp_element in ["contrast"]:
+      name += "_contrast_{level}"
+    elif self.vpp_element in ["saturation"]:
+      name += "_saturation_{level}"
+    elif self.vpp_element in ["hue"]:
+      name += "_hue_{level}"
+    elif self.vpp_element in ["brightness"]:
+      name += "_brightness_{level}"
+    elif self.vpp_element in ["denoise"]:
+      name += "_denoise_{level}"
+    elif self.vpp_element in ["sharpen"]:
+      name += "_sharpen_{level}"
+    elif self.vpp_element in ["scale"]:
+      name += "_scaled"
+    elif self.vpp_element in ["csc"]:
+      name += "_csc_{csc}"
+    elif self.vpp_element in ["deinterlace"]:
+      name += "_deinterlace_{method}_{rate}"
+    elif self.vpp_element in ["transpose"]:
+      name += "_transpose_{degrees}_{method}"
+    elif self.vpp_element in ["crop"]:
+      name += "_crop_{left}_{right}_{top}_{bottom}"
+    if vars(self).get("r2r", None) is not None:
+      name += "_r2r"
+    name += "_{format}"
+
+    return name
+
+  @timefn("gst")
+  def call_gst(self, iopts, oopts):
+    call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(iopts = iopts, oopts = oopts))
+
+  def validate_caps(self):
+    ifmts         = self.get_input_formats()
+    ofmts         = self.get_output_formats()
+    self.ifmt     = self.format
+    self.ofmt     = self.format if "csc" != self.vpp_element else self.csc
+    self.mformat  = self.map_format(self.format)
+    self.mformatu = self.map_formatu(self.format)
+
+    if self.mformat is None:
+      slash.skip_test("{gstvpp}.{format} unsupported".format(**vars(self)))
+
+    if "csc" == self.vpp_element:
+      self.ihwformat = self.map_formatu(self.ifmt if self.ifmt in ifmts else None)
+      self.ohwformat = self.map_formatu(self.ofmt if self.ofmt in ofmts else None)
+    else:
+      self.ihwformat = self.map_best_hw_format(self.ifmt, ifmts)
+      self.ohwformat = self.map_best_hw_format(self.ofmt, ofmts)
+
+    if self.ihwformat is None:
+      slash.skip_test("{ifmt} unsupported".format(**vars(self)))
+    if self.ohwformat is None:
+      slash.skip_test("{ofmt} unsupported".format(**vars(self)))
+
+  def vpp(self):
+    self.validate_caps()
+
+    iopts = self.gen_input_opts()
+    oopts = self.gen_output_opts()
+    name  = self.gen_name().format(**vars(self))
+
+    self.ofile = get_media()._test_artifact("{}.yuv".format(name))
+    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+
+    if vars(self).get("r2r", None) is not None:
+      assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
+      md5ref = md5(self.ofile)
+      get_media()._set_test_details(md5_ref = md5ref)
+
+      for i in range(1, self.r2r):
+        self.ofile = get_media()._test_artifact(
+          "{}_{}.yuv".format(name, i))
+        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+        result = md5(self.ofile)
+        get_media()._set_test_details(**{ "md5_{:03}".format(i) : result})
+        assert result == md5ref, "r2r md5 mismatch"
+        #delete output file after each iteration
+        get_media()._purge_test_artifact(self.ofile)
+    else:
+      self.check_metrics()


### PR DESCRIPTION
This is a minimal refactor to consolidate common gstreamer decoder, encoder and vpp test code into base classes so they can be shared between vaapi and msdk (and va) plugin tests without slash.requires and other plugin specific settings leaking across subclasses (e.g. see https://github.com/intel/vaapi-fits/pull/284#pullrequestreview-653824960).  NOTE: this does not include transcoder consolidation (will submit in separate PR).