### PR TITLE
Add dxva2 support for ffmpeg

### DIFF
--- a/lib/caps/TGL/dxva2
+++ b/lib/caps/TGL/dxva2
@@ -1,0 +1,87 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    vc1     = dict(maxres = res4k , fmts = ["NV12"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12"],
+      features  = dict(scc = False, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
+    av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    av1_10  = dict(maxres = res8k , fmts = ["P010"]),
+  ),
+  encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    hevc_8  = dict(
+      maxres    = res2k,
+      fmts      = ["NV12"],
+      features  = dict(scc = False, msp = True),
+    ),
+  ),
+  vpp    = dict(
+    # brightness, contrast, hue and saturation
+    procamp     = dict(
+      ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
+      ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # mirroring and rotation
+    transpose   = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    crop        = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    sharpen     = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    denoise     = dict(
+      ifmts = ["NV12", "P010", "YUY2"],
+      ofmts = ["NV12", "P010", "YUY2"],
+      chroma = False,
+    ),
+    scale       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    blend       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+  ),
+)

--- a/lib/ffmpeg/dxva2/__init__.py
+++ b/lib/ffmpeg/dxva2/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/lib/ffmpeg/dxva2/decoder.py
+++ b/lib/ffmpeg/dxva2/decoder.py
@@ -1,0 +1,17 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import slash
+
+from ....lib.common import get_media
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
+
+@slash.requires(*have_ffmpeg_hwaccel("dxva2"))
+class DecoderTest(BaseDecoderTest):
+  def before(self):
+    super().before()
+    self.hwaccel = "dxva2"

--- a/lib/ffmpeg/dxva2/util.py
+++ b/lib/ffmpeg/dxva2/util.py
@@ -1,0 +1,12 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib.common import memoize
+from ....lib.ffmpeg.util import *
+
+def load_test_spec(*ctx):
+  from ....lib import util as libutil
+  return libutil.load_test_spec("ffmpeg-dxva2", *ctx)

--- a/test/ffmpeg-dxva2/__init__.py
+++ b/test/ffmpeg-dxva2/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-dxva2/decode/10bit/__init__.py
+++ b/test/ffmpeg-dxva2/decode/10bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-dxva2/decode/10bit/av1.py
+++ b/test/ffmpeg-dxva2/decode/10bit/av1.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.dxva2.util import *
+from .....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("av1", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "av1_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "av1_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/10bit/hevc.py
+++ b/test/ffmpeg-dxva2/decode/10bit/hevc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.dxva2.util import *
+from .....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("hevc", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "hevc_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/10bit/vp9.py
+++ b/test/ffmpeg-dxva2/decode/10bit/vp9.py
@@ -1,0 +1,30 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.dxva2.util import *
+from .....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("vp9", "decode", "10bit")
+
+@slash.requires(*platform.have_caps("decode", "vp9_10"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp9_10")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  def check_output(self):
+    m = re.search("No support for codec vp9", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+    super(default, self).check_output()

--- a/test/ffmpeg-dxva2/decode/__init__.py
+++ b/test/ffmpeg-dxva2/decode/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-dxva2/decode/avc.py
+++ b/test/ffmpeg-dxva2/decode/avc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("avc", "decode")
+
+@slash.requires(*platform.have_caps("decode", "avc"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "avc")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/hevc.py
+++ b/test/ffmpeg-dxva2/decode/hevc.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("hevc", "decode", "8bit")
+
+@slash.requires(*platform.have_caps("decode", "hevc_8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "hevc_8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/jpeg.py
+++ b/test/ffmpeg-dxva2/decode/jpeg.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("jpeg", "decode")
+spec_r2r = load_test_spec("jpeg", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "jpeg"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "jpeg")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/mpeg2.py
+++ b/test/ffmpeg-dxva2/decode/mpeg2.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("mpeg2", "decode")
+spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "mpeg2"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "mpeg2")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/vc1.py
+++ b/test/ffmpeg-dxva2/decode/vc1.py
@@ -1,0 +1,33 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("vc1", "decode")
+spec_r2r = load_test_spec("vc1", "decode", "r2r")
+
+@slash.requires(*platform.have_caps("decode", "vc1"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99)
+    self.caps   = platform.get_caps("decode", "vc1")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  @slash.parametrize(("case"), sorted(spec_r2r.keys()))
+  def test_r2r(self, case):
+    vars(self).update(spec_r2r[case].copy())
+    vars(self).setdefault("r2r", 5)
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/vp8.py
+++ b/test/ffmpeg-dxva2/decode/vp8.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("vp8", "decode")
+
+@slash.requires(*platform.have_caps("decode", "vp8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()

--- a/test/ffmpeg-dxva2/decode/vp9.py
+++ b/test/ffmpeg-dxva2/decode/vp9.py
@@ -1,0 +1,30 @@
+###
+### Copyright (C) 2021 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.dxva2.util import *
+from ....lib.ffmpeg.dxva2.decoder import DecoderTest
+
+spec = load_test_spec("vp9", "decode", "8bit")
+
+@slash.requires(*platform.have_caps("decode", "vp9_8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "vp9_8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()
+
+  def check_output(self):
+    m = re.search("No support for codec vp9", self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+    super(default, self).check_output()


### PR DESCRIPTION
fork from ffmpeg-d3d11

1. add caps of TGL/dxva2
2. add lib/ffmpeg/dxva2
3. add test/ffmpeg-dxva2

Signed-off-by: Bin Wu <bin1.wu@intel.com>