### PR TITLE
ffmpeg-vaapi encode: use compression_level option for quality (tu)

### DIFF
--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -33,7 +33,7 @@ class EncoderTest(BaseEncoderTest):
   def gen_quality_opts(self):
     if self.codec in ["jpeg"]:
       return " -global_quality {quality}"
-    return " -quality {quality}"
+    return " -compression_level {quality}"
 
   def validate_caps(self):
     super().validate_caps()

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -48,7 +48,7 @@ class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
     )
 
 class cqp(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, profile):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -56,41 +56,43 @@ class cqp(HEVC10EncoderTest):
       gop     = gop,
       profile = profile,
       qp      = qp,
+      quality = quality,
       rcmode  = "cqp",
       slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec, case, gop, slices, bframes, qp, profile)
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, qp, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC10EncoderLPTest):
-  def init(self, tspec, case, gop, slices, qp, profile):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case    = case,
       gop     = gop,
       profile = profile,
       qp      = qp,
+      quality = quality,
       rcmode  = "cqp",
       slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, qp, quality, profile):
-    self.init(spec, case, gop, slices, qp, profile)
+    self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, qp, profile)
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
@@ -148,56 +150,58 @@ class cbr_lp(HEVC10EncoderLPTest):
     self.encode()
 
 class vbr(HEVC10EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       bitrate = bitrate,
-      case = case,
-      fps = fps,
-      gop = gop,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,
-      rcmode = "vbr",
-      refs = refs,
-      slices = slices,
+      quality = quality,
+      rcmode  = "vbr",
+      refs    = refs,
+      slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bframes, bitrate, fps, refs, profile)
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC10EncoderLPTest):
-  def init(self, tspec, case, gop, slices, bitrate, fps, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
-      case = case,
-      fps = fps,
-      gop = gop,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,
-      rcmode = "vbr",
-      refs = refs,
-      slices = slices,
+      quality = quality,
+      rcmode  = "vbr",
+      refs    = refs,
+      slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main10']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bitrate, fps, refs, profile)
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main10']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bitrate, fps, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -35,7 +35,7 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
     )
 
 class cqp_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, slices, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -43,13 +43,14 @@ class cqp_lp(VP9_10EncoderLPTest):
       looplvl   = looplvl,
       loopshp   = loopshp,
       qp        = qp,
+      quality   = quality,
       rcmode    = "cqp",
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, slices, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9_10EncoderLPTest):
@@ -74,7 +75,7 @@ class cbr_lp(VP9_10EncoderLPTest):
     self.encode()
 
 class vbr_lp(VP9_10EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -85,13 +86,14 @@ class vbr_lp(VP9_10EncoderLPTest):
       loopshp   = loopshp,
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
+      quality   = quality,
       rcmode    = "vbr",
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
+    self.init(spec, case, gop, bitrate, fps, quality, slices, loopshp)
     self.encode()
 
 

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -50,49 +50,51 @@ class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
     )
 
 class cqp(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, qp, profile):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
       gop     = gop,
-      qp      = qp,
       profile = profile,
+      qp      = qp,
+      quality = quality,
       rcmode  = "cqp",
       slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec, case, gop, slices, bframes, qp, profile)
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_cqp_parameters(spec_r2r, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, qp, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class cqp_lp(HEVC8EncoderLPTest):
-  def init(self, tspec, case, gop, slices, qp, profile):
+  def init(self, tspec, case, gop, slices, qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case     = case,
       gop      = gop,
-      qp       = qp,
       profile  = profile,
+      qp       = qp,
+      quality  = quality,
       rcmode   = "cqp",
       slices   = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, qp, quality, profile):
-    self.init(spec, case, gop, slices, qp, profile)
+    self.init(spec, case, gop, slices, qp, quality, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_cqp_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, qp, quality, profile):
-    self.init(spec_r2r, case, gop, slices, qp, profile)
+    self.init(spec_r2r, case, gop, slices, qp, quality, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
@@ -156,7 +158,7 @@ class cbr_lp(HEVC8EncoderLPTest):
     self.encode()
 
 class vbr(HEVC8EncoderTest):
-  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, refs, profile):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
@@ -167,24 +169,25 @@ class vbr(HEVC8EncoderTest):
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,
+      quality = quality,
       rcmode  = "vbr",
       refs    = refs,
       slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main']))
   def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bframes, bitrate, fps, refs, profile)
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_vbr_parameters(spec_r2r, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
 
 class vbr_lp(HEVC8EncoderLPTest):
-  def init(self, tspec, case, gop, slices, bitrate, fps, refs, profile):
+  def init(self, tspec, case, gop, slices, bitrate, fps, quality, refs, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate = bitrate,
@@ -194,18 +197,19 @@ class vbr_lp(HEVC8EncoderLPTest):
       maxrate = bitrate * 2, # target percentage 50%
       minrate = bitrate,
       profile = profile,
+      quality = quality,
       rcmode  = "vbr",
       refs    = refs,
       slices  = slices,
     )
 
-  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec, ['main']))
   def test(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec, case, gop, slices, bitrate, fps, refs, profile)
+    self.init(spec, case, gop, slices, bitrate, fps, quality, refs, profile)
     self.encode()
 
