### PR TITLE
lib/gstreamer/msdk/vpp:remove scaling-mode parameter

### DIFF
--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -51,8 +51,6 @@ class VppTest(BaseVppTest):
         self.level, [0.0, 50.0, 100.0], procamp[self.vpp_op]
       )
       opts += " {vpp_op}={mlevel}"
-    elif self.vpp_op in ["scale"]:
-      opts += " scaling-mode=1"
     elif self.vpp_op in ["deinterlace"]:
       opts += " deinterlace-mode=1 deinterlace-method={mmethod}"
     elif self.vpp_op in ["denoise"]:


### PR DESCRIPTION
Align the gst-msdk cmd arguments with ffmpeg-qsv.

Signed-off-by: Li Fan <fan1x.li@intel.com>