### PR TITLE
lib/ffmpeg: provide context for have_ffmpeg_hwaccel

### DIFF
--- a/lib/ffmpeg/d3d11/decoder.py
+++ b/lib/ffmpeg/d3d11/decoder.py
@@ -10,7 +10,7 @@ from ....lib.common import get_media
 from ....lib.ffmpeg.decoderbase import BaseDecoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 
-@slash.requires(have_ffmpeg_hwaccel("d3d11va"))
+@slash.requires(*have_ffmpeg_hwaccel("d3d11va"))
 class DecoderTest(BaseDecoderTest):
   def before(self):
     super().before()

--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -12,7 +12,7 @@ from ....lib.ffmpeg.decoderbase import BaseDecoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
 
-@slash.requires(have_ffmpeg_hwaccel("qsv"))
+@slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class DecoderTest(BaseDecoderTest):
   def before(self):

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -11,7 +11,7 @@ from ....lib.ffmpeg.encoderbase import BaseEncoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 from ....lib.ffmpeg.qsv.util import mapprofile, using_compatible_driver
 
-@slash.requires(have_ffmpeg_hwaccel("qsv"))
+@slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class EncoderTest(BaseEncoderTest):
   def before(self):

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -11,7 +11,7 @@ from ....lib.ffmpeg.transcoderbase import BaseTranscoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_decoder, have_ffmpeg_encoder, have_ffmpeg_hwaccel, have_ffmpeg_filter
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
 
-@slash.requires(have_ffmpeg_hwaccel("qsv"))
+@slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -8,7 +8,7 @@ from ....lib import *
 from .util import *
 
 @slash.requires(have_ffmpeg)
-@slash.requires(have_ffmpeg_hwaccel("qsv"))
+@slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(*have_ffmpeg_filter("vpp_qsv"))
 @slash.requires(using_compatible_driver)
 class VppTest(slash.Test):

--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -13,7 +13,8 @@ def have_ffmpeg():
 
 @memoize
 def have_ffmpeg_hwaccel(accel):
-  return try_call(f"{exe2os('ffmpeg')} -hide_banner -hwaccels | grep {accel}")
+  result = try_call(f"{exe2os('ffmpeg')} -hide_banner -hwaccels | grep {accel}")
+  return result, accel
 
 @memoize
 def have_ffmpeg_filter(name):

--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -10,7 +10,7 @@ from ....lib.common import get_media
 from ....lib.ffmpeg.decoderbase import BaseDecoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 
-@slash.requires(have_ffmpeg_hwaccel("vaapi"))
+@slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class DecoderTest(BaseDecoderTest):
   def before(self):
     super().before()

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -11,7 +11,7 @@ from ....lib.ffmpeg.encoderbase import BaseEncoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 from ....lib.ffmpeg.vaapi.util import mapprofile
 
-@slash.requires(have_ffmpeg_hwaccel("vaapi"))
+@slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class EncoderTest(BaseEncoderTest):
   def before(self):
     super().before()

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -10,7 +10,7 @@ from ....lib import platform
 from ....lib.ffmpeg.transcoderbase import BaseTranscoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_decoder, have_ffmpeg_encoder, have_ffmpeg_hwaccel, have_ffmpeg_filter
 
-@slash.requires(have_ffmpeg_hwaccel("vaapi"))
+@slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     # ffmpeg-vaapi HW decoders are built-in

--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -8,7 +8,7 @@ from ....lib import *
 from .util import *
 
 @slash.requires(have_ffmpeg)
-@slash.requires(have_ffmpeg_hwaccel("vaapi"))
+@slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class VppTest(slash.Test):
   def before(self):
     self.refctx = []

--- a/test/ffmpeg-qsv/general/runtime.py
+++ b/test/ffmpeg-qsv/general/runtime.py
@@ -11,7 +11,7 @@ from ....lib.ffmpeg.qsv.util import *
 from ....lib.mfx.runtime import MFXRuntimeTest
 
 @slash.requires(have_ffmpeg)
-@slash.requires(have_ffmpeg_hwaccel("qsv"))
+@slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class detect(MFXRuntimeTest):
   def before(self):


### PR DESCRIPTION
When have_ffmpeg_hwaccel is false we should return
a context, too, so slash.requires reports something
useful.

Without the context, the missing requirement will emit:

  Skipped (Unmet requirement: ?)

With a context, it will emit (for example):

  Skipped (Unmet requirement: d3d11va)

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>