### PR TITLE
enable max frame size for ffmpeg avc/hevc enc

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -5,6 +5,7 @@
 ###
 
 import os
+import re
 import slash
 
 from ...lib.common import get_media, timefn, call, exe2os, filepath2os
@@ -86,6 +87,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       opts += " -look_ahead_depth {ladepth}"
     if vars(self).get("vforced_idr", None) is not None:
       opts += " -force_key_frames expr:1 -forced_idr 1"
+    if vars(self).get("maxFrameSize", None) is not None:
+      opts += " -max_frame_size {maxFrameSize}k"
 
     # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
     if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
@@ -221,6 +224,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       self.check_metrics()
       self.check_level()
       self.check_forced_idr()
+      self.check_max_frame_size()
 
   def check_output(self):
     pass
@@ -239,7 +243,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       # acceptable bitrate within 10% of bitrate
       assert(bitrate_gap <= 0.10)
 
-    elif "vbr" == self.rcmode:
+    elif "vbr" == self.rcmode and vars(self).get("maxFrameSize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
       assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
 
@@ -289,3 +293,14 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       " -vframes {frames} -bsf:v trace_headers"
       " -f null - 2>&1 | grep 'nal_unit_type.*{judge}' | wc -l".format(**vars(self)))
     assert str(self.frames) == output.strip(), "It appears that the forced_idr did not work"
+
+  def check_max_frame_size(self):
+    if vars(self).get("maxFrameSize", None) is None:
+      return
+
+    output = call(
+      f"{exe2os('ffprobe')}"
+      " -i {osencoded} -show_frames | grep pkt_size".format(**vars(self)))
+    frameSizes = re.findall(r'(?<=pkt_size=).[0-9]*', output)
+    for frameSize in frameSizes:
+      assert (self.maxFrameSize * 1000) >= int(frameSize), "It appears that the max_frame_size did not work"

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -468,11 +468,32 @@ def gen_vpp_sharpen_parameters(spec):
   params = gen_vpp_sharpen_variants(spec)
   return keys, params
 
+def gen_avc_max_frame_size_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("variants", dict()).get("max_frame_size", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      bitrate_max_frame_size = variant["bitrate_max_frame_size"]
+      bitrate = bitrate_max_frame_size[0]
+      maxFrameSize = bitrate_max_frame_size[1]
+      variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, bitrate, variant["maxrate"],
+          variant["fps"], maxFrameSize, profile
+        ]
+
+def gen_avc_max_frame_size_parameters(spec, profiles):
+  keys = ("case", "bitrate", "maxrate", "fps", "maxFrameSize", "profile")
+  params = gen_avc_max_frame_size_variants(spec, profiles)
+  return keys, params
+
 gen_vpp_denoise_parameters = gen_vpp_sharpen_parameters
 gen_vpp_brightness_parameters = gen_vpp_sharpen_parameters
 gen_vpp_contrast_parameters = gen_vpp_sharpen_parameters
 gen_vpp_hue_parameters = gen_vpp_sharpen_parameters
 gen_vpp_saturation_parameters = gen_vpp_sharpen_parameters
+gen_hevc_max_frame_size_parameters = gen_avc_max_frame_size_parameters
 
 def gen_vpp_deinterlace_variants(spec, default_modes):
   for case, params in spec.items():
@@ -581,3 +602,4 @@ def gen_vpp_crop_parameters(spec):
   keys = ("case", "left", "right", "top", "bottom")
   params = gen_vpp_crop_variants(spec)
   return keys, params
+

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -240,3 +240,22 @@ class forced_idr(AVCEncoderTest):
   def test(self, case, rcmode, bitrate, maxrate, qp, quality, profile):
     self.init(spec, case, rcmode, bitrate, maxrate, qp, quality, profile)
     self.encode()
+
+class max_frame_size(AVCEncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxFrameSize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode       = "vbr",
+      bitrate      = bitrate,
+      case         = case,
+      maxrate      = maxrate,
+      fps          = fps,
+      minrate      = bitrate,
+      profile      = profile,
+      maxFrameSize = maxFrameSize,
+    )
+
+  @slash.parametrize(*gen_avc_max_frame_size_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, bitrate, maxrate, fps, maxFrameSize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxFrameSize, profile)
+    self.encode()

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -221,3 +221,23 @@ class forced_idr(HEVC8EncoderTest):
   def test(self, case, rcmode, bitrate, maxrate, qp, quality, profile):
     self.init(spec, case, rcmode, bitrate, maxrate, qp, quality, profile)
     self.encode()
+
+class max_frame_size(HEVC8EncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxFrameSize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode       = "vbr",
+      bitrate      = bitrate,
+      case         = case,
+      maxrate      = maxrate,
+      fps          = fps,
+      minrate      = bitrate,
+      profile      = profile,
+      maxFrameSize = maxFrameSize,            
+    )
+
+  @slash.parametrize(*gen_hevc_max_frame_size_parameters(spec, ['main']))
+  def test(self, case, bitrate, maxrate, fps, maxFrameSize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxFrameSize, profile)
+    self.encode()
+


### PR DESCRIPTION
lib/parameters: add function for max_frame_size
ffmpeg-qsv: add max_frame_size for avc/hevc enc

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>