### PR TITLE
skip redundant cases with unused params

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -42,6 +42,23 @@ def timefn(label):
 
   return inner
 
+def parametrize_with_unused(names, values, unused):
+  def inner(func):
+    used = vars(func).setdefault("__params_used__", list())
+    @functools.wraps(func)
+    @slash.parametrize(names, sorted(values))
+    def wrapper(*args, **kwargs):
+      params = kwargs.copy()
+      for param in unused:
+        slash.logger.notice("NOTICE: '{}' parameter unused".format(param))
+        del params[param]
+      if params in used:
+        slash.skip_test("Test case is redundant")
+      used.append(params)
+      func(*args, **kwargs)
+    return wrapper
+  return inner
+
 class memoize:
   def __init__(self, function):
     self.function = function

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -35,9 +35,6 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -48,16 +45,13 @@ class cqp_lp(VP9_10EncoderLPTest):
       quality   = quality,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -71,16 +65,13 @@ class cbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -95,7 +86,7 @@ class vbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
     self.encode()

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -34,7 +34,7 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
     )
 
 class cqp_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -47,11 +47,11 @@ class cqp_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -67,11 +67,11 @@ class cbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -88,5 +88,5 @@ class vbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, quality)
     self.encode()

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -35,9 +35,6 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -48,16 +45,13 @@ class cqp_lp(VP9EncoderLPTest):
       quality   = quality,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -71,16 +65,13 @@ class cbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -95,7 +86,7 @@ class vbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
     self.encode()

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -34,7 +34,7 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
     )
 
 class cqp_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -47,11 +47,11 @@ class cqp_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -67,11 +67,11 @@ class cbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       quality   = quality,
@@ -88,6 +88,6 @@ class vbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, quality)
     self.encode()
 

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -49,7 +49,6 @@ class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -61,12 +60,12 @@ class cqp(HEVC10EncoderTest):
       slices  = slices,
     )
 
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
+  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
+  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
@@ -74,7 +73,6 @@ class cqp(HEVC10EncoderTest):
 
 class cqp_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -85,12 +83,12 @@ class cqp_lp(HEVC10EncoderLPTest):
       slices  = slices,
     )
 
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
+  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
+  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
@@ -151,7 +149,6 @@ class cbr_lp(HEVC10EncoderLPTest):
 
 class vbr(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -167,12 +164,12 @@ class vbr(HEVC10EncoderTest):
       slices = slices,
     )
 
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
+  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
+  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
@@ -180,7 +177,6 @@ class vbr(HEVC10EncoderTest):
 
 class vbr_lp(HEVC10EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
@@ -195,12 +191,12 @@ class vbr_lp(HEVC10EncoderLPTest):
       slices = slices,
     )
 
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
+  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
+  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -48,7 +48,7 @@ class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
     )
 
 class cqp(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, bframes, qp, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -62,17 +62,17 @@ class cqp(HEVC10EncoderTest):
 
   @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.init(spec, case, gop, slices, bframes, qp, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, qp, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC10EncoderLPTest):
-  def init(self, tspec, case, gop, slices, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, qp, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
@@ -85,12 +85,12 @@ class cqp_lp(HEVC10EncoderLPTest):
 
   @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, qp, quality, profile):
-    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.init(spec, case, gop, slices, qp, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    self.init(spec_r2r, case, gop, slices, qp, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
@@ -148,7 +148,7 @@ class cbr_lp(HEVC10EncoderLPTest):
     self.encode()
 
 class vbr(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -166,17 +166,17 @@ class vbr(HEVC10EncoderTest):
 
   @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, refs, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC10EncoderLPTest):
-  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
@@ -193,11 +193,11 @@ class vbr_lp(HEVC10EncoderLPTest):
 
   @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main10']), ['quality'])
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.init(spec, case, gop, slices, bitrate, fps, refs, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']), ['quality'])
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -35,7 +35,7 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
     )
 
 class cqp_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -49,11 +49,11 @@ class cqp_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, slices, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -70,11 +70,11 @@ class cbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -91,7 +91,7 @@ class vbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
     self.encode()
 
 

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -36,8 +36,6 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -49,15 +47,13 @@ class cqp_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -72,16 +68,13 @@ class cbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -96,7 +89,7 @@ class vbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -50,7 +50,7 @@ class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
     )
 
 class cqp(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, bframes, qp, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -64,17 +64,17 @@ class cqp(HEVC8EncoderTest):
 
   @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.init(spec, case, gop, slices, bframes, qp, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, qp, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC8EncoderLPTest):
-  def init(self, tspec, case, gop, slices, qp, quality, profile):
+  def init(self, tspec, case, gop, slices, qp, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
@@ -87,12 +87,12 @@ class cqp_lp(HEVC8EncoderLPTest):
 
   @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, qp, quality, profile):
-    self.init(spec, case, gop, slices, qp, quality, profile)
+    self.init(spec, case, gop, slices, qp, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
+    self.init(spec_r2r, case, gop, slices, qp, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
@@ -156,7 +156,7 @@ class cbr_lp(HEVC8EncoderLPTest):
     self.encode()
 
 class vbr(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -174,17 +174,17 @@ class vbr(HEVC8EncoderTest):
 
   @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, refs, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC8EncoderLPTest):
-  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
@@ -201,11 +201,11 @@ class vbr_lp(HEVC8EncoderLPTest):
 
   @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.init(spec, case, gop, slices, bitrate, fps, refs, profile)
     self.encode()
 
   @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -51,7 +51,6 @@ class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -63,12 +62,12 @@ class cqp(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
+  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
+  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
@@ -76,7 +75,6 @@ class cqp(HEVC8EncoderTest):
 
 class cqp_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, qp, quality, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
@@ -87,12 +85,12 @@ class cqp_lp(HEVC8EncoderLPTest):
       slices   = slices,
     )
 
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
+  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, qp, quality, profile):
     self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
+  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, qp, quality, profile):
     self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
@@ -159,7 +157,6 @@ class cbr_lp(HEVC8EncoderLPTest):
 
 class vbr(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -175,12 +172,12 @@ class vbr(HEVC8EncoderTest):
       slices  = slices,
     )
 
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
+  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
+  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
@@ -188,7 +185,6 @@ class vbr(HEVC8EncoderTest):
 
 class vbr_lp(HEVC8EncoderLPTest):
   def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
@@ -203,12 +199,12 @@ class vbr_lp(HEVC8EncoderLPTest):
       slices  = slices,
     )
 
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
+  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main']), ['quality'])
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
+  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']), ['quality'])
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -30,7 +30,6 @@ class MPEG2EncoderTest(EncoderTest):
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -41,12 +40,12 @@ class cqp(MPEG2EncoderTest):
       rcmode  = "cqp",
     )
 
-  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
+  @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec), ['quality'])
   def test(self, case, gop, bframes, qp, quality):
     self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
