### PR TITLE
caps: remove ayuv from enc/jpeg

### DIFF
--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -40,7 +40,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "AYUV"],

--- a/lib/caps/APL/iHD
+++ b/lib/caps/APL/iHD
@@ -26,7 +26,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/CFL/iHD
+++ b/lib/caps/CFL/iHD
@@ -31,7 +31,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/CML/iHD
+++ b/lib/caps/CML/iHD
@@ -31,7 +31,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -44,7 +44,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "AYUV"],

--- a/lib/caps/EHL/iHD
+++ b/lib/caps/EHL/iHD
@@ -23,7 +23,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/caps/GLK/iHD
+++ b/lib/caps/GLK/iHD
@@ -29,7 +29,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/ICL/iHD
+++ b/lib/caps/ICL/iHD
@@ -30,7 +30,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/caps/JSL/iHD
+++ b/lib/caps/JSL/iHD
@@ -23,7 +23,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),

--- a/lib/caps/KBL/iHD
+++ b/lib/caps/KBL/iHD
@@ -32,7 +32,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -44,7 +44,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "AYUV"],

--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -44,7 +44,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "AYUV"],

--- a/lib/caps/SKL/iHD
+++ b/lib/caps/SKL/iHD
@@ -25,7 +25,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -45,7 +45,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12", "AYUV"],

--- a/lib/caps/WHL/iHD
+++ b/lib/caps/WHL/iHD
@@ -30,7 +30,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], cbr = False, vbr = False),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY", "AYUV", "Y800"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation


### PR DESCRIPTION
Media driver does not support jpeg/ayuv anymore.
Signed-off-by: Li Fan <fan1x.li@intel.com>