### PR TITLE
Caps: Change chroma config for d3d11 and dxva2

### DIFF
--- a/lib/caps/TGL/d3d11
+++ b/lib/caps/TGL/d3d11
@@ -85,7 +85,7 @@ caps = dict(
     denoise     = dict(
       ifmts = ["NV12", "P010", "YUY2"],
       ofmts = ["NV12", "P010", "YUY2"],
-      chroma = False,
+      chroma = True,
     ),
     scale       = dict(
       ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],

--- a/lib/caps/TGL/dxva2
+++ b/lib/caps/TGL/dxva2
@@ -84,7 +84,7 @@ caps = dict(
     denoise     = dict(
       ifmts = ["NV12", "P010", "YUY2"],
       ofmts = ["NV12", "P010", "YUY2"],
-      chroma = False,
+      chroma = True,
     ),
     scale       = dict(
       ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],


### PR DESCRIPTION
According to driver team, the U and V can be changed for TGL Windows.

Signed-off-by: Tong Wu <tong1.wu@intel.com>