### PR TITLE
gst-va: add vpp scale test

### DIFF
--- a/test/gst-va/vpp/scale.py
+++ b/test/gst-va/vpp/scale.py
@@ -1,0 +1,40 @@
+###
+### Copyright (C) 2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.gstreamer.va.util import *
+from ....lib.gstreamer.va.vpp import VppTest
+
+spec      = load_test_spec("vpp", "scale")
+spec_r2r  = load_test_spec("vpp", "scale", "r2r")
+
+@slash.requires(*platform.have_caps("vpp", "scale"))
+class default(VppTest):
+  def before(self):
+    vars(self).update(
+      caps    = platform.get_caps("vpp", "scale"),
+      vpp_op  = "scale",
+    )
+    super().before()
+
+  def init(self, tspec, case, scale_width, scale_height):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case          = case,
+      scale_width   = scale_width,
+      scale_height  = scale_height,
+    )
+
+  @slash.parametrize(*gen_vpp_scale_parameters(spec))
+  def test(self, case, scale_width, scale_height):
+    self.init(spec, case, scale_width, scale_height)
+    self.vpp()
+
+  @slash.parametrize(*gen_vpp_scale_parameters(spec_r2r))
+  def test_r2r(self, case, scale_width, scale_height):
+    self.init(spec_r2r, case, scale_width, scale_height)
+    vars(self).setdefault("r2r", 5)
+    self.vpp()


### PR DESCRIPTION
gst-va supports vpp scale with vapostproc.  So add it to the tests.