### PR TITLE
lib: parse encode config params from variants dict

### DIFF
--- a/config/avc.default
+++ b/config/avc.default
@@ -32,76 +32,84 @@ media._get_test_spec("avc", "encode").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "high"),
-    ],
-    cqp_lp = [
-      dict(gop = 1, slices = 1, qp = 28, quality = 4),
-      dict(gop = 30, slices = 1, qp = 14, quality = 4),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 250, fps = 30, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "high"),
+      ],
+      cqp_lp = [
+        dict(gop = 1, slices = 1, qp = 28, quality = 4),
+        dict(gop = 30, slices = 1, qp = 14, quality = 4),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 250, fps = 30, profile = "main"),
+      ],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "high"),
-      dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
-    ],
-    cqp_lp = [
-      dict(gop = 1, slices = 1, qp = 28, quality = 4),
-      dict(gop = 30, slices = 1, qp = 14, quality = 4),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 500, fps = 25, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "high"),
+        dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
+      ],
+      cqp_lp = [
+        dict(gop = 1, slices = 1, qp = 28, quality = 4),
+        dict(gop = 30, slices = 1, qp = 14, quality = 4),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 500, fps = 25, profile = "main"),
+      ],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "high"),
-    ],
-    cqp_lp = [
-      dict(gop = 30, slices = 1, qp = 14, quality = 4),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 4, bframes = 2, bitrate = 4000, fps = 30, profile = "main"),
-    ],
-    vbr = [
-      dict(gop = 30, slices = 3, bframes = 0, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "high"),
-      dict(gop = 30, slices = 1, bframes = 3, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "high"),
+      ],
+      cqp_lp = [
+        dict(gop = 30, slices = 1, qp = 14, quality = 4),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 4, bframes = 2, bitrate = 4000, fps = 30, profile = "main"),
+      ],
+      vbr = [
+        dict(gop = 30, slices = 3, bframes = 0, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "high"),
+        dict(gop = 30, slices = 1, bframes = 3, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
+      ],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "high"),
-      dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
-    ],
-    cqp_lp = [
-      dict(gop = 30, slices = 1, qp = 28, quality = 4),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 6000, fps = 30, profile = "high"),
-    ],
-    vbr = [
-      dict(gop = 30, slices = 3, bframes = 0, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
-      dict(gop = 30, slices = 1, bframes = 3, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "high"),
+        dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
+      ],
+      cqp_lp = [
+        dict(gop = 30, slices = 1, qp = 28, quality = 4),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 6000, fps = 30, profile = "high"),
+      ],
+      vbr = [
+        dict(gop = 30, slices = 3, bframes = 0, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
+        dict(gop = 30, slices = 1, bframes = 3, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
+      ],
+    ),
   ),
 })
 
 if media._get_driver_name() == "iHD": # iHD driver supports LP with multi-slice
   for v in media._get_test_spec("avc", "encode").values():
-    v["cqp_lp"].append(dict(gop = 30, slices = 4, qp = 14, quality = 4))
+    v["variants"]["cqp_lp"].append(dict(gop = 30, slices = 4, qp = 14, quality = 4))
 
 media._get_test_spec("avc", "transcode").update({
   "H_H-AVC_QCIF" : dict(

--- a/config/hevc.default
+++ b/config/hevc.default
@@ -32,56 +32,64 @@ media._get_test_spec("hevc", "encode", "8bit").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "main"),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 250, fps = 30, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "main"),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 250, fps = 30, profile = "main"),
+      ],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 500, fps = 25, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 500, fps = 25, profile = "main"),
+      ],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "main"),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 4, bframes = 2, bitrate = 4000, fps = 30, profile = "main"),
-    ],
-    vbr = [
-      dict(gop = 30, slices = 3, bframes = 0, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
-      dict(gop = 30, slices = 1, bframes = 3, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 28, quality = 4, profile = "main"),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 4, bframes = 2, bitrate = 4000, fps = 30, profile = "main"),
+      ],
+      vbr = [
+        dict(gop = 30, slices = 3, bframes = 0, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
+        dict(gop = 30, slices = 1, bframes = 3, bitrate = 4000, fps = 30, quality = 4, refs = 1, profile = "main"),
+      ],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
-    ],
-    cbr = [
-      dict(gop = 30, slices = 1, bframes = 0, bitrate = 6000, fps = 30, profile = "main"),
-    ],
-    vbr = [
-      dict(gop = 30, slices = 3, bframes = 0, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
-      dict(gop = 30, slices = 1, bframes = 3, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, slices = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, slices = 4, bframes = 2, qp = 28, quality = 4, profile = "main"),
+      ],
+      cbr = [
+        dict(gop = 30, slices = 1, bframes = 0, bitrate = 6000, fps = 30, profile = "main"),
+      ],
+      vbr = [
+        dict(gop = 30, slices = 3, bframes = 0, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
+        dict(gop = 30, slices = 1, bframes = 3, bitrate = 6000, fps = 30, quality = 4, refs = 1, profile = "main"),
+      ],
+    ),
   ),
 })
 

