### PR TITLE
Revert ".slashrc: parser parameter before load configure file"

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -14,7 +14,6 @@ import slash
 from slash.utils.traceback_utils import get_traceback_string
 import sys
 import xml.etree.cElementTree as et
-import argparse
 
 __required_slash_version__ = "1.12.0"
 assert slash.__version__ == __required_slash_version__, \
@@ -382,12 +381,6 @@ class MediaPlugin(slash.plugins.PluginInterface):
 
 media = MediaPlugin()
 slash.plugins.manager.install(media, activate = True, is_internal = True)
-
-parser = argparse.ArgumentParser(add_help = False)
-args = argparse.Namespace()
-media.configure_argument_parser(parser)
-parser.parse_known_args(sys.argv[1:], namespace=args)
-media.configure_from_parsed_args(args)
 
 # Allow user to override test config file via environment variable.
 # NOTE: It would be nice to use the configure_argument_parser mechanism in our


### PR DESCRIPTION
Reverts intel/vaapi-fits#382

This is bad.  It breaks all sorts of slash framework logic (e.g. vaapi-fits list).  The only way to access media._get_gpu_gen() at config level is to use various supported runtime evaluated lambdas.