### PR TITLE
WSL updates for #342

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -104,7 +104,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
     assert not (args.ctapt != -1 and slash.config.root.parallel.num_workers > 0), "ctapt in parallel mode is not supported"
     assert not (args.ctapr != -1 and slash.config.root.parallel.num_workers > 0), "ctapr in parallel mode is not supported"
 
-    if self._get_os() != 'windows' and "NONE" != self.platform.upper():
+    if self._get_os() == 'linux' and "NONE" != self.platform.upper():
       assert os.path.exists(args.device), "Target Device {} not exist".format(args.device)
 
   def _calls_allowed(self):

--- a/lib/caps/TGL/d3d11
+++ b/lib/caps/TGL/d3d11
@@ -1,0 +1,76 @@
+###
+### Copyright (C) 2020 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    vc1     = dict(maxres = res4k , fmts = ["NV12"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12"],
+      features  = dict(scc = True, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    av1_10  = dict(maxres = res8k , fmts = ["P010"]),
+  ),
+  vpp    = dict(
+    # brightness, contrast, hue and saturation
+    procamp     = dict(
+      ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
+      ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # mirroring and rotation
+    transpose   = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    crop        = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    sharpen     = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    denoise     = dict(
+      ifmts = ["NV12", "P010", "YUY2"],
+      ofmts = ["NV12", "P010", "YUY2"],
+      chroma = False,
+    ),
+    scale       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    blend       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+  ),
+)

--- a/lib/common.py
+++ b/lib/common.py
@@ -226,12 +226,12 @@ def exe2os(name):
 def filepath2os(file_path):
   if get_media()._get_os() == "wsl":
     # WSL mounts the windows file system in "/mnt/<DRIVE LETTER>/path/to/file" form.
-    # Here, we convert to native windows file path form "<DRIVE LETTER>:\\path\\to\\file"
+    # Here, we convert to native windows file path form "<DRIVE LETTER>:/path/to/file"
     # wslpath issue: https://github.com/microsoft/WSL/issues/4908
     # return call(f"wslpath -w {file_path}")
-    # Windows binaray need access absolute path
-    # when command run in WSL shell environment, '\\' -> '\'
-    windows_path = call(f'realpath {file_path}').strip().replace('/mnt/', '').replace('/', '\\\\')
-    return windows_path[0] + ':' + windows_path[1:]
+    path = os.path.realpath(file_path).strip(os.sep).split(os.sep)
+    assert "mnt" == path[0], f"{file_path} does not resolve to /mnt/<drive>/.."
+    path[1] += ':'
+    return os.sep.join(path[1:])
   else:
     return file_path

--- a/lib/common.py
+++ b/lib/common.py
@@ -217,3 +217,21 @@ def pathexists(path):
 def makepath(path):
   if not pathexists(path):
     os.makedirs(abspath(path))
+
+@memoize
+def exe2os(name):
+  return f"{name}" if "linux" == get_media()._get_os() else f"{name}.exe"
+
+@memoize
+def filepath2os(file_path):
+  if get_media()._get_os() == "wsl":
+    # WSL mounts the windows file system in "/mnt/<DRIVE LETTER>/path/to/file" form.
+    # Here, we convert to native windows file path form "<DRIVE LETTER>:\\path\\to\\file"
+    # wslpath issue: https://github.com/microsoft/WSL/issues/4908
+    # return call(f"wslpath -w {file_path}")
+    # Windows binaray need access absolute path
+    # when command run in WSL shell environment, '\\' -> '\'
+    windows_path = call(f'realpath {file_path}').strip().replace('/mnt/', '').replace('/', '\\\\')
+    return windows_path[0] + ':' + windows_path[1:]
+  else:
+    return file_path

--- a/lib/ffmpeg/d3d11/__init__.py
+++ b/lib/ffmpeg/d3d11/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/ffmpeg/d3d11/decoder.py
+++ b/lib/ffmpeg/d3d11/decoder.py
@@ -1,0 +1,17 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ....lib.common import get_media
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
+
+@slash.requires(have_ffmpeg_hwaccel("d3d11va"))
+class DecoderTest(BaseDecoderTest):
+  def before(self):
+    super().before()
+    self.hwaccel = "d3d11va"