--- a/config/jpeg.default
+++ b/config/jpeg.default
@@ -32,25 +32,33 @@ media._get_test_spec("jpeg", "encode").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [dict(quality = 10), dict(quality = 73)],
+    variants = dict(
+      cqp = [dict(quality = 10), dict(quality = 73)],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [dict(quality = 10), dict(quality = 73)],
+    variants = dict(
+      cqp = [dict(quality = 10), dict(quality = 73)],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [dict(quality = 10), dict(quality = 73)],
+    variants = dict(
+      cqp = [dict(quality = 10), dict(quality = 73)],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [dict(quality = 10), dict(quality = 73)],
+    variants = dict(
+      cqp = [dict(quality = 10), dict(quality = 73)],
+    ),
   ),
 })
 

--- a/config/mpeg2.default
+++ b/config/mpeg2.default
@@ -32,35 +32,43 @@ media._get_test_spec("mpeg2", "encode").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, bframes = 0, qp = 28, quality = 4, profile = "simple"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, bframes = 0, qp = 28, quality = 4, profile = "simple"),
+      ],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 30, bframes = 2, qp = 14, quality = 4, profile = "simple"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 30, bframes = 2, qp = 14, quality = 4, profile = "simple"),
+      ],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 30, bframes = 0, qp = 28, quality = 4, profile = "main"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 30, bframes = 0, qp = 28, quality = 4, profile = "main"),
+      ],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 50,
     refctx = ["driver"],
-    cqp = [
-      dict(gop = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
-      dict(gop = 30, bframes = 2, qp = 28, quality = 4, profile = "simple"),
-    ],
+    variants = dict(
+      cqp = [
+        dict(gop = 1, bframes = 0, qp = 14, quality = 4, profile = "main"),
+        dict(gop = 30, bframes = 2, qp = 28, quality = 4, profile = "simple"),
+      ],
+    ),
   ),
 })
 

--- a/config/vp8.default
+++ b/config/vp8.default
@@ -32,44 +32,52 @@ media._get_test_spec("vp8", "encode").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 0, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
-      dict(ipmode = 1, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 250)],
-    vbr = [dict(bitrate = 250)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 0, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
+        dict(ipmode = 1, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 250)],
+      vbr = [dict(bitrate = 250)],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 1, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
-      dict(ipmode = 0, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 500)],
-    vbr = [dict(bitrate = 500)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 1, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
+        dict(ipmode = 0, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 500)],
+      vbr = [dict(bitrate = 500)],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 0, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 4000)],
-    vbr = [dict(bitrate = 4000)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 0, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 4000)],
+      vbr = [dict(bitrate = 4000)],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 1, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
-      dict(ipmode = 1, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 6000)],
-    vbr = [dict(bitrate = 6000)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 1, qp = 14, quality = 4, looplvl = 0, loopshp = 0),
+        dict(ipmode = 1, qp = 28, quality = 4, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 6000)],
+      vbr = [dict(bitrate = 6000)],
+    ),
   ),
 })
 

