### PR TITLE
load_test_spec: allow cases to explicitly avoid components

### DIFF
--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -120,13 +120,5 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ....lib import get_media
-  import copy
-
-  # get copy of general ctx entries
-  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
-
-  # component specific entries override general ctx entries
-  spec.update(get_media()._get_test_spec("ffmpeg-qsv", *ctx))
-
-  return spec
+  from ....lib import util as libutil
+  return libutil.load_test_spec("ffmpeg-qsv", *ctx)

--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -134,13 +134,5 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ....lib import get_media
-  import copy
-
-  # get copy of general ctx entries
-  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
-
-  # component specific entries override general ctx entries
-  spec.update(get_media()._get_test_spec("ffmpeg-vaapi", *ctx))
-
-  return spec
+  from ....lib import util as libutil
+  return libutil.load_test_spec("ffmpeg-vaapi", *ctx)

--- a/lib/gstreamer/msdk/util.py
+++ b/lib/gstreamer/msdk/util.py
@@ -109,13 +109,5 @@ def mapprofile(codec,profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ....lib import get_media
-  import copy
-
-  # get copy of general ctx entries
-  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
-
-  # component specific entries override general ctx entries
-  spec.update(get_media()._get_test_spec("gst-msdk", *ctx))
-
-  return spec
+  from ....lib import util as libutil
+  return libutil.load_test_spec("gst-msdk", *ctx)

--- a/lib/gstreamer/va/util.py
+++ b/lib/gstreamer/va/util.py
@@ -62,13 +62,5 @@ def map_transpose_direction(degrees, method):
   }.get((degrees, method), None)
 
 def load_test_spec(*ctx):
-  from ....lib import get_media
-  import copy
-
-  # get copy of general ctx entries
-  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
-
-  # component specific entries override general ctx entries
-  spec.update(get_media()._get_test_spec("gst-va", *ctx))
-
-  return spec
+  from ....lib import util as libutil
+  return libutil.load_test_spec("gst-va", *ctx)

--- a/lib/gstreamer/vaapi/util.py
+++ b/lib/gstreamer/vaapi/util.py
@@ -113,13 +113,5 @@ def mapprofile(codec, profile):
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):
-  from ....lib import get_media
-  import copy
-
-  # get copy of general ctx entries
-  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
-
-  # component specific entries override general ctx entries
-  spec.update(get_media()._get_test_spec("gst-vaapi", *ctx))
-
-  return spec
+  from ....lib import util as libutil
+  return libutil.load_test_spec("gst-vaapi", *ctx)

--- a/lib/util.py
+++ b/lib/util.py
@@ -22,6 +22,11 @@ def load_test_spec(component, *ctx):
   # get copy of general ctx entries
   spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
 
+  # remove cases that explicitly don't want to use this component
+  for k, v in list(spec.items()):
+    if component in set(v.get("not_components", set())):
+      del spec[k]
+
   # component specific entries override general ctx entries
   spec.update(get_media()._get_test_spec(component, *ctx))
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -14,3 +14,15 @@ def skip_test_if_missing_features(test):
         format_value(
           "{platform}.{driver}.feature({feature}) not supported",
           **vars(test), feature = feature))
+
+def load_test_spec(component, *ctx):
+  from .common import get_media
+  import copy
+
+  # get copy of general ctx entries
+  spec = copy.deepcopy(get_media()._get_test_spec(*ctx))
+
+  # component specific entries override general ctx entries
+  spec.update(get_media()._get_test_spec(component, *ctx))
+
+  return spec


### PR DESCRIPTION
Currently, user config cases can be added on a component-specific
basis.  Often, this mechanism is used to avoid running cases on a
specific component.  That is, if the user config wants cases to be
run on all components except component X, then the user config has
to know about all of the components.  This poses a problem where
the user config might forget about one component where the intention
is to run it.  Or, if a new component is added to the framework,
then all user configs need to be updated to ensure cases are added
to that new component.

This change adds a test case property, called "not_components",
that allows the user config to explicitly avoid specific
components for given cases.  Thus, the user config does not
need to know about every available/new component in the
framework.

Example:

```python
media._get_test_spec("jpeg", "encode").update({
  "case_a" : dict(
    format = "AYUV", width = ..., ...,
    not_components = set(["ffmpeg-vaapi",]),
  ),
  ...
})
```