--- a/lib/ffmpeg/d3d11/util.py
+++ b/lib/ffmpeg/d3d11/util.py
@@ -1,0 +1,12 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib.common import memoize
+from ....lib.ffmpeg.util import *
+
+def load_test_spec(*ctx):
+  from ....lib import util as libutil
+  return libutil.load_test_spec("ffmpeg-d3d11", *ctx)

--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -7,7 +7,7 @@
 import re
 import slash
 
-from ...lib.common import timefn, get_media, call
+from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.ffmpeg.util import have_ffmpeg, map_best_hw_format, mapformat
 from ...lib.parameters import format_value
 from ...lib.util import skip_test_if_missing_features
@@ -24,16 +24,17 @@ class BaseDecoderTest(slash.Test):
   def call_ffmpeg(self):
     return call(
       (
-        "ffmpeg -hwaccel {hwaccel} -init_hw_device {hwaccel}=hw:{renderDevice}"
-        " -hwaccel_output_format {hwformat} -hwaccel_flags allow_profile_mismatch"
-        " -v verbose"
-      ).format(**vars(self)) + (
+        f"{exe2os('ffmpeg')} -hwaccel {self.hwaccel}"
+        f" -init_hw_device {self.hwaccel}=hw:{self.renderDevice}"
+        f" -hwaccel_output_format {self.hwformat}"
+        f" -hwaccel_flags allow_profile_mismatch -v verbose"
+      ) + (
         " -c:v {ffdecoder}" if hasattr(self, "ffdecoder") else ""
       ).format(**vars(self)) + (
-        " -i {source}"
-        " -pix_fmt {mformat} -f rawvideo -vsync passthrough -autoscale 0"
-        " -vframes {frames} -y {decoded}"
-      ).format(**vars(self))
+        f" -i {filepath2os(self.source)}"
+        f" -pix_fmt {self.mformat} -f rawvideo -vsync passthrough -autoscale 0"
+        f" -vframes {self.frames} -y {filepath2os(self.decoded)}"
+      )
     )
 
   def gen_name(self):

--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -4,37 +4,37 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from ...lib.common import memoize, try_call, call
+from ...lib.common import memoize, try_call, call, exe2os
 from ...lib.formats import match_best_format
 
 @memoize
 def have_ffmpeg():
-  return try_call("which ffmpeg")
+  return try_call(f"which {exe2os('ffmpeg')}")
 
 @memoize
 def have_ffmpeg_hwaccel(accel):
-  return try_call("ffmpeg -hide_banner -hwaccels | grep {}".format(accel))
+  return try_call(f"{exe2os('ffmpeg')} -hide_banner -hwaccels | grep {accel}")
 
 @memoize
 def have_ffmpeg_filter(name):
-  result = try_call("ffmpeg -hide_banner -filters | awk '{{print $2}}' | grep -w {}".format(name))
+  result = try_call(f"{exe2os('ffmpeg')} -hide_banner -filters | awk '{{print $2}}' | grep -w {name}")
   return result, name
 
 @memoize
 def have_ffmpeg_encoder(encoder):
-  result = try_call("ffmpeg -hide_banner -encoders | awk '{{print $2}}' | grep -w {}".format(encoder))
+  result = try_call(f"{exe2os('ffmpeg')} -hide_banner -encoders | awk '{{print $2}}' | grep -w {encoder}")
   return result, encoder
 
 @memoize
 def have_ffmpeg_decoder(decoder):