--- a/config/vp9.default
+++ b/config/vp9.default
@@ -33,44 +33,52 @@ media._get_test_spec("vp9", "encode", "8bit").update({
     source = os.path.join(assets, "yuv", "QCIF_NV12.yuv"),
     width = 176, height = 144, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 0, qp = 14, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
-      dict(ipmode = 1, qp = 28, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 250)],
-    vbr = [dict(bitrate = 250)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 0, qp = 14, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
+        dict(ipmode = 1, qp = 28, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 250)],
+      vbr = [dict(bitrate = 250)],
+    ),
   ),
   "QVGA" : dict(
     source = os.path.join(assets, "yuv", "QVGA_NV12.yuv"),
     width = 320, height = 240, format = "NV12", frames = 300,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 1, qp = 14, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
-      dict(ipmode = 0, qp = 28, quality = 4, refmode = 1, looplvl = 16, loopshp = 7),
-    ],
-    cbr = [dict(bitrate = 500)],
-    vbr = [dict(bitrate = 500)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 1, qp = 14, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
+        dict(ipmode = 0, qp = 28, quality = 4, refmode = 1, looplvl = 16, loopshp = 7),
+      ],
+      cbr = [dict(bitrate = 500)],
+      vbr = [dict(bitrate = 500)],
+    ),
   ),
   "720p" : dict(
     source = os.path.join(assets, "yuv", "720p_NV12.yuv"),
     width = 1280, height = 720, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 0, qp = 28, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 4000)],
-    vbr = [dict(bitrate = 4000)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 0, qp = 28, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 4000)],
+      vbr = [dict(bitrate = 4000)],
+    ),
   ),
   "1080p" : dict(
     source = os.path.join(assets, "yuv", "1080p_NV12.yuv"),
     width = 1920, height = 1080, format = "NV12", frames = 150,
     refctx = ["driver"],
-    cqp = [
-      dict(ipmode = 1, qp = 14, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
-      dict(ipmode = 1, qp = 28, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
-    ],
-    cbr = [dict(bitrate = 6000)],
-    vbr = [dict(bitrate = 6000)],
+    variants = dict(
+      cqp = [
+        dict(ipmode = 1, qp = 14, quality = 4, refmode = 1, looplvl = 0, loopshp = 0),
+        dict(ipmode = 1, qp = 28, quality = 4, refmode = 0, looplvl = 0, loopshp = 0),
+      ],
+      cbr = [dict(bitrate = 6000)],
+      vbr = [dict(bitrate = 6000)],
+    ),
   ),
 })
 

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -20,7 +20,7 @@ def format_value(value, **params):
 
 def gen_avc_cqp_variants(spec, profiles):
   for case, params in spec.items():
-    variants = copy.deepcopy(params.get("cqp", None))
+    variants = copy.deepcopy(params.get("variants", dict()).get("cqp", None))
     if variants is None:
       keys = ["gop", "slices", "bframes", "qp", "quality", "profile"]
       product  = list(itertools.product([1], [1], [0], [14, 28], [1, 4, 7], profiles))  # I, single-slice
@@ -56,7 +56,7 @@ def gen_avc_cqp_parameters(spec, profiles):
 
 def gen_avc_cbr_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cbr", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("cbr", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
 
