### PR TITLE
lib/mfx/runtime: add logger info to record runtime path

### DIFF
--- a/lib/mfx/runtime.py
+++ b/lib/mfx/runtime.py
@@ -38,6 +38,7 @@ class MFXRuntimeTest(slash.Test):
 
     for m in psutil.Process(proc.pid).memory_maps():
       path = os.path.split(m.path)
+      slash.logger.info(path)
       if path[-1].startswith("libmfxhw64.so"):
         runtimes.append("msdk")
       elif path[-1].startswith("libmfx-gen.so"):


### PR DESCRIPTION
this patch to help trace general/runtime failed reason

Signed-off-by: Bin Wu <bin1.wu@intel.com>