### PR TITLE
lib/gst: decouple encode/decode command-line from test classes

### DIFF
--- a/lib/gstreamer/decoderbase.py
+++ b/lib/gstreamer/decoderbase.py
@@ -12,25 +12,34 @@ from ...lib.gstreamer.util import have_gst, have_gst_element
 from ...lib.parameters import format_value
 from ...lib.util import skip_test_if_missing_features
 from ...lib.metrics import md5, check_metric
+from ...lib.properties import PropertyHandler
+
+class Decoder(PropertyHandler):
+  #required properties
+  gstdecoder  = property(lambda s: s.props["gstdecoder"])
+  frames      = property(lambda s: s.props["frames"])
+  format      = property(lambda s: s.props["format"])
+  source      = property(lambda s: s.props["source"])
+  decoded     = property(lambda s: s.props["decoded"])
+
+  @timefn("gst-decode")
+  def decode(self):
+    return call(
+      f"gst-launch-1.0 -vf filesrc location={self.source} ! {self.gstdecoder}"
+      f" ! videoconvert chroma-mode=none dither=0"
+      f" ! video/x-raw,format={self.format} ! checksumsink2 qos=false"
+      f" file-checksum=false frame-checksum=false plane-checksum=false"
+      f" eos-after={self.frames} dump-output=true dump-location={self.decoded}"
+    )
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("checksumsink2"))
 class BaseDecoderTest(slash.Test):
+  DecoderClass = Decoder
+
   def before(self):
+    super().before()
     self.refctx = []
-
-  def map_formatu(self):
-    raise NotImplementedError
-
-  @timefn("gst")
-  def call_gst(self):
-    call(
-      "gst-launch-1.0 -vf filesrc location={source}"
-      " ! {gstdecoder}"
-      " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu}"
-      " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
-      " frame-checksum=false plane-checksum=false dump-output=true"
-      " dump-location={decoded}".format(**vars(self)))
 
   def gen_name(self):
     name = "{case}_{width}x{height}_{format}"
@@ -39,6 +48,13 @@ class BaseDecoderTest(slash.Test):
     return name
 
   def validate_caps(self):
