### PR TITLE
ffmpeg-qsv av1 8bit encode support low power cqp mode

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -59,6 +59,10 @@ class BaseEncoderTest(slash.Test):
       opts += " -extbrc {extbrc}"
     if vars(self).get("slices", None) is not None:
       opts += " -slices {slices}"
+    if vars(self).get("tilecols", None) is not None:
+      opts += " -tile_cols {tilecols}"
+    if vars(self).get("tilerows", None) is not None:
+      opts += " -tile_rows {tilerows}"
     if vars(self).get("bframes", None) is not None:
       opts += " -bf {bframes}"
     if vars(self).get("minrate", None) is not None:

--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -59,7 +59,7 @@ def mapprofile(codec, profile):
       "main12"                : "main-12",
     },
     "av1-8"   : {
-      "main"      : "main",
+      "profile0"  : "main",
     },
     "vp9-12" : {
       "profile3"  : "profile3",

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -411,6 +411,19 @@ def gen_vp9_vbr_lp_parameters(spec):
   params = gen_vp9_vbr_lp_variants(spec)
   return keys, params
 
+def gen_av1_cqp_lp_variants(spec):
+  for case, params in spec.items():
+    variants = params.get("variants", dict()).get("cqp_lp", [])
+    for variant in variants:
+      yield [
+        case, variant["gop"], variant["bframes"], variant["qp"], variant["quality"],
+        variant.get("tilecols", 0), variant.get("tilerows", 0), variant.get("profile", "profile0")]
+
+def gen_av1_cqp_lp_parameters(spec):
+  keys = ("case", "gop", "bframes", "qp", "quality", "tilecols", "tilerows", "profile")
+  params = gen_av1_cqp_lp_variants(spec)
+  return keys, params
+
 def gen_vpp_sharpen_variants(spec):
   for case, params in spec.items():
     variants = params.get("levels", None) or [0, 1, 20, 50, 59, 99, 100]

--- a/test/ffmpeg-qsv/encode/av1.py
+++ b/test/ffmpeg-qsv/encode/av1.py
@@ -1,0 +1,54 @@
+###
+### Copyright (C) 2019-2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.encoder import EncoderTest
+
+spec = load_test_spec("av1", "encode", "8bit")
+
+@slash.requires(*have_ffmpeg_encoder("av1_qsv"))
+@slash.requires(*have_ffmpeg_decoder("av1_qsv"))
+class AV1EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec     = "av1-8",
+      ffencoder = "av1_qsv",
+      ffdecoder = "av1_qsv",
+    )
+
+  def get_file_ext(self):
+    return "ivf"
+
+@slash.requires(*platform.have_caps("vdenc", "av1_8"))
+class AV1EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_8"),
+      lowpower  = 1,
+    )
+
+class cqp_lp(AV1EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = gop,
+      bframes   = bframes,
+      qp        = qp,
+      rcmode    = "cqp",
+      quality   = quality,
+      profile   = profile,
+      tilerows  = tilerows,
+      tilecols  = tilecols,
+    )
+
+  @slash.parametrize(*gen_av1_cqp_lp_parameters(spec))
+  def test(self, case, gop, bframes, tilecols, tilerows, qp, quality, profile):
+    self.init(spec, case, gop, bframes, tilecols, tilerows, qp, quality, profile)
+    self.encode()


### PR DESCRIPTION
1,  added av1-8 enc: added parameters and variants in core
2, ffmpeg-qsv lib added new parameter tile_cols and tile_rows
3, added av1 8bit map
4, ffmpeg-qsv added new av1 enc implement support