### PR TITLE
encoder: support config call_timeout

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -142,6 +142,8 @@ class EncoderTest(slash.Test):
   def encode(self):
     self.validate_caps()
 
+    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
+
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
     name  = self.gen_name().format(**vars(self))

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -155,6 +155,8 @@ class EncoderTest(slash.Test):
   def encode(self):
     self.validate_caps()
 
+    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
+
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
     name  = self.gen_name().format(**vars(self))

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -136,6 +136,8 @@ class BaseEncoderTest(slash.Test):
   def encode(self):
     self.validate_caps()
 
+    get_media().test_call_timeout = vars(self).get("call_timeout", 0)
+
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()
     name  = self.gen_name().format(**vars(self))


### PR DESCRIPTION
Add encode test support for user config test case "call_timeout" override.