+    self.decoder = self.DecoderClass(
+      gstdecoder  = self.gstdecoder,
+      frames      = self.frames,
+      format      = self.format,
+      source      = self.source,
+    )
+
     if match_best_format(self.format, self.caps["fmts"]) is None:
       slash.skip_test(
         format_value(
@@ -50,8 +66,7 @@ class BaseDecoderTest(slash.Test):
         format_value(
           "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
 
-    self.mformatu = self.map_formatu()
-    if self.mformatu is None:
+    if self.decoder.format is None:
       slash.skip_test(
         "gstreamer.{format} not supported".format(**vars(self)))
 
@@ -63,23 +78,25 @@ class BaseDecoderTest(slash.Test):
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
     name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst()
+    self.decoder.update(
+      decoded = get_media()._test_artifact("{}.yuv".format(name)))
+    self.output = self.decoder.decode()
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.decoded)
+      md5ref = md5(self.decoder.decoded)
       get_media()._set_test_details(md5_ref = md5ref)
       for i in range(1, self.r2r):
-        self.decoded = get_media()._test_artifact(
-          "{}_{}.yuv".format(name, i))
-        self.call_gst()
-        result = md5(self.decoded)
+        self.decoder.update(
+          decoded = get_media()._test_artifact("{}_{}.yuv".format(name, i)))
+        self.decoder.decode()
+        result = md5(self.decoder.decoded)
         get_media()._set_test_details(**{"md5_{:03}".format(i): result})
         assert result == md5ref, "r2r md5 mismatch"
         # delete decoded file after each iteration
-        get_media()._purge_test_artifact(self.decoded)
+        get_media()._purge_test_artifact(self.decoder.decoded)
     else:
+      self.decoded = self.decoder.decoded
       self.check_metrics()
 
   def check_metrics(self):

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -9,56 +9,57 @@ import slash
 
 from ...lib.common import timefn, get_media, call
 from ...lib.gstreamer.util import have_gst, have_gst_element
+from ...lib.gstreamer.decoderbase import Decoder
 from ...lib.metrics import md5, calculate_psnr
 from ...lib.parameters import format_value
 from ...lib.util import skip_test_if_missing_features
+from ...lib.properties import PropertyHandler
+
+class Encoder(PropertyHandler):
+  # required properties
+  gstencoder    = property(lambda s: s.props["gstencoder"])
+  gstmediatype  = property(lambda s: s.props["gstmediatype"])
+  codec         = property(lambda s: s.props["codec"])
+  rcmode        = property(lambda s: s.props["rcmode"])
+  hwformat      = property(lambda s: s.props["hwformat"])
+  format        = property(lambda s: s.props["format"])
+  frames        = property(lambda s: s.props["frames"])
+  width         = property(lambda s: s.props["width"])
+  height        = property(lambda s: s.props["height"])
+  source        = property(lambda s: s.props["source"])
+  encoded       = property(lambda s: s.props["encoded"])
+
+  # optional properties
+  gstparser     = property(lambda s: s.ifprop("gstparser", " ! {gstparser}"))
+  gstmuxer      = property(lambda s: s.ifprop("gstmuxer", " ! {gstmuxer}"))
+  fps           = property(lambda s: s.ifprop("fps", " framerate={fps}"))
+  profile       = property(lambda s: s.ifprop("profile", ",profile={profile}"))
+
+  @timefn("gst-encode")
+  def encode(self):
+    return call(
+      f"gst-launch-1.0 -vf filesrc location={self.source} num-buffers={self.frames}"
+      f" ! rawvideoparse format={self.format} width={self.width} height={self.height}{self.fps}"
+      f" ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={self.hwformat}"
+      f" ! {self.gstencoder} ! {self.gstmediatype}{self.profile}{self.gstparser}{self.gstmuxer}"
+      f" ! filesink location={self.encoded}"
+    )
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("checksumsink2"))
 class BaseEncoderTest(slash.Test):
+  EncoderClass = Encoder
+  DecoderClass = Decoder
+
   def before(self):
+    super().before()
     self.refctx = []
 
   def map_profile(self):
     raise NotImplementedError
 
-  def map_best_hw_format(self):
-    raise NotImplementedError
-
-  def map_format(self):
-    raise NotImplementedError
-
-  def map_formatu(self):
-    raise NotImplementedError
-
-  def gen_encoder_opts(self):
-    raise NotImplementedError
-
   def get_file_ext(self):
     raise NotImplementedError
-
-  def gen_input_opts(self):
-    opts = "filesrc location={source} num-buffers={frames}"
-    opts += " ! rawvideoparse format={mformat} width={width} height={height}"
-    if vars(self).get("fps", None) is not None:
-      opts += " framerate={fps}"
-    opts += " ! videoconvert chroma-mode=none dither=0 ! video/x-raw,format={hwformat}"
-
-    return opts
-
-  def gen_output_opts(self):
-    opts = "{gstencoder} "
-    opts += self.gen_encoder_opts()
-    opts += " ! {gstmediatype}"
-    if vars(self).get("profile", None) is not None:
-      opts += ",profile={mprofile}"
-    if vars(self).get("gstparser", None) is not None:
-      opts += " ! {gstparser}"
-    if vars(self).get("gstmuxer", None) is not None:
-      opts += " ! {gstmuxer}"
-    opts += " ! filesink location={encoded}"
-
-    return opts
 
   def gen_name(self):
     name = "{case}-{rcmode}"
@@ -97,19 +98,17 @@ class BaseEncoderTest(slash.Test):
 
     return name
 
-  @timefn("gst")
-  def call_gst(self, iopts, oopts):
-    self.output = call("gst-launch-1.0 -vf {iopts} ! {oopts}".format(
-      iopts = iopts, oopts = oopts))
-
   def validate_caps(self):
     skip_test_if_missing_features(self)
 
-    self.hwformat = self.map_best_hw_format()
-    self.mformat  = self.map_format()
-    self.mformatu = self.map_formatu()
+    self.encoder = self.EncoderClass(**vars(self))
+    self.decoder = self.DecoderClass(
+      gstdecoder  = self.gstdecoder,
+      frames      = self.frames,
+      format      = self.format,
+    )
 
-    if None in [self.hwformat, self.mformatu]:
+    if None in [self.encoder.hwformat, self.encoder.format, self.decoder.format]:
       slash.skip_test("{format} format not supported".format(**vars(self)))
 
     maxw, maxh = self.caps["maxres"]
@@ -132,57 +131,55 @@ class BaseEncoderTest(slash.Test):
       self.mprofile = self.map_profile()
       if self.mprofile is None:
         slash.skip_test("{profile} profile is not supported".format(**vars(self)))
+      self.encoder.update(profile = self.mprofile)
 
   def encode(self):
     self.validate_caps()
 
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
     name  = self.gen_name().format(**vars(self))
     ext   = self.get_file_ext()
 
-    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+    self.encoder.update(
+      encoded = get_media()._test_artifact("{}.{}".format(name, ext)))
+    self.encoder.encode()
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.encoded)
+      md5ref = md5(self.encoder.encoded)
       get_media()._set_test_details(md5_ref = md5ref)
       for i in range(1, self.r2r):
