### PR TITLE
vpp/sharpen: change metric threshold to 0.25

### DIFF
--- a/lib/mixin/vpp.py
+++ b/lib/mixin/vpp.py
@@ -132,7 +132,7 @@ class VppMetricMixin:
 
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
-      assert abs(ref[-3] - actual[-3]) <  0.2, "Luma (Y) out of baseline range"
+      assert abs(ref[-3] - actual[-3]) <  0.25, "Luma (Y) out of baseline range"
 
     get_media().baseline.check_result(
       compare = compare, context = self.refctx, psnr = psnr)

--- a/test/ffmpeg-qsv/vpp/sharpen.py
+++ b/test/ffmpeg-qsv/vpp/sharpen.py
@@ -47,7 +47,7 @@ class default(VppTest):
 
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
-      assert abs(ref[-3] - actual[-3]) <  0.2, "Luma (Y) out of baseline range"
+      assert abs(ref[-3] - actual[-3]) <  0.25, "Luma (Y) out of baseline range"
 
     get_media().baseline.check_result(
       compare = compare, context = self.refctx, psnr = psnr)


### PR DESCRIPTION
Change metric threshold from 0.2 to 0.25 in test/ffmpeg-qsv/vpp/sharpen.