### PR TITLE
test/gst-msdk/encode/av1: add bframes in cbr_lp

### DIFF
--- a/test/gst-msdk/encode/av1.py
+++ b/test/gst-msdk/encode/av1.py
@@ -81,6 +81,7 @@ class cbr_lp(AV1EncoderLPTest):
       tilerows  = tilerows,
       tilecols  = tilecols,
       quality   = quality,
+      bframes   = bframes,
     )
 
   @slash.parametrize(*gen_av1_cbr_lp_parameters(spec))


### PR DESCRIPTION
Class cbr_lp missing bframes. 
Signed-off-by: Li Fan <fan1x.li@intel.com>