-        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
-        self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.encoded)
+        self.encoder.update(
+          encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext)))
+        self.encoder.encode()
+        result = md5(self.encoder.encoded)
         get_media()._set_test_details(**{"md5_{:03}".format(i): result})
         assert md5ref == result, "r2r md5 mismatch"
         # delete encoded file after each iteration
-        get_media()._purge_test_artifact(self.encoded)
+        get_media()._purge_test_artifact(self.encoder.encoded)
     else:
       self.check_bitrate()
       self.check_metrics()
 
   def check_metrics(self):
-    iopts = "filesrc location={encoded} ! {gstdecoder}"
-    oopts = (
-      "videoconvert chroma-mode=none dither=0 ! video/x-raw,format={mformatu} ! checksumsink2"
-      " file-checksum=false frame-checksum=false plane-checksum=false"
-      " dump-output=true qos=false dump-location={decoded} eos-after={frames}")
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
-
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.call_gst(iopts.format(**vars(self)), oopts.format(**vars(self)))
+    self.decoder.update(
+      source      = self.encoder.encoded,
+      decoded     = get_media()._test_artifact("{}.yuv".format(name)),
+    )
+    self.decoder.decode()
 
     get_media().baseline.check_psnr(
       psnr = calculate_psnr(
-        self.source, self.decoded,
+        self.source, self.decoder.decoded,
         self.width, self.height,
         self.frames, self.format),
       context = self.refctx,
     )
 
   def check_bitrate(self):
