### PR TITLE
slashrc: add os type detect

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -104,7 +104,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
     assert not (args.ctapt != -1 and slash.config.root.parallel.num_workers > 0), "ctapt in parallel mode is not supported"
     assert not (args.ctapr != -1 and slash.config.root.parallel.num_workers > 0), "ctapr in parallel mode is not supported"
 
-    if "NONE" != self.platform.upper():
+    if self._get_os() != 'windows' and "NONE" != self.platform.upper():
       assert os.path.exists(args.device), "Target Device {} not exist".format(args.device)
 
   def _calls_allowed(self):
@@ -213,6 +213,10 @@ class MediaPlugin(slash.plugins.PluginInterface):
        return self.test_call_timeout
     else:
        return self.call_timeout
+
+  def _get_os(self):
+    from lib.platform import info
+    return info()["os"]
 
   def test_start(self):
     test = slash.context.test

--- a/lib/platform.py
+++ b/lib/platform.py
@@ -133,6 +133,14 @@ def info():
   except:
     cpu = "unknown"
 
+  # python load from WSL1: 'linux-{kernel_version}-microsoft-{architecture}-with-{glibc_version}'
+  # python load from WSL2: 'linux-{kernel_version}-microsoft-standard-{architecture}-with-{glibc_version}'
+  # python load from OS native: 'windows-{os_family}_{os_version}-{patch_version}'
+  if 'microsoft' in platform.platform().lower() or 'windows' in platform.platform().lower():
+    os='windows'
+  else:
+    os='linux'
+
   from .common import get_media
 
   capsinfo = load_capsinfo() or dict()
@@ -144,5 +152,6 @@ def info():
     cpu = cpu,
     driver = str(get_media()._get_driver_name()),
     platform = str(get_media()._get_platform_name()),
+    os = os,
     **capsinfo,
   )


### PR DESCRIPTION
With Windows side support, some code maybe different between windows/linux
Because they use the different environment, some option/environment will different

Like:
windows side don't restrict the render device

Signed-off-by: Bin Wu <bin1.wu@intel.com>