### PR TITLE
test/gst-msdk/encode/av1: add av1parse

### DIFF
--- a/test/gst-msdk/encode/av1.py
+++ b/test/gst-msdk/encode/av1.py
@@ -23,6 +23,7 @@ class AV1EncoderBaseTest(EncoderTest):
       gstmediatype  = "video/x-av1",
       gstmuxer      = "matroskamux",
       gstdemuxer    = "matroskademux",
+      gstparser     = "av1parse",
     )
 
   def get_file_ext(self):


### PR DESCRIPTION
Signed-off-by: Li Fan <fan1x.li@intel.com>
Add av1parse in cmd can fix the issue in gst-msdk/encode/av1 on DG2.