-    encsize = os.path.getsize(self.encoded)
+    encsize = os.path.getsize(self.encoder.encoded)
     bitrate_actual = encsize * 8 * vars(self).get("fps", 25) / 1024.0 / self.frames
     get_media()._set_test_details(
       size_encoded = encsize,

--- a/lib/gstreamer/msdk/decoder.py
+++ b/lib/gstreamer/msdk/decoder.py
@@ -8,16 +8,18 @@ import os
 import slash
 
 from ....lib.common import get_media
-from ....lib.gstreamer.decoderbase import BaseDecoderTest
+from ....lib.gstreamer.decoderbase import BaseDecoderTest, Decoder as GstDecoder
 from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.msdk.util import mapformatu, using_compatible_driver
+
+class Decoder(GstDecoder):
+  format = property(lambda s: mapformatu(super().format))
 
 @slash.requires(*have_gst_element("msdk"))
 @slash.requires(using_compatible_driver)
 class DecoderTest(BaseDecoderTest):
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     os.environ["GST_MSDK_DRM_DEVICE"] = get_media().render_device
-
-  def map_formatu(self):
-    return mapformatu(self.format)

--- a/lib/gstreamer/va/decoder.py
+++ b/lib/gstreamer/va/decoder.py
@@ -8,15 +8,18 @@ import os
 import slash
 
 from ....lib.common import get_media
-from ....lib.gstreamer.decoderbase import BaseDecoderTest
+from ....lib.gstreamer.decoderbase import BaseDecoderTest, Decoder as GstDecoder
 from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.va.util import mapformatu
 
+class Decoder(GstDecoder):
+  format = property(lambda s: mapformatu(super().format))
+
 @slash.requires(*have_gst_element("va"))
 class DecoderTest(BaseDecoderTest):
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     # TODO: need gst-va to fix target render device
 
-  def map_formatu(self):
-    return mapformatu(self.format)

--- a/lib/gstreamer/vaapi/decoder.py
+++ b/lib/gstreamer/vaapi/decoder.py
@@ -8,15 +8,17 @@ import os
 import slash
 
 from ....lib.common import get_media
-from ....lib.gstreamer.decoderbase import BaseDecoderTest
+from ....lib.gstreamer.decoderbase import BaseDecoderTest, Decoder as GstDecoder
 from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.vaapi.util import mapformatu
 
+class Decoder(GstDecoder):
+  format = property(lambda s: mapformatu(super().format))
+
 @slash.requires(*have_gst_element("vaapi"))
 class DecoderTest(BaseDecoderTest):
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
-
-  def map_formatu(self):
-    return mapformatu(self.format)

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -7,63 +7,79 @@
 import os
 import slash
 
-from ....lib.gstreamer.encoderbase import BaseEncoderTest
+from ....lib.gstreamer.encoderbase import BaseEncoderTest, Encoder as GstEncoder
 from ....lib.gstreamer.util import have_gst_element
-from ....lib.gstreamer.vaapi.util import mapprofile, map_best_hw_format, mapformat, mapformatu
-from ....lib.common import get_media
+from ....lib.gstreamer.vaapi.util import mapprofile, map_best_hw_format, mapformat
+from ....lib.gstreamer.vaapi.decoder import Decoder
+from ....lib.common import get_media, mapRangeInt
+
+class Encoder(GstEncoder):
+  @property
+  def hwformat(self):
+    return map_best_hw_format(super().format, self.props["caps"]["fmts"])
+
+  @property
+  def format(self):
+    return mapformat(super().format)
+
+  @property
+  def rcmode(self):
+    if self.codec in ["jpeg"]:
+      return ""
+    return f" rate-control={super().rcmode}"
+
+  @property
+  def qp(self):
+    def inner(qp):
+      if self.codec in ["mpeg2"]:
+        mqp = mapRangeInt(qp, [0, 100], [2, 62])
+        return f" quantizer={mqp}"
+      if self.codec in ["vp8", "vp9"]:
+        return f" yac-qi={qp}"
+      return f" init-qp={qp}"
+    return self.ifprop("qp", inner)
+
+  @property
+  def quality(self):
+    def inner(quality):
+      if self.codec in ["jpeg"]:
+        return f" quality={quality}"
+      return f" quality-level={quality}"
+    return self.ifprop("quality", inner)
+
+  @property
+  def lowpower(self):
+    def inner(lowpower):
+      return f" tune={'low-power' if lowpower else 'none'}"
+    return self.ifprop("lowpower", inner)
+
+  gop     = property(lambda s: s.ifprop("gop", " keyframe-period={gop}"))
+  slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
+  bframes = property(lambda s: s.ifprop("bframes", " max-bframes={bframes}"))
+  maxrate = property(lambda s: s.ifprop("maxrate", " bitrate={maxrate}"))
+  refmode = property(lambda s: s.ifprop("refmode", " ref-pic-mode={refmode}"))
+  refs    = property(lambda s: s.ifprop("refs", " refs={refs}"))
+  loopshp = property(lambda s: s.ifprop("loopshp", " sharpness-level={loopshp}"))
+  looplvl = property(lambda s: s.ifprop("looplvl", " loop-filter-level={looplvl}"))
+
+  @property
+  def gstencoder(self):
+    return (
+      f"{super().gstencoder}"
+      f"{self.rcmode}{self.gop}{self.qp}"
+      f"{self.quality}{self.slices}{self.bframes}"
+      f"{self.maxrate}{self.refmode}{self.refs}"
+      f"{self.lowpower}{self.loopshp}{self.looplvl}"
+    )
 
 @slash.requires(*have_gst_element("vaapi"))
 class EncoderTest(BaseEncoderTest):
+  EncoderClass = Encoder
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     os.environ["GST_VAAPI_DRM_DEVICE"] = get_media().render_device
 
   def map_profile(self):
     return mapprofile(self.codec, self.profile)
-
-  def map_best_hw_format(self):
-    return map_best_hw_format(self.format, self.caps["fmts"])
-
-  def map_format(self):
-    return mapformat(self.format)
-
-  def map_formatu(self):
-    return mapformatu(self.format)
-
-  def gen_encoder_opts(self):
-    opts = ""
-    if self.codec not in ["jpeg",]:
-      opts += " rate-control={rcmode}"
-    if vars(self).get("gop", None) is not None:
-      opts += " keyframe-period={gop}"
-    if vars(self).get("qp", None) is not None:
-      if self.codec in ["vp8", "vp9",]:
-        opts += " yac-qi={qp}"
-      elif self.codec in ["mpeg2"]:
-        opts += " quantizer={mqp}"
-      else:
-        opts += " init-qp={qp}"
-    if vars(self).get("quality", None) is not None:
-      if self.codec in ["jpeg",]:
-        opts += " quality={quality}"
-      else:
-        opts += " quality-level={quality}"
-    if vars(self).get("slices", None) is not None:
-      opts += " num-slices={slices}"
-    if vars(self).get("bframes", None) is not None:
-      opts += " max-bframes={bframes}"
-    if vars(self).get("maxrate", None) is not None:
-      opts += " bitrate={maxrate}"
-    if vars(self).get("refmode", None) is not None:
-      opts += " ref-pic-mode={refmode}"
-    if vars(self).get("refs", None) is not None:
-      opts += " refs={refs}"
-    if vars(self).get("lowpower", None) is not None:
-      opts += " tune="
-      opts += "low-power" if self.lowpower else "none"
-    if vars(self).get("loopshp", None) is not None:
-      opts += " sharpness-level={loopshp}"
-    if vars(self).get("looplvl", None) is not None:
-      opts += " loop-filter-level={looplvl}"
-
-    return opts

--- a/lib/properties.py
+++ b/lib/properties.py
@@ -1,0 +1,23 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import types
+
+class PropertyHandler:
+  def __init__(self, **properties):
+    self.props = dict()
+    self.update(**properties)
+
+  def update(self, **properties):
+    self.props.update(**properties)
+
+  def ifprop(self, prop, val):
+    v = self.props.get(prop, None)
+    if type(val) in [types.FunctionType, types.MethodType]:
+      result = val(v) if v is not None else ""
+    else:
+      result = val if v is not None else ""
+    return result.format(**self.props)

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -36,7 +36,6 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRangeInt(qp, [0, 100], [0, 51]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -36,7 +36,6 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRangeInt(qp, [0, 100], [2, 62]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",


### PR DESCRIPTION
Move gstreamer decode/encode command-line generator code into separate classes so they can be reused across different test contexts.