### PR TITLE
gst-va: fixed a typo for av1-10 dec cmd line

### DIFF
--- a/test/gst-va/decode/10bit/av1.py
+++ b/test/gst-va/decode/10bit/av1.py
@@ -33,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapiav1dec".format(dx),
+      gstdecoder  = "{} ! vaav1dec".format(dx),
     )
     self.decode()


### PR DESCRIPTION
fixed a typo for av1-10 dec cmd line, which miss type
 "vaapiav1dec" as "vaav1dec"
On local machine, the "vaapiav1dec" worked with cmdline
./smoke run test/gst-va/decode/10bit/av1.py --pl TGL
\ --contex=sanity

Signed-off-by: Luo Focus <focus.luo@intel.com>