### PR TITLE
ffmpeg-qsv: fix forced_idr bug

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -57,7 +57,7 @@ class EncoderTest(slash.Test):
     if vars(self).get("ladepth", None) is not None:
       opts += " -look_ahead 1"
       opts += " -look_ahead_depth {ladepth}"
-    if vars(self).get("forced_idr", None) is not None:
+    if vars(self).get("vforced_idr", None) is not None:
       opts += " -force_key_frames expr:1 -forced_idr 1"
 
     opts += " -vframes {frames} -y {encoded}"
@@ -92,8 +92,8 @@ class EncoderTest(slash.Test):
       name += "-{lowpower}"
     if vars(self).get("ladepth", None) is not None:
       name += "-{ladepth}"
-    if vars(self).get("forced_idr", None) is not None:
-      name += "-{forced_idr}"
+    if vars(self).get("vforced_idr", None) is not None:
+      name += "-{vforced_idr}"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"
 
@@ -175,7 +175,7 @@ class EncoderTest(slash.Test):
       m = re.search(r"Using the VBR with lookahead \(LA\) ratecontrol method", self.output, re.MULTILINE)
       assert m is not None, "It appears that the lookahead did not load"
 
-    if vars(self).get("forced_idr", None) is not None:
+    if vars(self).get("vforced_idr", None) is not None:
       output = call(
         "ffmpeg -v verbose -i {encoded} -c:v copy"
         " -vframes {frames} -bsf:v trace_headers"

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -233,7 +233,7 @@ class forced_idr(AVCEncoderTest):
       profile    = profile,
       qp         = qp,
       quality    = quality,
-      forced_idr = 1,
+      vforced_idr= 1,
     )
 
   @slash.parametrize(*gen_avc_forced_idr_parameters(spec, ['high', 'main', 'baseline']))


### PR DESCRIPTION
For forced_idr, don't use the same name for the test
variable as the user config variant key.  Because
tests that don't explicitly use the forced_idr test
variable (e.g. vbr, cbr, etc.) will inherit the config
variant as the test variable value.

Thus, rename the test variable to vforced_idr to avoid
conflict with user config.

Since #316

cc: @yefengxx @FocusLuo @Bin-CI 