### PR TITLE
Speedup test case

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -14,3 +14,20 @@ def skip_test_if_missing_features(test):
         format_value(
           "{platform}.{driver}.feature({feature}) not supported",
           **vars(test), feature = feature))
+
+case_parameter_list = {}
+def skip_test_by_parameter(class_name, skip_lst, **kwargs):
+    if class_name not in case_parameter_list:
+      case_parameter_list[class_name] = list()
+    case_dict = case_parameter_list[class_name]
+    parameter_str = ''
+    for k,v in kwargs.items():
+      if k in skip_lst:
+        slash.logger.notice("NOTICE: '{}' parameter unused (not supported by plugin)".format(k))
+      else:
+        parameter_str += '{}={} '.format(k, v)
+
+    if parameter_str not in case_dict:
+      case_dict.append(parameter_str)
+    else:
+      slash.skip_test("{} already run, because '{}' unused".format(parameter_str, ','.join(skip_lst)))

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -35,9 +35,16 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cqp_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -55,9 +62,16 @@ class cqp_lp(VP9_10EncoderLPTest):
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -78,9 +92,17 @@ class cbr_lp(VP9_10EncoderLPTest):
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/vbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -35,9 +35,16 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cqp_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -55,9 +62,16 @@ class cqp_lp(VP9EncoderLPTest):
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -78,9 +92,17 @@ class cbr_lp(VP9EncoderLPTest):
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/vbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -49,7 +49,15 @@ class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/hevc/cqp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bframes   = bframes,
+      qp        = qp,
+      quality   = quality,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -74,7 +82,14 @@ class cqp(HEVC10EncoderTest):
 
 class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/hevc/cqp_lp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      qp        = qp,
+      quality   = quality,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -151,7 +166,17 @@ class cbr_lp(HEVC10EncoderLPTest):
 
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/hevc/vbr", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bframes   = bframes,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      refs      = refs,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -180,7 +205,16 @@ class vbr(HEVC10EncoderTest):
 
 class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/hevc/vbr_lp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      refs      = refs,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -36,8 +36,16 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cqp_lp", ['quality', 'refmode'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -56,8 +64,16 @@ class cqp_lp(VP9_10EncoderLPTest):
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cbr_lp", ['looplvl', 'refmode'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -79,9 +95,17 @@ class cbr_lp(VP9_10EncoderLPTest):
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/vbr_lp", ['quality', 'looplvl', 'refmode'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -51,7 +51,15 @@ class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/hevc/cqp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bframes   = bframes,
+      qp        = qp,
+      quality   = quality,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -76,7 +84,14 @@ class cqp(HEVC8EncoderTest):
 
 class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/hevc/cqp_lp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      qp        = qp,
+      quality   = quality,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
@@ -159,7 +174,17 @@ class cbr_lp(HEVC8EncoderLPTest):
 
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/hevc/vbr", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bframes   = bframes,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      refs      = refs,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -188,7 +213,16 @@ class vbr(HEVC8EncoderTest):
 
 class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/hevc/vbr_lp", ['quality'],
+      case      = case,
+      gop       = gop,
+      slices    = slices,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      refs      = refs,
+      profile   = profile,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -30,7 +30,13 @@ class MPEG2EncoderTest(EncoderTest):
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/mpeg2/cqp", ['quality'],
+      case      = case,
+      gop       = gop,
+      bframes   = bframes,
+      qp        = qp,
+      quality   = quality,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -37,7 +37,14 @@ class VP8EncoderTest(VP8EncoderBaseTest):
 class cqp(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp8/cqp", ['quality'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(spec[case].copy())
     vars(self).update(
       case      = case,
@@ -70,7 +77,15 @@ class cbr(VP8EncoderTest):
 class vbr(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp8/vbr", ['quality'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -45,8 +45,15 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cqp", ['quality', 'refmode'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -64,8 +71,16 @@ class cqp(VP9EncoderTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cqp_lp", ['quality', 'refmode'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -84,7 +99,15 @@ class cqp_lp(VP9EncoderLPTest):
 
 class cbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cbr", ['refmode'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -106,8 +129,16 @@ class cbr(VP9EncoderTest):
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cbr_lp", ['refmode', 'looplvl'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -129,8 +160,16 @@ class cbr_lp(VP9EncoderLPTest):
 
 class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/vbr", ['refmode', 'quality'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      refmode   = refmode,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -152,9 +191,17 @@ class vbr(VP9EncoderTest):
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/vbr_lp", ['refmode', 'quality', 'looplvl'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      quality   = quality,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -38,9 +38,16 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cqp_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -58,9 +65,16 @@ class cqp_lp(VP9_10EncoderLPTest):
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -81,9 +95,17 @@ class cbr_lp(VP9_10EncoderLPTest):
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/vbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -38,9 +38,16 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cqp_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -58,9 +65,16 @@ class cqp_lp(VP9EncoderLPTest):
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -81,9 +95,17 @@ class cbr_lp(VP9EncoderLPTest):
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/vbr_lp", ['refmode', 'looplvl', 'loopshp'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -37,7 +37,16 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cqp_lp", ['slices'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -57,7 +66,16 @@ class cqp_lp(VP9_10EncoderLPTest):
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/cbr_lp", ['slices'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -80,7 +98,17 @@ class cbr_lp(VP9_10EncoderLPTest):
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/10bit/vp9/vbr_lp", ['slices'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -112,7 +112,16 @@ class vbr(VP9EncoderTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cqp_lp", ['slices'],
+      case      = case,
+      ipmode    = ipmode,
+      qp        = qp,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -132,7 +141,16 @@ class cqp_lp(VP9EncoderLPTest):
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/cbr_lp", ['slices'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -155,7 +173,17 @@ class cbr_lp(VP9EncoderLPTest):
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
+    skip_test_by_parameter("encode/vp9/vbr_lp", ['slices'],
+      case      = case,
+      gop       = gop,
+      bitrate   = bitrate,
+      fps       = fps,
+      quality   = quality,
+      slices    = slices,
+      refmode   = refmode,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+    )
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,


### PR DESCRIPTION
Use list to record test-case parameter, so when meet `not supported` plugin
can query the parameter to confirm run/skip it