### PR TITLE
ffmpeg-d3d11: add av1.py for ffmpeg-d3d11

### DIFF
--- a/test/ffmpeg-d3d11/decode/av1.py
+++ b/test/ffmpeg-d3d11/decode/av1.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.d3d11.util import *
+from ....lib.ffmpeg.d3d11.decoder import DecoderTest
+
+spec = load_test_spec("av1", "decode", "8bit")
+
+@slash.requires(*platform.have_caps("decode", "av1_8"))
+class default(DecoderTest):
+  def before(self):
+    # default metric
+    self.metric = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)
+    self.caps   = platform.get_caps("decode", "av1_8")
+    super(default, self).before()
+
+  @slash.parametrize(("case"), sorted(spec.keys()))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    self.case = case
+    self.decode()


### PR DESCRIPTION
add av1.py to enable 8bit av1 test cases

Signed-off-by: Tong Wu <tong1.wu@intel.com>