### PR TITLE
ffmpeg-qsv/gst-msdk: enable max frame size testing

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -5,6 +5,7 @@
 ###
 
 import os
+import re
 import slash
 
 from ...lib.common import get_media, timefn, call, exe2os, filepath2os
@@ -90,6 +91,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       opts += " -int_ref_type {intref[type]}"
       opts += " -int_ref_cycle_size {intref[size]}"
       opts += " -int_ref_cycle_dist {intref[dist]}"
+    if vars(self).get("maxframesize", None) is not None:
+      opts += " -max_frame_size {maxframesize}k"
 
     # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
     if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
@@ -227,6 +230,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       self.check_metrics()
       self.check_level()
       self.check_forced_idr()
+      self.check_max_frame_size()
 
   def check_output(self):
     pass
@@ -245,7 +249,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       # acceptable bitrate within 10% of bitrate
       assert(bitrate_gap <= 0.10)
 
-    elif "vbr" == self.rcmode:
+    elif "vbr" == self.rcmode and vars(self).get("maxframesize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
       assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
 
@@ -295,3 +299,14 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       " -vframes {frames} -bsf:v trace_headers"
       " -f null - 2>&1 | grep 'nal_unit_type.*{judge}' | wc -l".format(**vars(self)))
     assert str(self.frames) == output.strip(), "It appears that the forced_idr did not work"
+
+  def check_max_frame_size(self):
+    if vars(self).get("maxframesize", None) is None:
+      return
+
+    output = call(
+      f"{exe2os('ffprobe')}"
+      " -i {osencoded} -show_frames | grep pkt_size".format(**vars(self)))
+    frameSizes = re.findall(r'(?<=pkt_size=).[0-9]*', output)
+    for frameSize in frameSizes:
+      assert (self.maxframesize * 1000) >= int(frameSize), "It appears that the max_frame_size did not work"

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -5,9 +5,10 @@
 ###
 
 import os
+import re
 import slash
 
-from ...lib.common import timefn, get_media, call
+from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.gstreamer.util import have_gst, have_gst_element
 from ...lib.gstreamer.decoderbase import Decoder
 from ...lib.metrics import md5, calculate_psnr
@@ -176,6 +177,7 @@ class BaseEncoderTest(slash.Test):
     else:
       self.check_bitrate()
       self.check_metrics()
+      self.check_max_frame_size()
 
   def check_metrics(self):
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
@@ -207,9 +209,22 @@ class BaseEncoderTest(slash.Test):
       # acceptable bitrate within 10% of bitrate
       assert(bitrate_gap <= 0.10)
 
