### PR TITLE
Some fixups for intra refresh tests

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -135,6 +135,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       name += "-{vforced_idr}"
     if vars(self).get("level", None) is not None:
       name += "-{level}"
+    if vars(self).get("intref", None) is not None:
+      name += "-intref-{intref[type]}-{intref[size]}-{intref[dist]}"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"
 

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -51,3 +51,14 @@ class EncoderTest(BaseEncoderTest):
     if vars(self).get("profile", None) in ["main10sp"]:
       m = re.search(r"Main10sp.*: enable", self.output, re.MULTILINE)
       assert m is not None, "It appears that main10sp did not get enabled"
+
+    if vars(self).get("intref", None) is not None:
+      patterns = [
+        f"IntRefType: {self.intref['type']};",
+        f"IntRefCycleSize: {self.intref['size']};",
+        f"IntRefCycleDist: {self.intref['dist']}",
+      ]
+
+      for pattern in patterns:
+        m = re.search(pattern, self.output, re.MULTILINE)
+        assert m is not None, f"'{pattern}' missing in output"

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -238,7 +238,7 @@ class intref_lp(HEVC8EncoderLPTest):
       intref     = dict(type = reftype, size = refsize, dist = refdist),
     )
 
-  @slash.parametrize(*gen_hevc_intref_lp_parameters(spec, ['high', 'main', 'baseline']))
+  @slash.parametrize(*gen_hevc_intref_lp_parameters(spec, ['main']))
   def test(self, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist):
     self.init(spec, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist)
     self.encode()


### PR DESCRIPTION
1. Fix default profiles in hevce
2. Validate/check for intra refresh command output messages
3. Ensure intref params are reflected in the name to minimize duplicate with other test case artifact names.