### PR TITLE
Add hevc-8 mainsp profile map for gst-msdk

### DIFF
--- a/lib/gstreamer/msdk/util.py
+++ b/lib/gstreamer/msdk/util.py
@@ -99,6 +99,7 @@ def mapprofile(codec,profile):
       "scc"                   : "screen-extended-main",
       "scc-444"               : "screen-extended-main-444",
       "main444"               : "main-444",
+      "mainsp"                : "main-still-picture",
     },
     "hevc-10" : {
       "main10"                : "main-10",


### PR DESCRIPTION
Add hevc-8 mainsp profile map for gst-msdk

Signed-off-by: Luo Focus <focus.luo@intel.com>