@@ -84,7 +84,7 @@ def gen_avc_cbr_parameters(spec, profiles):
 
 def gen_hevc_cbr_level_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cbr_level", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("cbr_level", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -100,7 +100,7 @@ def gen_hevc_cbr_level_parameters( spec, profiles):
 
 def gen_avc_vbr_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("vbr", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("vbr", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -117,7 +117,7 @@ def gen_avc_vbr_parameters(spec, profiles):
 
 def gen_avc_cqp_lp_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cqp_lp", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("cqp_lp", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -133,7 +133,7 @@ def gen_avc_cqp_lp_parameters(spec, profiles):
 
 def gen_avc_cbr_lp_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("cbr_lp", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("cbr_lp", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -149,7 +149,7 @@ def gen_avc_cbr_lp_parameters(spec, profiles):
 
 def gen_avc_vbr_lp_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("vbr_lp", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("vbr_lp", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -166,7 +166,7 @@ def gen_avc_vbr_lp_parameters(spec, profiles):
 
 def gen_avc_vbr_la_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("vbr_la", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("vbr_la", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       for profile in cprofiles:
@@ -183,7 +183,7 @@ def gen_avc_vbr_la_parameters(spec, profiles):
 
 def gen_avc_forced_idr_variants(spec, profiles):
   for case, params in spec.items():
-    for variant in copy.deepcopy(params.get("forced_idr", [])):
+    for variant in copy.deepcopy(params.get("variants", dict()).get("forced_idr", [])):
       uprofile = variant.get("profile", None)
       cprofiles = [uprofile] if uprofile else profiles
       rcmode  = variant["rcmode"]
@@ -218,7 +218,7 @@ gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
 
 def gen_mpeg2_cqp_variants(spec):
   for case, params in spec.items():
-    variants = copy.deepcopy(params.get("cqp", None))
+    variants = copy.deepcopy(params.get("variants", dict()).get("cqp", None))
     if variants is None:
       keys = ["gop", "bframes", "qp", "quality"]
       product  = list(itertools.product([1], [0], [14, 28], [1, 4, 7]))  # I
@@ -248,7 +248,7 @@ def gen_mpeg2_cqp_parameters(spec):
 
 def gen_jpeg_cqp_variants(spec):
   for case, params in spec.items():
-    variants = params.get("cqp", None)
+    variants = params.get("variants", dict()).get("cqp", None)
 
     if variants is None:
       variants = list()
@@ -265,7 +265,7 @@ def gen_jpeg_cqp_parameters(spec):
 
 def gen_vp8_cqp_variants(spec):
   for case, params in spec.items():
-    variants = params.get("cqp", None)
+    variants = params.get("variants", dict()).get("cqp", None)
 
     if variants is None:
       keys = ["ipmode", "qp", "quality", "looplvl", "loopshp"]
@@ -284,7 +284,7 @@ def gen_vp8_cqp_parameters(spec):
 
 def gen_vp8_cbr_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("cbr", []):
+    for variant in params.get("variants", dict()).get("cbr", []):
         # Required: bitrate
         # Optional: gop, fps, looplvl, loopshp
         yield [
@@ -300,7 +300,7 @@ def gen_vp8_cbr_parameters(spec):
 
 def gen_vp8_vbr_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("vbr", []):
+    for variant in params.get("variants", dict()).get("vbr", []):
         # Required: bitrate
         # Optional: gop, fps, quality, looplvl, loopshp
         yield [
@@ -316,7 +316,7 @@ def gen_vp8_vbr_parameters(spec):
 
 def gen_vp9_cqp_variants(spec):
   for case, params in spec.items():
-    variants = params.get("cqp", None)
+    variants = params.get("variants", dict()).get("cqp", None)
 
     if variants is None:
       keys = ["ipmode", "qp", "quality", "refmode", "looplvl", "loopshp"]
@@ -335,7 +335,7 @@ def gen_vp9_cqp_parameters(spec):
 
 def gen_vp9_cbr_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("cbr", []):
+    for variant in params.get("variants", dict()).get("cbr", []):
         # Required: bitrate
         # Optional: gop, fps, refmode, looplvl, loopshp
         yield [
@@ -351,7 +351,7 @@ def gen_vp9_cbr_parameters(spec):
 
 def gen_vp9_vbr_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("vbr", []):
+    for variant in params.get("variants", dict()).get("vbr", []):
         # Required: bitrate
         # Optional: gop, fps, refmode, quality, looplvl, loopshp
         yield [
@@ -368,7 +368,7 @@ def gen_vp9_vbr_parameters(spec):
 
 def gen_vp9_cqp_lp_variants(spec):
   for case, params in spec.items():
-    variants = params.get("cqp_lp", [])
+    variants = params.get("variants", dict()).get("cqp_lp", [])
     for variant in variants:
       yield [
         case, variant["ipmode"], variant["qp"], variant["quality"], variant["slices"],
@@ -381,7 +381,7 @@ def gen_vp9_cqp_lp_parameters(spec):
 
 def gen_vp9_cbr_lp_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("cbr_lp", []):
+    for variant in params.get("variants", dict()).get("cbr_lp", []):
         # Required: bitrate
         # Optional: gop, fps, refmode, looplvl, loopshp
         yield [
@@ -397,7 +397,7 @@ def gen_vp9_cbr_lp_parameters(spec):
 
 def gen_vp9_vbr_lp_variants(spec):
   for case, params in spec.items():
-    for variant in params.get("vbr_lp", []):
+    for variant in params.get("variants", dict()).get("vbr_lp", []):
         # Required: bitrate
         # Optional: gop, fps, refmode, looplvl, loopshp
         yield [


### PR DESCRIPTION
Encode test params should be wrapped inside their
own dict to prevent accidental class variable
conflicts as found in #323.
