### PR TITLE
Simplify command line for QSV

### DIFF
--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -18,7 +18,7 @@ class DecoderTest(slash.Test):
   @timefn("ffmpeg")
   def call_ffmpeg(self):
     self.output = call(
-      "ffmpeg -init_hw_device qsv=qsv:hw -qsv_device {renderDevice} -hwaccel qsv -filter_hw_device qsv"
+      "ffmpeg -init_hw_device qsv=qsv:hw_any,child_device={renderDevice} -hwaccel qsv"
       " -hwaccel_output_format qsv -v verbose -c:v {ffdecoder} -i {source}"
       " -vf 'hwdownload,format={hwformat}'"
       " -pix_fmt {mformat} -f rawvideo -vsync passthrough"

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -106,7 +106,7 @@ class EncoderTest(slash.Test):
   @timefn("ffmpeg")
   def call_ffmpeg(self, iopts, oopts):
     self.output = call(
-      "ffmpeg -init_hw_device qsv=qsv:hw -qsv_device {renderDevice} -hwaccel qsv -filter_hw_device qsv"
+      "ffmpeg -init_hw_device qsv=qsv:hw_any,child_device={renderDevice} -hwaccel qsv"
       " -hwaccel_output_format qsv -v verbose"
       " {iopts} {oopts}".format(renderDevice= self.renderDevice, iopts = iopts, oopts = oopts))
 

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -152,7 +152,7 @@ class TranscoderTest(slash.Test):
         "Missing one or more required ffmpeg elements: {}".format(list(unmet)))
 
   def gen_input_opts(self):
-    opts = "-init_hw_device qsv=qsv:hw -qsv_device {renderDevice} -filter_hw_device qsv"
+    opts = "-init_hw_device qsv=qsv:hw_any,child_device={renderDevice}"
     opts += " -hwaccel_output_format qsv"
     if "hw" == self.mode:
       opts += " -hwaccel qsv"

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -96,7 +96,7 @@ class VppTest(slash.Test):
   @timefn("ffmpeg")
   def call_ffmpeg(self, iopts, oopts):
     call(
-      "ffmpeg -init_hw_device qsv=qsv:hw -qsv_device {renderDevice} -hwaccel qsv -filter_hw_device qsv"
+      "ffmpeg -init_hw_device qsv=qsv:hw_any,child_device={renderDevice} -hwaccel qsv"
       " -v verbose {iopts} {oopts}".format(renderDevice= self.renderDevice, iopts = iopts, oopts = oopts))
 
   def validate_caps(self):

--- a/test/ffmpeg-qsv/general/runtime.py
+++ b/test/ffmpeg-qsv/general/runtime.py
@@ -20,8 +20,9 @@ class detect(MFXRuntimeTest):
 
   def test(self):
     self.check(
-      "ffmpeg -nostats -v verbose -init_hw_device qsv=qsv:hw"
-      " -qsv_device {renderDevice} -hwaccel qsv"
-      " -filter_hw_device qsv -f lavfi -i yuvtestsrc"
+      "ffmpeg -nostats -v verbose"
+      " -init_hw_device qsv=qsv:hw_any,child_device={renderDevice}"
+      " -hwaccel qsv"
+      " -f lavfi -i yuvtestsrc"
       " -f null /dev/null".format(**vars(self))
     )


### PR DESCRIPTION
The latest FFmpeg supports hw_device_ctx interface for QSV decoder, we
may use the common device stuff to initialize hw device for QSV
decoder. In addtion, -filter_hw_device option is not needed when there
is only one hw device.