### PR TITLE
lib/platform: replace distro.linux_distribution

### DIFF
--- a/lib/platform.py
+++ b/lib/platform.py
@@ -120,7 +120,8 @@ def load_capsinfo():
 def info():
   import platform
   try:
-    from distro import linux_distribution as linux_dist
+    import distro
+    linux_dist = lambda: (distro.name(), distro.version(), distro.os_release_attr('release_codename'))
   except:
     try:
       from platform import dist as linux_dist


### PR DESCRIPTION
distro.linux_distribution is deprecated from python3.8
now replace this function

Signed-off-by: Bin Wu <bin1.wu@intel.com>