### PR TITLE
gst: encode/decode: add gstparser and gstdemuxer props

### DIFF
--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -104,6 +104,8 @@ class BaseEncoderTest(slash.Test):
     self.encoder = self.EncoderClass(**vars(self))
     self.decoder = self.DecoderClass(
       gstdecoder  = self.gstdecoder,
+      gstparser   = vars(self).get("gstparser", None),
+      gstdemuxer  = vars(self).get("gstdemuxer", None),
       frames      = self.frames,
       format      = self.format,
     )

--- a/test/gst-msdk/decode/10bit/av1.py
+++ b/test/gst-msdk/decode/10bit/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_10"),
+      gstdecoder  = "msdkav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -28,11 +32,8 @@ class default(DecoderTest):
     dx = dxmap.get(ext, None)
     assert dx is not None, "Unrecognized source file extension {}".format(ext)
 
-    if "av1parse" not in dx:
-      dx += " ! av1parse"
-
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkav1dec".format(dx),
+      gstdemuxer  = dx if self.gstparser not in dx else None,
     )
     self.decode()

--- a/test/gst-msdk/decode/10bit/av1.py
+++ b/test/gst-msdk/decode/10bit/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/10bit/hevc.py
+++ b/test/gst-msdk/decode/10bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_10"),
+      gstdecoder  = "msdkh265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! msdkh265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-msdk/decode/10bit/hevc.py
+++ b/test/gst-msdk/decode/10bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkh265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/10bit/vp9.py
+++ b/test/gst-msdk/decode/10bit/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_10"),
+      gstdecoder  = "msdkvp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkvp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-msdk/decode/10bit/vp9.py
+++ b/test/gst-msdk/decode/10bit/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkvp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/12bit/hevc.py
+++ b/test/gst-msdk/decode/12bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_12"),
+      gstdecoder  = "msdkh265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! msdkh265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-msdk/decode/12bit/hevc.py
+++ b/test/gst-msdk/decode/12bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkh265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/12bit/vp9.py
+++ b/test/gst-msdk/decode/12bit/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkvp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/12bit/vp9.py
+++ b/test/gst-msdk/decode/12bit/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_12"),
+      gstdecoder  = "msdkvp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkvp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/av1.py
+++ b/test/gst-msdk/decode/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_8"),
+      gstdecoder  = "msdkav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! av1parse ! msdkav1dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-msdk/decode/avc.py
+++ b/test/gst-msdk/decode/avc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("msdkh264dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkh264dec",
       gstparser   = "h264parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/avc.py
+++ b/test/gst-msdk/decode/avc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("msdkh264dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "avc")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "avc"),
+      gstdecoder  = "msdkh264dec",
+      gstparser   = "h264parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h264parse ! msdkh264dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-msdk/decode/hevc.py
+++ b/test/gst-msdk/decode/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkh265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/hevc.py
+++ b/test/gst-msdk/decode/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkh265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_8"),
+      gstdecoder  = "msdkh265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! msdkh265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-msdk/decode/jpeg.py
+++ b/test/gst-msdk/decode/jpeg.py
@@ -15,26 +15,24 @@ spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkmjpegdec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "jpeg")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "jpeg"),
+      gstdecoder  = "msdkmjpegdec",
+      gstparser   = "jpegparse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "jpegparse ! msdkmjpegdec",
-    )
+    vars(self).update(case = case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "jpegparse ! msdkmjpegdec",
-    )
+    vars(self).update(case = case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-msdk/decode/jpeg.py
+++ b/test/gst-msdk/decode/jpeg.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkmjpegdec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -22,7 +23,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkmjpegdec",
       gstparser   = "jpegparse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/mpeg2.py
+++ b/test/gst-msdk/decode/mpeg2.py
@@ -15,26 +15,24 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkmpeg2dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "mpeg2")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "mpeg2"),
+      gstdecoder  = "msdkmpeg2dec",
+      gstparser   = "mpegvideoparse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! msdkmpeg2dec",
-    )
+    vars(self).update(case = case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! msdkmpeg2dec",
-    )
+    vars(self).update(case = case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-msdk/decode/mpeg2.py
+++ b/test/gst-msdk/decode/mpeg2.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkmpeg2dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -22,7 +23,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkmpeg2dec",
       gstparser   = "mpegvideoparse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/vc1.py
+++ b/test/gst-msdk/decode/vc1.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("vc1", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkvc1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -23,7 +24,6 @@ class default(DecoderTest):
       gstparser   = "'video/x-wmv,profile=(string)advanced'"
                     ",width={width},height={height},framerate=14/1",
     )
-    super(default, self).before()
 
   def init(self, tspec, case):
     vars(self).update(tspec[case].copy())

--- a/test/gst-msdk/decode/vc1.py
+++ b/test/gst-msdk/decode/vc1.py
@@ -15,30 +15,28 @@ spec_r2r = load_test_spec("vc1", "decode", "r2r")
 @slash.requires(*have_gst_element("msdkvc1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "vc1")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "vc1"),
+      gstdecoder  = "msdkvc1dec",
+      gstparser   = "'video/x-wmv,profile=(string)advanced'"
+                    ",width={width},height={height},framerate=14/1",
+    )
     super(default, self).before()
+
+  def init(self, tspec, case):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(case = case)
+    self.gstparser = self.gstparser.format(**vars(self))
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "'video/x-wmv,profile=(string)advanced'"
-                    ",width={width},height={height},framerate=14/1"
-                    " ! msdkvc1dec".format(**vars(self)),
-    )
+    self.init(spec, case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
-    vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "'video/x-wmv,profile=(string)advanced'"
-                    ",width={width},height={height},framerate=14/1"
-                    " ! msdkvc1dec".format(**vars(self)),
-    )
+    self.init(spec_r2r, case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-msdk/decode/vp8.py
+++ b/test/gst-msdk/decode/vp8.py
@@ -14,9 +14,12 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("msdkvp8dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp8"),
+      gstdecoder  = "msdkvp8dec",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +32,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkvp8dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-msdk/decode/vp8.py
+++ b/test/gst-msdk/decode/vp8.py
@@ -14,13 +14,13 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("msdkvp8dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
       caps        = platform.get_caps("decode", "vp8"),
       gstdecoder  = "msdkvp8dec",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/decode/vp9.py
+++ b/test/gst-msdk/decode/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_8"),
+      gstdecoder  = "msdkvp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! msdkvp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-msdk/decode/vp9.py
+++ b/test/gst-msdk/decode/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("msdkvp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "msdkvp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -19,7 +19,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "hevc-10",
       gstencoder    = "msdkh265enc",
-      gstdecoder    = "h265parse ! msdkh265dec hardware=true",
+      gstdecoder    = "msdkh265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
     )

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -18,9 +18,11 @@ class VP9_10EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "msdkvp9enc",
-      gstdecoder    = "matroskademux ! msdkvp9dec hardware=true",
+      gstdecoder    = "msdkvp9dec",
       gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
       gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
     )
 
   def get_file_ext(self):

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -19,7 +19,7 @@ class AVCEncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "avc",
       gstencoder    = "msdkh264enc",
-      gstdecoder    = "h264parse ! msdkh264dec hardware=true",
+      gstdecoder    = "msdkh264dec",
       gstmediatype  = "video/x-h264",
       gstparser     = "h264parse",
     )

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -19,7 +19,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "hevc-8",
       gstencoder    = "msdkh265enc",
-      gstdecoder    = "h265parse ! msdkh265dec hardware=true",
+      gstdecoder    = "msdkh265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
     )

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -21,7 +21,7 @@ class JPEGEncoderTest(EncoderTest):
       caps          = platform.get_caps("vdenc", "jpeg"),
       codec         = "jpeg",
       gstencoder    = "msdkmjpegenc",
