### PR TITLE
lib/caps/TGL/d3d11: add supported cases for libvpl

### DIFF
--- a/lib/caps/TGL/d3d11
+++ b/lib/caps/TGL/d3d11
@@ -14,16 +14,29 @@ caps = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
     mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
     vc1     = dict(maxres = res4k , fmts = ["NV12"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
-      fmts      = ["NV12"],
-      features  = dict(scc = False, msp = True),
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True, msp = True),
     ),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
-    vp9_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
     av1_10  = dict(maxres = res8k , fmts = ["P010"]),
+  ),
+  encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "AYUV"],
+      features  = dict(scc = True, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation


### PR DESCRIPTION
The added cases are all supported by ffmpeg-libvpl on Windows,
so add them all for testing.

Signed-off-by: Tong Wu <tong1.wu@intel.com>