### PR TITLE
baseline: use 98% psnr drop tolerance

### DIFF
--- a/lib/baseline.py
+++ b/lib/baseline.py
@@ -80,7 +80,7 @@ class Baseline:
   def check_psnr(self, psnr, context = []):
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
-      assert all(map(lambda r,a: a+0.2 > r, ref[3:], actual[3:]))
+      assert all(map(lambda r,a: a > (r * 0.98), ref[3:], actual[3:]))
     self.check_result(compare = compare, context = context, psnr = psnr)
 
   def check_md5(self, md5, expect = None, context = []):


### PR DESCRIPTION
Allow PSNR drop tolerance within 98% of reference value.
This relaxes the pass/fail criteria, instead of a constant
0.2db drop tolerance.  For example, a 40db reference allows
for 0.8db drop tolerance, now.