-      gstdecoder    = "jpegparse ! msdkmjpegdec hardware=true",
+      gstdecoder    = "msdkmjpegdec",
       gstmediatype  = "image/jpeg",
       gstparser     = "jpegparse",
     )

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -21,7 +21,7 @@ class MPEG2EncoderTest(EncoderTest):
       caps          = platform.get_caps("encode", "mpeg2"),
       codec         = "mpeg2",
       gstencoder    = "msdkmpeg2enc",
-      gstdecoder    = "mpegvideoparse ! msdkmpeg2dec hardware=true",
+      gstdecoder    = "msdkmpeg2dec",
       gstmediatype  = "video/mpeg,mpegversion=2",
       gstparser     = "mpegvideoparse",
     )

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -18,9 +18,11 @@ class VP9EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "msdkvp9enc",
-      gstdecoder    = "matroskademux ! msdkvp9dec hardware=true",
+      gstdecoder    = "msdkvp9dec",
       gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
       gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
     )
 
   def get_file_ext(self):

--- a/test/gst-va/decode/10bit/av1.py
+++ b/test/gst-va/decode/10bit/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/10bit/av1.py
+++ b/test/gst-va/decode/10bit/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_10"),
+      gstdecoder  = "vaav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -28,11 +32,8 @@ class default(DecoderTest):
     dx = dxmap.get(ext, None)
     assert dx is not None, "Unrecognized source file extension {}".format(ext)
 
