### PR TITLE
lib/gst/vaapi/encoder: handle minrate

### DIFF
--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -47,6 +47,13 @@ class Encoder(GstEncoder):
       return f" quality-level={quality}"
     return self.ifprop("quality", inner)
 
+  @property
+  def minrate(self):
+    if super().rcmode in ["vbr"]:
+      tp = self.props["minrate"] / self.props["maxrate"]
+      return f" target-percentage={int(tp * 100)}"
+    return ""
+
   gop     = property(lambda s: s.ifprop("gop", " keyframe-period={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " max-bframes={bframes}"))
@@ -62,7 +69,7 @@ class Encoder(GstEncoder):
       f"{super().gstencoder}"
       f"{self.rcmode}{self.gop}{self.qp}"
       f"{self.quality}{self.slices}{self.bframes}"
-      f"{self.maxrate}{self.refmode}{self.refs}"
+      f"{self.minrate}{self.maxrate}{self.refmode}{self.refs}"
       f"{self.lowpower}{self.loopshp}{self.looplvl}"
     )
 


### PR DESCRIPTION
    gst-vaapi encoders can support custom VBR
    minrate with target-percentage property.
    Thus, set target-percentage property based on
    minrate/maxrate to allow future tests to tweek
    the target.
    
    Currently, gst-vaapi tests hardcode minrate/maxrate
    at 70% which is the gst-vaapi encoder default.  Thus,
    this change should not affect current test case
    results.