### PR TITLE
caps: Change RKL chroma config for d3d11 and dxva2

### DIFF
--- a/lib/caps/RKL/d3d11
+++ b/lib/caps/RKL/d3d11
@@ -73,7 +73,7 @@ caps = dict(
     denoise     = dict(
       ifmts = ["NV12", "P010", "YUY2"],
       ofmts = ["NV12", "P010", "YUY2"],
-      chroma = False,
+      chroma = True,
     ),
     scale       = dict(
       ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],

--- a/lib/caps/RKL/dxva2
+++ b/lib/caps/RKL/dxva2
@@ -72,7 +72,7 @@ caps = dict(
     denoise     = dict(
       ifmts = ["NV12", "P010", "YUY2"],
       ofmts = ["NV12", "P010", "YUY2"],
-      chroma = False,
+      chroma = True,
     ),
     scale       = dict(
       ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],


### PR DESCRIPTION
According to driver team, the U and V can be changed for TGL Windows.

Signed-off-by: Tong Wu <tong1.wu@intel.com>