-    if "av1parse" not in dx:
-      dx += " ! av1parse"
-
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaav1dec".format(dx),
+      gstdemuxer  = dx if self.gstparser not in dx else None,
     )
     self.decode()

--- a/test/gst-va/decode/10bit/hevc.py
+++ b/test/gst-va/decode/10bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vah265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/10bit/hevc.py
+++ b/test/gst-va/decode/10bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_10"),
+      gstdecoder  = "vah265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vah265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-va/decode/10bit/vp9.py
+++ b/test/gst-va/decode/10bit/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vavp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/10bit/vp9.py
+++ b/test/gst-va/decode/10bit/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_10"),
+      gstdecoder  = "vavp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vp9parse ! vavp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-va/decode/12bit/hevc.py
+++ b/test/gst-va/decode/12bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vah265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/12bit/hevc.py
+++ b/test/gst-va/decode/12bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_12"),
+      gstdecoder  = "vah265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vah265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-va/decode/12bit/vp9.py
+++ b/test/gst-va/decode/12bit/vp9.py
@@ -13,9 +13,13 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_12"),
+      gstdecoder  = "vavp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -28,6 +32,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vp9parse ! vavp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-va/decode/12bit/vp9.py
+++ b/test/gst-va/decode/12bit/vp9.py
@@ -13,6 +13,7 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -20,7 +21,6 @@ class default(DecoderTest):
       gstdecoder  = "vavp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/av1.py
