### PR TITLE
ffmpeg/qsv: skip test if no main10sp option

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -9,7 +9,7 @@ import slash
 
 from ....lib.ffmpeg.encoderbase import BaseEncoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
-from ....lib.ffmpeg.qsv.util import mapprofile, using_compatible_driver
+from ....lib.ffmpeg.qsv.util import mapprofile, using_compatible_driver, have_encode_main10sp
 
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
@@ -32,6 +32,11 @@ class EncoderTest(BaseEncoderTest):
       return " -global_quality {quality}"
     return " -preset {quality}"
 
+  def validate_caps(self):
+    super().validate_caps()
+    if vars(self).get("profile", None) in ["main10sp"] and not have_encode_main10sp(self.ffencoder):
+      slash.skip_test(f"{self.ffencoder} main10sp not supported")
+
   def check_output(self):
     m = re.search("Initialize MFX session", self.output, re.MULTILINE)
     assert m is not None, "It appears that the QSV plugin did not load"
@@ -39,3 +44,7 @@ class EncoderTest(BaseEncoderTest):
     if vars(self).get("ladepth", None) is not None:
       m = re.search(r"Using the VBR with lookahead \(LA\) ratecontrol method", self.output, re.MULTILINE)
       assert m is not None, "It appears that the lookahead did not load"
+
+    if vars(self).get("profile", None) in ["main10sp"]:
+      m = re.search(r"Main10sp.*: enable", self.output, re.MULTILINE)
+      assert m is not None, "It appears that main10sp did not get enabled"

--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -10,6 +10,9 @@ from ....lib.ffmpeg.util import *
 def using_compatible_driver():
   return get_media()._get_driver_name() in ["iHD", "d3d11", "dxva2"]
 
+def have_encode_main10sp(encoder):
+  return try_call(f"{exe2os('ffmpeg')} -hide_banner -h encoder={encoder} | grep '\-main10sp'")
+
 @memoize
 def map_deinterlace_method(method):
   return {


### PR DESCRIPTION
Currently, only cartwheel ffmpeg-qsv + onevpl supports
HEVC main10sp encode.

Thus, skip test if -main10sp is not found in the ffmpeg
encoder options.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>