### PR TITLE
ffmpeg-qsv: add avc forced_idr encode test support

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -57,6 +57,8 @@ class EncoderTest(slash.Test):
     if vars(self).get("ladepth", None) is not None:
       opts += " -look_ahead 1"
       opts += " -look_ahead_depth {ladepth}"
+    if vars(self).get("forced_idr", None) is not None:
+      opts += " -force_key_frames expr:1 -forced_idr 1"
 
     opts += " -vframes {frames} -y {encoded}"
 
@@ -90,6 +92,8 @@ class EncoderTest(slash.Test):
       name += "-{lowpower}"
     if vars(self).get("ladepth", None) is not None:
       name += "-{ladepth}"
+    if vars(self).get("forced_idr", None) is not None:
+      name += "-{forced_idr}"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"
 
@@ -170,6 +174,13 @@ class EncoderTest(slash.Test):
     if vars(self).get("ladepth", None) is not None:
       m = re.search(r"Using the VBR with lookahead \(LA\) ratecontrol method", self.output, re.MULTILINE)
       assert m is not None, "It appears that the lookahead did not load"
+
+    if vars(self).get("forced_idr", None) is not None:
+      output = call(
+        "ffmpeg -v verbose -i {encoded} -c:v copy"
+        " -vframes {frames} -bsf:v trace_headers"
+        " -f null - 2>&1 | grep 'nal_unit_type.*5' | wc -l".format(**vars(self)))
+      assert str(self.frames) == output.strip(), "It appears that the forced_idr did not work"
 
   def check_metrics(self):
     iopts = "-c:v {ffdecoder} -i {encoded}"

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -181,6 +181,34 @@ def gen_avc_vbr_la_parameters(spec, profiles):
   params = gen_avc_vbr_la_variants(spec, profiles)
   return keys, params
 
+def gen_avc_forced_idr_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("forced_idr", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      rcmode  = variant["rcmode"]
+      bitrate = variant.get("bitrate", None)
+      qp      = variant.get("qp", None)
+      if "cqp" == rcmode:
+        assert bitrate == None, "We shouldn't set a value to bitrate for CQP."
+        variant.update(maxrate = None)
+      else:
+        assert qp == None, "We shouldn't set a value to qp for CBR/VBR."
+        if "cbr" == rcmode:
+          variant.update(maxrate = bitrate)
+        elif "vbr" == rcmode:
+          variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, rcmode, bitrate, variant["maxrate"],
+          qp, variant["quality"], profile
+        ]
+
+def gen_avc_forced_idr_parameters(spec, profiles):
+  keys = ("case", "rcmode", "bitrate", "maxrate", "qp", "quality", "profile")
+  params = gen_avc_forced_idr_variants(spec, profiles)
+  return keys, params
+
 gen_hevc_cqp_parameters = gen_avc_cqp_parameters
 gen_hevc_cbr_parameters = gen_avc_cbr_parameters
 gen_hevc_vbr_parameters = gen_avc_vbr_parameters

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -220,3 +220,23 @@ class vbr_la(AVCEncoderTest):
       ladepth   = ladepth,
     )
     self.encode()
+
+class forced_idr(AVCEncoderTest):
+  def init(self, tspec, case, rcmode, bitrate, maxrate, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      qp         = qp,
+      quality    = quality,
+      forced_idr = 1,
+    )
+
+  @slash.parametrize(*gen_avc_forced_idr_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, rcmode, bitrate, maxrate, qp, quality, profile):
+    self.init(spec, case, rcmode, bitrate, maxrate, qp, quality, profile)
+    self.encode()


### PR DESCRIPTION
Add avc forced_idr encode test support for ffmpeg-qsv

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>