### PR TITLE
fmpeg-qsv: remove b_strategy from cmd-line for quality

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -69,7 +69,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     if vars(self).get("minrate", None) is not None:
       opts += " -b:v {minrate}k"
     if vars(self).get("maxrate", None) is not None:
-      opts += " -maxrate {maxrate}k"
+      if "vbr_default" != self.rcmode:
+        opts += " -maxrate {maxrate}k"
     if vars(self).get("refs", None) is not None:
       opts += " -refs {refs}"
     if vars(self).get("lowpower", None) is not None:
@@ -89,7 +90,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
     if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
-      opts += " -b_strategy 1"
+      if vars(self).get("default", None) is None:
+        opts += " -b_strategy 1"
 
     opts += " -vframes {frames} -y {osencoded}"
 


### PR DESCRIPTION
remove b_strategy from cmd-line for ffmpeg-qsv vbr_default

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>