+++ b/test/gst-va/decode/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_8"),
+      gstdecoder  = "vaav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! av1parse ! vaav1dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-va/decode/av1.py
+++ b/test/gst-va/decode/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/avc.py
+++ b/test/gst-va/decode/avc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("vah264dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vah264dec",
       gstparser   = "h264parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/avc.py
+++ b/test/gst-va/decode/avc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("vah264dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "avc")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "avc"),
+      gstdecoder  = "vah264dec",
+      gstparser   = "h264parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h264parse ! vah264dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-va/decode/hevc.py
+++ b/test/gst-va/decode/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vah265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/hevc.py
+++ b/test/gst-va/decode/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_8"),
+      gstdecoder  = "vah265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vah265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-va/decode/mpeg2.py
+++ b/test/gst-va/decode/mpeg2.py
@@ -15,26 +15,24 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("vampeg2dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "mpeg2")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "mpeg2"),
+      gstdecoder  = "vampeg2dec",
+      gstparser   = "mpegvideoparse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! vampeg2dec",
-    )
+    vars(self).update(case = case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! vampeg2dec",
-    )
+    vars(self).update(case = case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-va/decode/mpeg2.py
+++ b/test/gst-va/decode/mpeg2.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("vampeg2dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -22,7 +23,6 @@ class default(DecoderTest):
       gstdecoder  = "vampeg2dec",
       gstparser   = "mpegvideoparse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/vp8.py
+++ b/test/gst-va/decode/vp8.py
@@ -14,13 +14,13 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("vavp8dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
       caps        = platform.get_caps("decode", "vp8"),
       gstdecoder  = "vavp8dec",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-va/decode/vp8.py
+++ b/test/gst-va/decode/vp8.py
@@ -14,9 +14,12 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("vavp8dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp8"),
+      gstdecoder  = "vavp8dec",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +32,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vavp8dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-va/decode/vp9.py
+++ b/test/gst-va/decode/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_8"),
+      gstdecoder  = "vavp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vp9parse ! vavp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-va/decode/vp9.py
+++ b/test/gst-va/decode/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vavp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/10bit/av1.py
+++ b/test/gst-vaapi/decode/10bit/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapiav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/10bit/av1.py
+++ b/test/gst-vaapi/decode/10bit/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_10"),
+      gstdecoder  = "vaapiav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -28,11 +32,8 @@ class default(DecoderTest):
     dx = dxmap.get(ext, None)
     assert dx is not None, "Unrecognized source file extension {}".format(ext)
 
-    if "av1parse" not in dx:
-      dx += " ! av1parse"
-
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapiav1dec".format(dx),
+      gstdemuxer  = dx if self.gstparser not in dx else None,
     )
     self.decode()

--- a/test/gst-vaapi/decode/10bit/hevc.py
+++ b/test/gst-vaapi/decode/10bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_10"),
+      gstdecoder  = "vaapih265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vaapih265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-vaapi/decode/10bit/hevc.py
+++ b/test/gst-vaapi/decode/10bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapih265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapivp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/10bit/vp9.py
+++ b/test/gst-vaapi/decode/10bit/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "10bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_10")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_10"),
+      gstdecoder  = "vaapivp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-vaapi/decode/12bit/hevc.py
+++ b/test/gst-vaapi/decode/12bit/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_12"),
+      gstdecoder  = "vaapih265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vaapih265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-vaapi/decode/12bit/hevc.py
+++ b/test/gst-vaapi/decode/12bit/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "12bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapih265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/12bit/vp9.py
+++ b/test/gst-vaapi/decode/12bit/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapivp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/12bit/vp9.py
+++ b/test/gst-vaapi/decode/12bit/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "12bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_12")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_12"),
+      gstdecoder  = "vaapivp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-vaapi/decode/av1.py
+++ b/test/gst-vaapi/decode/av1.py
@@ -14,6 +14,7 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapiav1dec",
       gstparser   = "av1parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/av1.py
+++ b/test/gst-vaapi/decode/av1.py
@@ -14,9 +14,13 @@ spec = load_test_spec("av1", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapiav1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "av1_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "av1_8"),
+      gstdecoder  = "vaapiav1dec",
+      gstparser   = "av1parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! av1parse ! vaapiav1dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-vaapi/decode/avc.py
+++ b/test/gst-vaapi/decode/avc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("vaapih264dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "avc")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "avc"),
+      gstdecoder  = "vaapih264dec",
+      gstparser   = "h264parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h264parse ! vaapih264dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-vaapi/decode/avc.py
+++ b/test/gst-vaapi/decode/avc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("avc", "decode")
 @slash.requires(*have_gst_element("vaapih264dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapih264dec",
       gstparser   = "h264parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/hevc.py
+++ b/test/gst-vaapi/decode/hevc.py
@@ -14,6 +14,7 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapih265dec",
       gstparser   = "h265parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/hevc.py
+++ b/test/gst-vaapi/decode/hevc.py
@@ -14,16 +14,17 @@ spec = load_test_spec("hevc", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapih265dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "hevc_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "hevc_8"),
+      gstdecoder  = "vaapih265dec",
+      gstparser   = "h265parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "h265parse ! vaapih265dec",
-    )
+    vars(self).update(case = case)
     self.decode()

--- a/test/gst-vaapi/decode/jpeg.py
+++ b/test/gst-vaapi/decode/jpeg.py
@@ -15,26 +15,24 @@ spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapijpegdec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "jpeg")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "jpeg"),
+      gstdecoder  = "vaapijpegdec",
+      gstparser   = "jpegparse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "jpegparse ! vaapijpegdec",
-    )
+    vars(self).update(case = case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "jpegparse ! vaapijpegdec",
-    )
+    vars(self).update(case = case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-vaapi/decode/jpeg.py
+++ b/test/gst-vaapi/decode/jpeg.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapijpegdec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -22,7 +23,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapijpegdec",
       gstparser   = "jpegparse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/mpeg2.py
+++ b/test/gst-vaapi/decode/mpeg2.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapimpeg2dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -22,7 +23,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapimpeg2dec",
       gstparser   = "mpegvideoparse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/mpeg2.py
+++ b/test/gst-vaapi/decode/mpeg2.py
@@ -15,26 +15,24 @@ spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapimpeg2dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "mpeg2")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "mpeg2"),
+      gstdecoder  = "vaapimpeg2dec",
+      gstparser   = "mpegvideoparse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
     vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! vaapimpeg2dec",
-    )
+    vars(self).update(case = case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
     vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "mpegvideoparse ! vaapimpeg2dec",
-    )
+    vars(self).update(case = case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-vaapi/decode/vc1.py
+++ b/test/gst-vaapi/decode/vc1.py
@@ -15,6 +15,7 @@ spec_r2r = load_test_spec("vc1", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapivc1dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
@@ -23,7 +24,6 @@ class default(DecoderTest):
       gstparser   = "'video/x-wmv,profile=(string)advanced'"
                     ",width={width},height={height},framerate=14/1",
     )
-    super(default, self).before()
 
   def init(self, tspec, case):
     vars(self).update(tspec[case].copy())

--- a/test/gst-vaapi/decode/vc1.py
+++ b/test/gst-vaapi/decode/vc1.py
@@ -15,30 +15,28 @@ spec_r2r = load_test_spec("vc1", "decode", "r2r")
 @slash.requires(*have_gst_element("vaapivc1dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
-    self.caps   = platform.get_caps("decode", "vc1")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
+      caps        = platform.get_caps("decode", "vc1"),
+      gstdecoder  = "vaapivc1dec",
+      gstparser   = "'video/x-wmv,profile=(string)advanced'"
+                    ",width={width},height={height},framerate=14/1",
+    )
     super(default, self).before()
+
+  def init(self, tspec, case):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(case = case)
+    self.gstparser = self.gstparser.format(**vars(self))
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):
-    vars(self).update(spec[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "'video/x-wmv,profile=(string)advanced'"
-                    ",width={width},height={height},framerate=14/1"
-                    " ! vaapivc1dec".format(**vars(self)),
-    )
+    self.init(spec, case)
     self.decode()
 
   @slash.parametrize(("case"), sorted(spec_r2r.keys()))
   def test_r2r(self, case):
-    vars(self).update(spec_r2r[case].copy())
-    vars(self).update(
-      case        = case,
-      gstdecoder  = "'video/x-wmv,profile=(string)advanced'"
-                    ",width={width},height={height},framerate=14/1"
-                    " ! vaapivc1dec".format(**vars(self)),
-    )
+    self.init(spec_r2r, case)
     vars(self).setdefault("r2r", 5)
     self.decode()

--- a/test/gst-vaapi/decode/vp8.py
+++ b/test/gst-vaapi/decode/vp8.py
@@ -14,9 +14,12 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("vaapivp8dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp8"),
+      gstdecoder  = "vaapivp8dec",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +32,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp8dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-vaapi/decode/vp8.py
+++ b/test/gst-vaapi/decode/vp8.py
@@ -14,13 +14,13 @@ spec = load_test_spec("vp8", "decode")
 @slash.requires(*have_gst_element("vaapivp8dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
       caps        = platform.get_caps("decode", "vp8"),
       gstdecoder  = "vaapivp8dec",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/vp9.py
+++ b/test/gst-vaapi/decode/vp9.py
@@ -14,6 +14,7 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
+    super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
@@ -21,7 +22,6 @@ class default(DecoderTest):
       gstdecoder  = "vaapivp9dec",
       gstparser   = "vp9parse",
     )
-    super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
   def test(self, case):

--- a/test/gst-vaapi/decode/vp9.py
+++ b/test/gst-vaapi/decode/vp9.py
@@ -14,9 +14,13 @@ spec = load_test_spec("vp9", "decode", "8bit")
 @slash.requires(*have_gst_element("vaapivp9dec"))
 class default(DecoderTest):
   def before(self):
-    # default metric
-    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
-    self.caps   = platform.get_caps("decode", "vp9_8")
+    vars(self).update(
+      # default metric
+      metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
+      caps        = platform.get_caps("decode", "vp9_8"),
+      gstdecoder  = "vaapivp9dec",
+      gstparser   = "vp9parse",
+    )
     super(default, self).before()
 
   @slash.parametrize(("case"), sorted(spec.keys()))
@@ -29,6 +33,6 @@ class default(DecoderTest):
 
     vars(self).update(
       case        = case,
-      gstdecoder  = "{} ! vaapivp9dec".format(dxmap[ext]),
+      gstdemuxer  = dxmap[ext],
     )
     self.decode()

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -19,7 +19,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "hevc-10",
       gstencoder    = "vaapih265enc",
-      gstdecoder    = "h265parse ! vaapih265dec",
+      gstdecoder    = "vaapih265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
     )

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -18,9 +18,11 @@ class VP9_10EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "vaapivp9enc",
-      gstdecoder    = "matroskademux ! vaapivp9dec",
+      gstdecoder    = "vaapivp9dec",
       gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
       gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
     )
 
   def get_file_ext(self):

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -19,7 +19,7 @@ class AVCEncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "avc",
       gstencoder    = "vaapih264enc",
-      gstdecoder    = "h264parse ! vaapih264dec",
+      gstdecoder    = "vaapih264dec",
       gstmediatype  = "video/x-h264",
       gstparser     = "h264parse",
     )

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -19,7 +19,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "hevc-8",
       gstencoder    = "vaapih265enc",
-      gstdecoder    = "h265parse ! vaapih265dec",
+      gstdecoder    = "vaapih265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",
     )

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -21,7 +21,7 @@ class JPEGEncoderTest(EncoderTest):
       caps          = platform.get_caps("vdenc", "jpeg"),
       codec         = "jpeg",
       gstencoder    = "vaapijpegenc",