-  result = try_call("ffmpeg -hide_banner -decoders | awk '{{print $2}}' | grep -w {}".format(decoder))
+  result = try_call(f"{exe2os('ffmpeg')} -hide_banner -decoders | awk '{{print $2}}' | grep -w {decoder}")
   return result, decoder
 
 def ffmpeg_probe_resolution(filename):
   return call(
-    "ffprobe -v quiet -select_streams v:0"
+    f"{exe2os('ffprobe')} -v quiet -select_streams v:0"
     " -show_entries stream=width,height -of"
-    " csv=s=x:p=0 {}".format(filename)
+    f" csv=s=x:p=0 {filename}"
   ).strip()
 
 def get_supported_format_map():

--- a/lib/platform.py
+++ b/lib/platform.py
@@ -136,8 +136,8 @@ def info():
   # python load from WSL1: 'linux-{kernel_version}-microsoft-{architecture}-with-{glibc_version}'
   # python load from WSL2: 'linux-{kernel_version}-microsoft-standard-{architecture}-with-{glibc_version}'
   # python load from OS native: 'windows-{os_family}_{os_version}-{patch_version}'
-  if 'microsoft' in platform.platform().lower() or 'windows' in platform.platform().lower():
-    os='windows'
+  if 'microsoft' in platform.platform().lower():
+    os='wsl'
   else:
     os='linux'
 

--- a/test/ffmpeg-d3d11/__init__.py
+++ b/test/ffmpeg-d3d11/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-d3d11/decode/10bit/__init__.py
+++ b/test/ffmpeg-d3d11/decode/10bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-d3d11/decode/10bit/av1.py
+++ b/test/ffmpeg-d3d11/decode/10bit/av1.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.d3d11.util import *
+from .....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("av1", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "av1_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "av1_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/10bit/hevc.py
+++ b/test/ffmpeg-d3d11/decode/10bit/hevc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.d3d11.util import *
+from .....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("hevc", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "hevc_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/10bit/vp9.py
+++ b/test/ffmpeg-d3d11/decode/10bit/vp9.py
@@ -1,0 +1,30 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.d3d11.util import *
+from .....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("vp9", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp9_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  def check_output(self):
+    m = re.search("No support for codec vp9", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+    super(default, self).check_output()

--- a/test/ffmpeg-d3d11/decode/__init__.py
+++ b/test/ffmpeg-d3d11/decode/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-d3d11/decode/avc.py
+++ b/test/ffmpeg-d3d11/decode/avc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("avc", "decode")
+
+@slash.requires(*platform.have_caps("decode", "avc"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "avc")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/hevc.py
+++ b/test/ffmpeg-d3d11/decode/hevc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("hevc", "decode", "8bit")
+
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "hevc_8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/jpeg.py
+++ b/test/ffmpeg-d3d11/decode/jpeg.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("jpeg", "decode")
+spec_r2r = load_test_spec("jpeg", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "jpeg"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "jpeg")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/mpeg2.py
+++ b/test/ffmpeg-d3d11/decode/mpeg2.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("mpeg2", "decode")
+spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "mpeg2")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/vc1.py
+++ b/test/ffmpeg-d3d11/decode/vc1.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("vc1", "decode")
+spec_r2r = load_test_spec("vc1", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "vc1"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "vc1")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/vp8.py
+++ b/test/ffmpeg-d3d11/decode/vp8.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("vp8", "decode")
+
+@slash.requires(*platform.have_caps("decode", "vp8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-d3d11/decode/vp9.py
+++ b/test/ffmpeg-d3d11/decode/vp9.py
@@ -1,0 +1,30 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("vp9", "decode", "8bit")
+
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp9_8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  def check_output(self):
+    m = re.search("No support for codec vp9", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+    super(default, self).check_output()


### PR DESCRIPTION
This PR adds additional patches to #342 and test implementations for ffmpeg-d3d11.

Example:
```
  export LIBVA_DRIVER_NAME=d3d11
  ./vaapi-fits run test/ffmpeg-d3d11 --platform TGL \
    --parallel-metrics --device d3d11va -vv
```

Obviously, d3d11 is not a vaapi driver... and using
LIBVA_DRIVER_NAME to set this is awkward.  So we will
want to improve upon this at some point.