-    elif self.rcmode in ["vbr", "la_vbr"]:
+    elif self.rcmode in ["vbr", "la_vbr"] and vars(self).get("maxframesize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
       assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
+
+  def check_max_frame_size(self):
+    if vars(self).get("maxframesize", None) is None:
+      return
+
+    output = call(
+      f"{exe2os('gst-launch-1.0')}"
+      " -vf filesrc location={encoder.encoded} !"
+      " {gstparser} ! {gstmediatype},alignment=\\(string\\)au !"
+      " identity silent=false ! fakesink".format(**vars(self)))
+    frameSizes = re.findall(r'(?<=identity0:sink\) \().[0-9]*', output)
+    for frameSize in frameSizes:
+      assert (self.maxframesize * 1000) >= int(frameSize), "It appears that the max_frame_size did not work"
 
   def md5_demuxed(self):
     # gstreamer muxers write timestamps to container header and will be

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -63,12 +63,13 @@ class Encoder(GstEncoder):
   ladepth = property(lambda s: s.ifprop("ladepth", " rc-lookahead={ladepth}"))
   tilecols = property(lambda s: s.ifprop("tilecols", " num-tile-cols={tilecols}"))
   tilerows = property(lambda s: s.ifprop("tilerows", " num-tile-rows={tilerows}"))
+  maxframesize = property(lambda s: s.ifprop("maxframesize", " max-frame-size={maxframesize}"))
 
   @property
   def gstencoder(self):
     return (
       f"{super().gstencoder}"
-      f"{self.rcmode}{self.gop}{self.qp}"
+      f"{self.rcmode}{self.gop}{self.qp}{self.maxframesize}"
       f"{self.quality}{self.slices}{self.tilecols}{self.tilerows}{self.bframes}"
       f"{self.maxrate}{self.minrate}{self.refmode}"
       f"{self.refs}{self.lowpower}{self.ladepth}"

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -279,6 +279,26 @@ def gen_avc_intref_lp_parameters(spec, profiles):
   params = gen_avc_intref_lp_variants(spec, profiles)
   return keys, params
 
+def gen_avc_max_frame_size_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("variants", dict()).get("max_frame_size", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      bitrate_max_frame_size = variant["bitrate_max_frame_size"]
+      bitrate = bitrate_max_frame_size[0]
+      maxframesize = bitrate_max_frame_size[1]
+      variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, bitrate, variant["maxrate"],
+          variant["fps"], maxframesize, profile
+        ]
+
+def gen_avc_max_frame_size_parameters(spec, profiles):
+  keys = ("case", "bitrate", "maxrate", "fps", "maxframesize", "profile")
+  params = gen_avc_max_frame_size_variants(spec, profiles)
+  return keys, params
+
 gen_hevc_cqp_parameters = gen_avc_cqp_parameters
 gen_hevc_cbr_parameters = gen_avc_cbr_parameters
 gen_hevc_vbr_parameters = gen_avc_vbr_parameters
@@ -287,6 +307,7 @@ gen_hevc_cbr_lp_parameters = gen_avc_cbr_lp_parameters
 gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
 gen_hevc_forced_idr_parameters = gen_avc_forced_idr_parameters
 gen_hevc_intref_lp_parameters = gen_avc_intref_lp_parameters
+gen_hevc_max_frame_size_parameters = gen_avc_max_frame_size_parameters
 
 def gen_mpeg2_cqp_variants(spec):
   for case, params in spec.items():

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -282,3 +282,22 @@ class intref_lp(AVCEncoderLPTest):
   def test(self, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist):
     self.init(spec, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist)
     self.encode()
+
+class max_frame_size(AVCEncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxframesize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode       = "vbr",
+      bitrate      = bitrate,
+      case         = case,
+      maxrate      = maxrate,
+      fps          = fps,
+      minrate      = bitrate,
+      profile      = profile,
+      maxframesize = maxframesize,
+    )
+
+  @slash.parametrize(*gen_avc_max_frame_size_parameters(spec, ['high', 'main', 'baseline']))
+  def test(self, case, bitrate, maxrate, fps, maxframesize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxframesize, profile)
+    self.encode()

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -242,3 +242,22 @@ class intref_lp(HEVC8EncoderLPTest):
   def test(self, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist):
     self.init(spec, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode, reftype, refsize, refdist)
     self.encode()
+
+class max_frame_size(HEVC8EncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxframesize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode       = "vbr",
+      bitrate      = bitrate,
+      case         = case,
+      maxrate      = maxrate,
+      fps          = fps,
+      minrate      = bitrate,
+      profile      = profile,
+      maxframesize = maxframesize,            
+    )
+
+  @slash.parametrize(*gen_hevc_max_frame_size_parameters(spec, ['main']))
+  def test(self, case, bitrate, maxrate, fps, maxframesize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxframesize, profile)
+    self.encode()

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -234,3 +234,22 @@ class vbr_la(AVCEncoderTest):
     self.init(spec_r2r, case, bframes, bitrate, fps, quality, refs, profile, ladepth)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class max_frame_size(AVCEncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxframesize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode       = "vbr",
+      bitrate      = bitrate,
+      case         = case,
+      maxrate      = maxrate,
+      fps          = fps,
+      minrate      = bitrate,
+      profile      = profile,
+      maxframesize = maxframesize,
+    )
+
+  @slash.parametrize(*gen_avc_max_frame_size_parameters(spec, ['main', 'high', 'constrained-baseline']))
+  def test(self, case, bitrate, maxrate, fps, maxframesize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxframesize, profile)
+    self.encode()

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -205,3 +205,23 @@ class vbr_lp(HEVC8EncoderLPTest):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class max_frame_size(HEVC8EncoderTest):
+  def init(self, tspec, case, bitrate, maxrate, fps, maxframesize, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      # target percentage 50%
+      maxrate = bitrate * 2,
+      minrate = bitrate,
+      profile = profile,
+      rcmode  = "vbr",
+      maxframesize = maxframesize,
+    )
+
+  @slash.parametrize(*gen_avc_max_frame_size_parameters(spec, ['main', 'high', 'constrained-baseline']))
+  def test(self, case, bitrate, maxrate, fps, maxframesize, profile):
+    self.init(spec, case, bitrate, maxrate, fps, maxframesize, profile)
+    self.encode()


### PR DESCRIPTION
lib/parameters: added functions for max_frame_size
ffmpeg-qsv: added max_frame_size for avc/hevc enc
gst-msdk: added max_frame_size for avc/hevc enc

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>