### PR TITLE
gstreamer/encode: use tune property and cqp for avc lp transcode

### DIFF
--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -35,6 +35,12 @@ class Encoder(PropertyHandler):
   fps           = property(lambda s: s.ifprop("fps", " framerate={fps}"))
   profile       = property(lambda s: s.ifprop("profile", ",profile={profile}"))
 
+  @property
+  def lowpower(self):
+    def inner(lowpower):
+      return f" tune={'low-power' if lowpower else 'none'}"
+    return self.ifprop("lowpower", inner)
+
   @timefn("gst-encode")
   def encode(self):
     return call(

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -54,12 +54,6 @@ class Encoder(GstEncoder):
       return f" max-vbv-bitrate={self.props['maxrate']}"
     return ""
 
-  @property
-  def lowpower(self):
-    def inner(lowpower):
-      return f" low-power={1 if lowpower else 0}"
-    return self.ifprop("lowpower", inner)
-
   gop     = property(lambda s: s.ifprop("gop", " gop-size={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " b-frames={bframes}"))

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -51,12 +51,12 @@ class TranscoderTest(BaseTranscoderTest):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
-        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc low-power=1 ! video/x-h264,profile=main ! h264parse"),
+        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc tune=low-power ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
-        lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc low-power=1 ! video/x-h265,profile=main ! h265parse"),
+        lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc tune=low-power ! video/x-h265,profile=main ! h265parse"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -51,7 +51,7 @@ class TranscoderTest(BaseTranscoderTest):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
-        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc tune=low-power ! video/x-h264,profile=main ! h264parse"),
+        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc rate-control=cqp tune=low-power ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -47,12 +47,6 @@ class Encoder(GstEncoder):
       return f" quality-level={quality}"
     return self.ifprop("quality", inner)
 
-  @property
-  def lowpower(self):
-    def inner(lowpower):
-      return f" tune={'low-power' if lowpower else 'none'}"
-    return self.ifprop("lowpower", inner)
-
   gop     = property(lambda s: s.ifprop("gop", " keyframe-period={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " max-bframes={bframes}"))

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -49,7 +49,7 @@ class TranscoderTest(BaseTranscoderTest):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
-        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc tune=low-power ! video/x-h264,profile=main ! h264parse"),
+        lp = (platform.get_caps("vdenc", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc rate-control=cqp tune=low-power ! video/x-h264,profile=main ! h264parse"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),


### PR DESCRIPTION
1. The gstreamer msdk elements deprecated the `low-power` property in favor of the `tune` property.
1. AVCe LP only supports CQP rate-control on some older platforms.  Thus, use CQP for AVC LP transcode tests.