-      gstdecoder    = "jpegparse ! vaapijpegdec",
+      gstdecoder    = "vaapijpegdec",
       gstmediatype  = "image/jpeg",
       gstparser     = "jpegparse",
     )

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -21,8 +21,8 @@ class MPEG2EncoderTest(EncoderTest):
       caps          = platform.get_caps("encode", "mpeg2"),
       codec         = "mpeg2",
       gstencoder    = "vaapimpeg2enc",
-      gstdecoder    = "mpegvideoparse ! vaapimpeg2dec",
-      gstmediatype  = "video/mpeg",
+      gstdecoder    = "vaapimpeg2dec",
+      gstmediatype  = "video/mpeg,mpegversion=2",
       gstparser     = "mpegvideoparse",
     )
 

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -18,9 +18,10 @@ class VP8EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "vp8",
       gstencoder    = "vaapivp8enc",
-      gstdecoder    = "matroskademux ! vaapivp8dec",
+      gstdecoder    = "vaapivp8dec",
       gstmediatype  = "video/x-vp8",
       gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
     )
 
   def get_file_ext(self):

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -18,9 +18,11 @@ class VP9EncoderBaseTest(EncoderTest):
     vars(self).update(
       codec         = "vp9",
       gstencoder    = "vaapivp9enc",
-      gstdecoder    = "matroskademux ! vaapivp9dec",
+      gstdecoder    = "vaapivp9dec",
       gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
       gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
     )
 
   def get_file_ext(self):


### PR DESCRIPTION
Add new properties for gstparser and gstdemuxer in the encoder/decoder classes and use them instead of specifying them in the `gstdecoder` property.