### PR TITLE
ffmpeg/transcode: use cqp in lp mode

### DIFF
--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -39,7 +39,7 @@ class TranscoderTest(slash.Test):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx264"), "libx264"),
         hw = (platform.get_caps("encode", "avc"), have_ffmpeg_encoder("h264_qsv"), "h264_qsv"),
-        lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_qsv"), "h264_qsv"),
+        lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_qsv"), "h264_qsv -q 20"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -39,7 +39,7 @@ class TranscoderTest(slash.Test):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx264"), "libx264"),
         hw = (platform.get_caps("encode", "avc"), have_ffmpeg_encoder("h264_vaapi"), "h264_vaapi"),
-        lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_vaapi"), "h264_vaapi"),
+        lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_vaapi"), "h264_vaapi -qp 20"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),


### PR DESCRIPTION
Some older platforms only support AVCe cqp in
low power (vdenc) mode.  Thus, explicitly use
cqp rate control for avc lp transcode.
