### PR TITLE
Add post_validate hook to decode/encode/vpp tests

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -19,6 +19,7 @@ class BaseDecoderTest(slash.Test, BaseFormatMapper):
     super().before()
     self.refctx = []
     self.renderDevice = get_media().render_device
+    self.post_validate = lambda: None
 
   @timefn("ffmpeg")
   def call_ffmpeg(self):
@@ -63,6 +64,8 @@ class BaseDecoderTest(slash.Test, BaseFormatMapper):
           "{platform}.{driver}.{width}x{height} not supported", **vars(self)))
 
     skip_test_if_missing_features(self)
+
+    self.post_validate()
 
   def decode(self):
     self.validate_caps()

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -19,6 +19,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     super().before()
     self.refctx = []
     self.renderDevice = get_media().render_device
+    self.post_validate = lambda: None
 
   def map_profile(self):
     raise NotImplementedError
@@ -170,6 +171,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       self.mprofile = self.map_profile()
       if self.mprofile is None:
         slash.skip_test("{profile} profile is not supported".format(**vars(self)))
+
+    self.post_validate()
 
   @timefn("ffmpeg")
   def call_ffmpeg(self, iopts, oopts):

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -15,6 +15,7 @@ class VppTest(slash.Test, BaseFormatMapper):
   def before(self):
     self.refctx = []
     self.renderDevice = get_media().render_device
+    self.post_validate = lambda: None
 
   def gen_input_opts(self):
     if self.vpp_op not in ["deinterlace"]:
@@ -131,6 +132,8 @@ class VppTest(slash.Test, BaseFormatMapper):
       for comp in self.comps:
         self.owidth = max(self.owidth, self.width + comp['x'])
         self.oheight = max(self.oheight, self.height + comp['y'])
+
+    self.post_validate()
 
   def vpp(self):
     self.validate_caps()

--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -13,6 +13,7 @@ class VppTest(slash.Test, BaseFormatMapper):
   def before(self):
     self.refctx = []
     self.renderDevice = get_media().render_device
+    self.post_validate = lambda: None
 
   def gen_input_opts(self):
     if self.vpp_op not in ["deinterlace"]:
@@ -123,6 +124,8 @@ class VppTest(slash.Test, BaseFormatMapper):
       for comp in self.comps:
         self.owidth = max(self.owidth, self.width + comp['x'])
         self.oheight = max(self.oheight, self.height + comp['y'])
+
+    self.post_validate()
 
   def vpp(self):
     self.validate_caps()

--- a/lib/gstreamer/decoderbase.py
+++ b/lib/gstreamer/decoderbase.py
@@ -45,6 +45,7 @@ class BaseDecoderTest(slash.Test):
   def before(self):
     super().before()
     self.refctx = []
+    self.post_validate = lambda: None
 
   def gen_name(self):
     name = "{case}_{width}x{height}_{format}"
@@ -71,6 +72,8 @@ class BaseDecoderTest(slash.Test):
         "gstreamer.{format} not supported".format(**vars(self)))
 
     skip_test_if_missing_features(self)
+
+    self.post_validate()
 
   def decode(self):
     self.validate_caps()

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -60,6 +60,7 @@ class BaseEncoderTest(slash.Test):
   def before(self):
     super().before()
     self.refctx = []
+    self.post_validate = lambda: None
 
   def map_profile(self):
     raise NotImplementedError
@@ -144,6 +145,8 @@ class BaseEncoderTest(slash.Test):
       if self.mprofile is None:
         slash.skip_test("{profile} profile is not supported".format(**vars(self)))
       self.encoder.update(profile = self.mprofile)
+
+    self.post_validate()
 
   def encode(self):
     self.validate_caps()

--- a/lib/gstreamer/vppbase.py
+++ b/lib/gstreamer/vppbase.py
@@ -16,6 +16,7 @@ from ...lib.mixin.vpp import VppMetricMixin
 class BaseVppTest(slash.Test, VppMetricMixin):
   def before(self):
     self.refctx = []
+    self.post_validate = lambda: None
 
   def get_input_formats(self):
     return self.caps.get("ifmts", [])
@@ -126,6 +127,8 @@ class BaseVppTest(slash.Test, VppMetricMixin):
       slash.skip_test("{ifmt} unsupported".format(**vars(self)))
     if self.ohwformat is None:
       slash.skip_test("{ofmt} unsupported".format(**vars(self)))
+
+    self.post_validate()
 
   def vpp(self):
     self.validate_caps()


### PR DESCRIPTION
The post_validate hook can be defined in user config test
case parameters.  This allows user config to do additional
runtime processing on each test case before the test starts
executing command lines.  For example, the post_validate
hook could instruct the case to skip based on various
criteria that can only be evaluated during test runtime
like gpu gen, platform name, etc...

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>