### PR TITLE
test/ffmpeg-qsv/encode/avc.py: modify the avc/cbr frames

### DIFF
--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -96,6 +96,7 @@ class cbr(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
+      frames    = vars(self).get("brframes", self.frames),
       bframes   = bframes,
       bitrate   = bitrate,
       case      = case,


### PR DESCRIPTION
Modify the encode/avc/cbr frames to meet the bitrate_gap requirements.