### PR TITLE
lib/ffmpeg/decoderbase: remove hwdownload filter

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -25,12 +25,12 @@ class BaseDecoderTest(slash.Test):
     return call(
       (
         "ffmpeg -hwaccel {hwaccel} -init_hw_device {hwaccel}=hw:{renderDevice}"
-        " -hwaccel_output_format {hwaccel} -hwaccel_flags allow_profile_mismatch"
+        " -hwaccel_output_format {hwformat} -hwaccel_flags allow_profile_mismatch"
         " -v verbose"
       ).format(**vars(self)) + (
         " -c:v {ffdecoder}" if hasattr(self, "ffdecoder") else ""
       ).format(**vars(self)) + (
-        " -i {source} -vf 'hwdownload,format={hwformat}'"
+        " -i {source}"
         " -pix_fmt {mformat} -f rawvideo -vsync passthrough -autoscale 0"
         " -vframes {frames} -y {decoded}"
       ).format(**vars(self))


### PR DESCRIPTION
The hwformat can be specified in the -hwaccel_output_format
option directly and removes the need for using a hwdownload
filter.

This also makes it easier to use other hwaccel plugins where
the hwaccel format name is not the same as the plugin name.
For example, d3d11va is an hwaccel plugin name but the
corresponding hwaccel format name is d3d11... so would require
additional class property to handle it in previous command
template.  Now setting hwformat in hwaccel_output_format
directly, we don't need to do any special case here.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>