### PR TITLE
lib/ffmpeg/qsv/util.py: add d3d11 support for ffmpeg-qsv test

### DIFF
--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -8,7 +8,7 @@ from ....lib.common import memoize, get_media
 from ....lib.ffmpeg.util import *
 
 def using_compatible_driver():
-  return get_media()._get_driver_name() == "iHD"
+  return get_media()._get_driver_name() in ["iHD", "d3d11"]
 
 @memoize
 def map_deinterlace_method(method):


### PR DESCRIPTION
ffmpeg-qsv can load d3d11/iHD on windows side

Signed-off-by: Bin Wu <bin1.wu@intel.com>