### PR TITLE
Add tests to detect and check MFX runtime.

### DIFF
--- a/lib/caps/ADL/info
+++ b/lib/caps/ADL/info
@@ -9,5 +9,5 @@
 ###
 
 info = dict(
-  gpu = dict(gen = 12),
+  gpu = dict(gen = 12.2),
 )

--- a/lib/mfx/__init__.py
+++ b/lib/mfx/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/mfx/runtime.py
+++ b/lib/mfx/runtime.py
@@ -1,0 +1,63 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+import psutil
+import slash
+import threading
+import time
+
+from ...lib.common import get_media, startproc, killproc
+
+class MFXRuntimeTest(slash.Test):
+  def expected(self, dispatcher):
+    if "msdk" == dispatcher:
+      return "msdk" if get_media()._get_gpu_gen() < 12.2 else "vpl"
+    if "vpl" == dispatcher:
+      return "msdk" if get_media()._get_gpu_gen() < 12 else "vpl"
+    return None
+
+  def check(self, command):
+    proc = startproc(command)
+
+    def readproc():
+      for line in iter(proc.stdout.readline, ''):
+        slash.logger.debug(line.rstrip('\n'))
+
+    reader = threading.Thread(target = readproc)
+    reader.daemon = True
+    reader.start()
+
+    time.sleep(5) # give proc some time to roll
+
+    dispatcher = None
+    runtimes = list()
+
+    for m in psutil.Process(proc.pid).memory_maps():
+      path = os.path.split(m.path)
+      if path[-1].startswith("libmfxhw64.so"):
+        runtimes.append("msdk")
+      elif path[-1].startswith("libmfx-gen.so"):
+        runtimes.append("vpl")
+      elif path[-1].startswith("libmfx.so"):
+        dispatcher = "msdk"
+      elif path[-1].startswith("libvpl.so"):
+        dispatcher = "vpl"
+
+    expected_runtime = self.expected(dispatcher)
+    get_media()._set_test_details(
+      dispatcher        = dispatcher,
+      runtimes          = runtimes,
+      expected_runtime  = expected_runtime,
+    )
+
+    try:
+      assert expected_runtime in runtimes
+    finally:
+      killproc(proc)
+      proc.stdin.close()
+      proc.stdout.close()
+      reader.join(30)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ slash==1.12.0
 numpy
 scikit-image
 distro
+psutil
 py-cpuinfo

--- a/test/ffmpeg-qsv/general/__init__.py
+++ b/test/ffmpeg-qsv/general/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-qsv/general/runtime.py
+++ b/test/ffmpeg-qsv/general/runtime.py
@@ -1,0 +1,27 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ....lib.common import get_media
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.mfx.runtime import MFXRuntimeTest
+
+@slash.requires(have_ffmpeg)
+@slash.requires(have_ffmpeg_qsv_accel)
+@slash.requires(using_compatible_driver)
+class detect(MFXRuntimeTest):
+  def before(self):
+    super().before()
+    self.renderDevice = get_media().render_device
+
+  def test(self):
+    self.check(
+      "ffmpeg -nostats -v verbose -init_hw_device qsv=qsv:hw"
+      " -qsv_device {renderDevice} -hwaccel qsv"
+      " -filter_hw_device qsv -f lavfi -i yuvtestsrc"
+      " -f null /dev/null".format(**vars(self))
+    )

--- a/test/gst-msdk/general/__init__.py
+++ b/test/gst-msdk/general/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-msdk/general/runtime.py
+++ b/test/gst-msdk/general/runtime.py
@@ -1,0 +1,19 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ....lib.gstreamer.msdk.util import *
+from ....lib.mfx.runtime import MFXRuntimeTest
+
+@slash.requires(have_gst)
+@slash.requires(*have_gst_element("msdkvpp"))
+@slash.requires(using_compatible_driver)
+class detect(MFXRuntimeTest):
+  def test(self):
+    self.check(
+      "gst-launch-1.0 --no-position -vf videotestsrc ! msdkvpp ! fakesink"
+    )


### PR DESCRIPTION
These are crude tests that execute ffmpeg-qsv and gst-msdk pipelines and searches which MFX dispatcher and runtime libraries are loaded in the process' memory map.