+  @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec_r2r), ['quality'])
   def test_r2r(self, case, gop, bframes, qp, quality):
     self.init(spec_r2r, case, gop, bframes, qp, quality)
     vars(self).setdefault("r2r", 5)

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -29,7 +29,7 @@ class MPEG2EncoderTest(EncoderTest):
     return "VAProfileMPEG2.*"
 
 class cqp(MPEG2EncoderTest):
-  def init(self, tspec, case, gop, bframes, qp, quality):
+  def init(self, tspec, case, gop, bframes, qp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -42,11 +42,11 @@ class cqp(MPEG2EncoderTest):
 
   @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec), ['quality'])
   def test(self, case, gop, bframes, qp, quality):
-    self.init(spec, case, gop, bframes, qp, quality)
+    self.init(spec, case, gop, bframes, qp)
     self.encode()
 
   @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec_r2r), ['quality'])
   def test_r2r(self, case, gop, bframes, qp, quality):
-    self.init(spec_r2r, case, gop, bframes, qp, quality)
+    self.init(spec_r2r, case, gop, bframes, qp)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -35,9 +35,8 @@ class VP8EncoderTest(VP8EncoderBaseTest):
     )
 
 class cqp(VP8EncoderTest):
-  @slash.parametrize(*gen_vp8_cqp_parameters(spec))
+  @parametrize_with_unused(*gen_vp8_cqp_parameters(spec), ['quality'])
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(spec[case].copy())
     vars(self).update(
       case      = case,
@@ -68,9 +67,8 @@ class cbr(VP8EncoderTest):
     self.encode()
 
 class vbr(VP8EncoderTest):
-  @slash.parametrize(*gen_vp8_vbr_parameters(spec))
+  @parametrize_with_unused(*gen_vp8_vbr_parameters(spec), ['quality'])
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
     vars(self).update(spec[case].copy())
     vars(self).update(
       bitrate   = bitrate,

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -44,7 +44,7 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
     )
 
 class cqp(VP9EncoderTest):
-  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -57,11 +57,11 @@ class cqp(VP9EncoderTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)  
+    self.init(spec, case, ipmode, qp, looplvl, loopshp)
     self.encode()
 
 class cqp_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -75,11 +75,11 @@ class cqp_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, slices, looplvl, loopshp)
     self.encode()
 
 class cbr(VP9EncoderTest):
