### PR TITLE
gst/transcode: add qtmux for x264enc

### DIFF
--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -49,7 +49,7 @@ class TranscoderTest(BaseTranscoderTest):
     },
     encode = {
       "avc" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! qtmux"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(

--- a/lib/gstreamer/transcoderbase.py
+++ b/lib/gstreamer/transcoderbase.py
@@ -6,6 +6,7 @@
 
 import slash
 
+from ...lib import *
 from ...lib.common import timefn, get_media, call
 from ...lib.metrics import calculate_psnr
 from ...lib.gstreamer.util import have_gst, have_gst_element, gst_discover
@@ -112,7 +113,10 @@ class BaseTranscoderTest(slash.Test):
       codec = output["codec"]
       mode  = output["mode"]
       encoder = self.get_encoder(codec, mode)
-      ext = self.get_file_ext(codec)
+      if "avc" == codec and "sw" == mode:
+        ext = "mp4"
+      else:
+        ext = self.get_file_ext(codec)
 
       vppscale = self.get_vpp_scale(
         output.get("width", None), output.get("height", None), mode)
@@ -158,7 +162,10 @@ class BaseTranscoderTest(slash.Test):
         encoded = self.goutputs[n][channel]
         yuv = get_media()._test_artifact(
           "{}_{}_{}.yuv".format(self.case, n, channel))
-        iopts = "filesrc location={} ! {}"
+        if ".mp4" == os.path.splitext(encoded)[1]:
+          iopts = "filesrc location={} ! qtdemux ! {}"
+        else:
+          iopts = "filesrc location={} ! {}"
         oopts = self.get_vpp_scale(self.width, self.height, "hw")
         oopts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
         oopts += " frame-checksum=false plane-checksum=false dump-output=true"

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -47,7 +47,7 @@ class TranscoderTest(BaseTranscoderTest):
     },
     encode = {
       "avc" : dict(
-        sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
+        sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! qtmux"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(


### PR DESCRIPTION
Fix the issue that files encoded by gst-x264enc cannot be decoded.

Signed-off-by: Yefeng Xu <yefengx.xu@intel.com>