-  @parametrize_with_unused(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']), ['quality'])
+  @slash.parametrize(*gen_hevc_vbr_lp_parameters(spec_r2r, ['main']))
   def test_r2r(self, case, gop, slices, bitrate, fps, quality, refs, profile):
-    self.init(spec_r2r, case, gop, slices, bitrate, fps, refs, profile)
+    self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -29,24 +29,25 @@ class MPEG2EncoderTest(EncoderTest):
     return "VAProfileMPEG2.*"
 
 class cqp(MPEG2EncoderTest):
-  def init(self, tspec, case, gop, bframes, qp):
+  def init(self, tspec, case, gop, bframes, qp, quality):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bframes = bframes,
       case    = case,
       gop     = gop,
       qp      = qp,
+      quality = quality,
       mqp     = mapRangeInt(qp, [0, 100], [1, 31]),
       rcmode  = "cqp",
     )
 
-  @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec), ['quality'])
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec))
   def test(self, case, gop, bframes, qp, quality):
-    self.init(spec, case, gop, bframes, qp)
+    self.init(spec, case, gop, bframes, qp, quality)
     self.encode()
 
-  @parametrize_with_unused(*gen_mpeg2_cqp_parameters(spec_r2r), ['quality'])
+  @slash.parametrize(*gen_mpeg2_cqp_parameters(spec_r2r))
   def test_r2r(self, case, gop, bframes, qp, quality):
-    self.init(spec_r2r, case, gop, bframes, qp)
+    self.init(spec_r2r, case, gop, bframes, qp, quality)
     vars(self).setdefault("r2r", 5)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -35,7 +35,7 @@ class VP8EncoderTest(VP8EncoderBaseTest):
     )
 
 class cqp(VP8EncoderTest):
-  @parametrize_with_unused(*gen_vp8_cqp_parameters(spec), ['quality'])
+  @slash.parametrize(*gen_vp8_cqp_parameters(spec))
   def test(self, case, ipmode, qp, quality, looplvl, loopshp):
     vars(self).update(spec[case].copy())
     vars(self).update(
@@ -44,6 +44,7 @@ class cqp(VP8EncoderTest):
       looplvl   = looplvl,
       loopshp   = loopshp,
       qp        = qp,
+      quality   = quality,
       rcmode    = "cqp",
     )
     self.encode()
@@ -67,7 +68,7 @@ class cbr(VP8EncoderTest):
     self.encode()
 
 class vbr(VP8EncoderTest):
-  @parametrize_with_unused(*gen_vp8_vbr_parameters(spec), ['quality'])
+  @slash.parametrize(*gen_vp8_vbr_parameters(spec))
   def test(self, case, gop, bitrate, fps, quality, looplvl, loopshp):
     vars(self).update(spec[case].copy())
     vars(self).update(
@@ -80,6 +81,7 @@ class vbr(VP8EncoderTest):
       loopshp   = loopshp,
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
+      quality   = quality,
       rcmode    = "vbr",
     )
     self.encode()

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -44,7 +44,7 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
     )
 
 class cqp(VP9EncoderTest):
-  def init(self, tspec, case, ipmode, qp, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -52,16 +52,17 @@ class cqp(VP9EncoderTest):
       looplvl   = looplvl,
       loopshp   = loopshp,
       qp        = qp,
+      quality   = quality,
       rcmode    = "cqp",
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['quality', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode'])
   def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, looplvl, loopshp)
     self.encode()
 
 class cqp_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, ipmode, qp, slices, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -69,13 +70,14 @@ class cqp_lp(VP9EncoderLPTest):
       looplvl   = looplvl,
       loopshp   = loopshp,
       qp        = qp,
-      slices    = slices,
+      quality   = quality,
       rcmode    = "cqp",
+      slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['quality', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, slices, looplvl, loopshp)
+    self.init(spec, case, ipmode, qp, quality, slices, looplvl, loopshp)
     self.encode()
 
 class cbr(VP9EncoderTest):
@@ -121,7 +123,7 @@ class cbr_lp(VP9EncoderLPTest):
     self.encode()
 
 class vbr(VP9EncoderTest):
-  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, quality, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -133,16 +135,17 @@ class vbr(VP9EncoderTest):
       loopshp   = loopshp,
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
+      quality   = quality,
       rcmode    = "vbr",
     )
 
-  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['quality', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode'])
   def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
+    self.init(spec, case, gop, bitrate, fps, quality, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
-  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -153,12 +156,13 @@ class vbr_lp(VP9EncoderLPTest):
       loopshp   = loopshp,
       maxrate   = bitrate * 2, # target percentage 50%
       minrate   = bitrate,
+      quality   = quality,
       rcmode    = "vbr",
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['quality', 'refmode', 'looplvl'])
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
+    self.init(spec, case, gop, bitrate, fps, slices, quality, loopshp)
     self.encode()
 


### PR DESCRIPTION
    The base vaapi encoder in ffmpeg uses the global
    -compression_level option to set the libva buffer
    quality level parameter.
    
    Only the vaapi h264 encoder in ffmpeg supports
    the global -quality option to set the libva buffer
    quality level parameter.  However, since the h264
    encoder derives from the base vaapi encoder, it also
    supports the -compression_level option.  Thus, -quality
    is redundant in h264 encoder.
    
    Using -compression_level allows us to properly enable
    the "quality" test parameter usage in the other encoder
    tests (e.g. hevc, vp9...).