-  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -96,11 +96,11 @@ class cbr(VP9EncoderTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode'])
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -117,11 +117,11 @@ class cbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
     self.encode()
 
 class vbr(VP9EncoderTest):
-  def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -138,11 +138,11 @@ class vbr(VP9EncoderTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['quality', 'refmode'])
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -159,6 +159,6 @@ class vbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
     self.encode()
 

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -45,8 +45,6 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -57,15 +55,13 @@ class cqp(VP9EncoderTest):
       rcmode    = "cqp",
     )
 
-  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)  
     self.encode()
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -77,14 +73,13 @@ class cqp_lp(VP9EncoderLPTest):
       rcmode    = "cqp",
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -99,15 +94,13 @@ class cbr(VP9EncoderTest):
       rcmode    = "cbr",
     )
 
-  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode'])
   def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -122,15 +115,13 @@ class cbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -145,16 +136,13 @@ class vbr(VP9EncoderTest):
       rcmode    = "vbr",
     )
 
-  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['quality', 'refmode'])
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'quality' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -169,7 +157,7 @@ class vbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp)
     self.encode()

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -38,9 +38,6 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -51,16 +48,13 @@ class cqp_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -74,16 +68,13 @@ class cbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -99,7 +90,7 @@ class vbr_lp(VP9_10EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -37,7 +37,7 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
     )
 
 class cqp_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -50,11 +50,11 @@ class cqp_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -70,11 +70,11 @@ class cbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -92,5 +92,5 @@ class vbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, quality, slices)
     self.encode()

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -37,7 +37,7 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
     )
 
 class cqp_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -50,11 +50,11 @@ class cqp_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -70,11 +70,11 @@ class cbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -92,5 +92,5 @@ class vbr_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, quality, slices)
     self.encode()

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -38,9 +38,6 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -51,16 +48,13 @@ class cqp_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -74,16 +68,13 @@ class cbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'refmode' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'looplvl' parameter unused (not supported by plugin)")
-    slash.logger.notice("NOTICE: 'loopshp' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -99,7 +90,7 @@ class vbr_lp(VP9EncoderLPTest):
       slices    = slices,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -36,7 +36,7 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
     )
 
 class cqp_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -51,11 +51,11 @@ class cqp_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -73,11 +73,11 @@ class cbr_lp(VP9_10EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -97,6 +97,6 @@ class vbr_lp(VP9_10EncoderLPTest):
     )
 
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices'])
-  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def test(self, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -37,7 +37,6 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -50,14 +49,13 @@ class cqp_lp(VP9_10EncoderLPTest):
       refmode   = refmode,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -73,14 +71,13 @@ class cbr_lp(VP9_10EncoderLPTest):
       refmode   = refmode,
     )
 
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -99,7 +96,7 @@ class vbr_lp(VP9_10EncoderLPTest):
       refmode   = refmode,
     )
 
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -111,7 +111,7 @@ class vbr(VP9EncoderTest):
     self.encode()
 
 class cqp_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -126,11 +126,11 @@ class cqp_lp(VP9EncoderLPTest):
 
   @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -148,11 +148,11 @@ class cbr_lp(VP9EncoderLPTest):
   
   @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -173,5 +173,5 @@ class vbr_lp(VP9EncoderLPTest):
   
   @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp)
     self.encode()

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -112,7 +112,6 @@ class vbr(VP9EncoderTest):
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -125,14 +124,13 @@ class cqp_lp(VP9EncoderLPTest):
       refmode   = refmode,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -148,14 +146,13 @@ class cbr_lp(VP9EncoderLPTest):
       refmode   = refmode,
     )
   
-  @slash.parametrize(*gen_vp9_cbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    slash.logger.notice("NOTICE: 'slices' parameter unused (not supported by plugin)")
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -174,7 +171,7 @@ class vbr_lp(VP9EncoderLPTest):
       refmode   = refmode,
     )
   
-  @slash.parametrize(*gen_vp9_vbr_lp_parameters(spec))
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp)
     self.encode()


### PR DESCRIPTION
    Test function parameters need to be consistent across each
    middleware implemented test.  However, some test functions
    don't support some parameters due to middleware limitations.
    Thus, if a test is variated on the unused parameter(s) it
    creates a redundancy of the same test case.
    
    This change adds support to allow test cases to be skipped
    when unused parameter(s) create a redundancy where the used
    parameters have already been exercised by another case.