### PR TITLE
Caps: removed vp8 encode on iHD GLK

### DIFF
--- a/lib/caps/GLK/iHD
+++ b/lib/caps/GLK/iHD
@@ -24,7 +24,6 @@ caps = dict(
   ),
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
-    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
     hevc_8  = dict(maxres = res4k , fmts = ["NV12"]),
     hevc_10 = dict(maxres = res4k , fmts = ["P010"]),
   ),


### PR DESCRIPTION
removed vp8 encode on iHD GLK

Signed-off-by: Luo Focus <focus.luo@intel.com>