### PR TITLE
lib/caps/TGL/d3d11: disable hevc scc profile cases

### DIFF
--- a/lib/caps/TGL/d3d11
+++ b/lib/caps/TGL/d3d11
@@ -17,7 +17,7 @@ caps = dict(
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12"],
-      features  = dict(scc = True, msp = True),
+      features  = dict(scc = False, msp = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12"]),


### PR DESCRIPTION
Since d3d11va doesn't support hevc scc profile, skip all the scc cases.

Signed-off-by: Tong Wu <tong1.wu@intel.com>