### PR TITLE
ffmpeg-qsv: delete b_strategy from cmd-line for quality

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -89,7 +89,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
     if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
-      opts += " -b_strategy 1"
+      if "compare_quality" != self.rcmode:
+        opts += " -b_strategy 1"
 
     opts += " -vframes {frames} -y {osencoded}"
 


### PR DESCRIPTION
delete b_strategy from cmd-line when rcmode is "compare_quality"

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>