### PR TITLE
ffmpeg-qsv: add hevc forced_idr encode test support

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -269,8 +269,11 @@ class BaseEncoderTest(slash.Test):
     if vars(self).get("vforced_idr", None) is None:
       return
 
+    judge = {"hevc-8" : 19, "avc" : 5}.get(self.codec, None)
+    assert judge is not None, f"{self.codec} codec not supported for forced_idr"
+
     output = call(
       "ffmpeg -v verbose -i {encoded} -c:v copy"
       " -vframes {frames} -bsf:v trace_headers"
-      " -f null - 2>&1 | grep 'nal_unit_type.*5' | wc -l".format(**vars(self)))
+      " -f null - 2>&1 | grep 'nal_unit_type.*{judge}' | wc -l".format(**vars(self)))
     assert str(self.frames) == output.strip(), "It appears that the forced_idr did not work"

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -215,6 +215,7 @@ gen_hevc_vbr_parameters = gen_avc_vbr_parameters
 gen_hevc_cqp_lp_parameters = gen_avc_cqp_lp_parameters
 gen_hevc_cbr_lp_parameters = gen_avc_cbr_lp_parameters
 gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
+gen_hevc_forced_idr_parameters = gen_avc_forced_idr_parameters
 
 def gen_mpeg2_cqp_variants(spec):
   for case, params in spec.items():

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -201,3 +201,23 @@ class vbr_lp(HEVC8EncoderLPTest):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class forced_idr(HEVC8EncoderTest):
+  def init(self, tspec, case, rcmode, bitrate, maxrate, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      qp         = qp,
+      quality    = quality,
+      vforced_idr = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_forced_idr_parameters(spec, ['main']))
+  def test(self, case, rcmode, bitrate, maxrate, qp, quality, profile):
+    self.init(spec, case, rcmode, bitrate, maxrate, qp, quality, profile)
+    self.encode()


### PR DESCRIPTION
Add hevc forced_idr encode test support for ffmpeg-qsv

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>