### PR TITLE
caps: remove av1 test from dxva2 config

### DIFF
--- a/lib/caps/TGL/dxva2
+++ b/lib/caps/TGL/dxva2
@@ -23,8 +23,6 @@ caps = dict(
     vp9_8   = dict(maxres = res8k , fmts = ["NV12"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
-    av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
-    av1_10  = dict(maxres = res8k , fmts = ["P010"]),
   ),
   encode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),


### PR DESCRIPTION
D3D9 does not support av1 decode, so remove them from ci test.

Signed-off-by: Tong Wu <tong1.wu@intel.com>