### PR TITLE
gst-va: fix lowpower encode tests

### DIFF
--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -54,6 +54,15 @@ class Encoder(GstEncoder):
       return f" target-percentage={int(tp * 100)}"
     return ""
 
+  @property # overrides base
+  def lowpower(self):
+    # gst-va implements lowpower as a separate element instead of using a gst property
+    if self.props.get('lowpower', False):
+      assert super().gstencoder.endswith("lpenc")
+    else:
+      assert not super().gstencoder.endswith("lpenc")
+    return ""
+
   gop     = property(lambda s: s.ifprop("gop", " key-int-max={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " b-frames={bframes}"))
@@ -70,7 +79,7 @@ class Encoder(GstEncoder):
       f"{self.rcmode}{self.gop}{self.qp}"
       f"{self.quality}{self.slices}{self.bframes}"
       f"{self.minrate}{self.maxrate}{self.refmode}{self.refs}"
-      #f"{self.lowpower}{self.loopshp}{self.looplvl}", gst-va not support lowpoer and vp8/vp9 enc
+      f"{self.lowpower}{self.loopshp}{self.looplvl}"
     )
 
 @slash.requires(*have_gst_element("va"))

--- a/test/gst-va/encode/avc.py
+++ b/test/gst-va/encode/avc.py
@@ -11,14 +11,12 @@ from ....lib.gstreamer.va.encoder import EncoderTest
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
 
-@slash.requires(*have_gst_element("vah264enc"))
 @slash.requires(*have_gst_element("vah264dec"))
 class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
       codec         = "avc",
-      gstencoder    = "vah264enc",
       gstdecoder    = "vah264dec",
       gstmediatype  = "video/x-h264",
       gstparser     = "h264parse",
@@ -27,21 +25,25 @@ class AVCEncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "h264"
 
+@slash.requires(*have_gst_element("vah264enc"))
 @slash.requires(*platform.have_caps("encode", "avc"))
 class AVCEncoderTest(AVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
       caps      = platform.get_caps("encode", "avc"),
+      gstencoder= "vah264enc",
       lowpower  = False,
     )
 
+@slash.requires(*have_gst_element("vah264lpenc"))
 @slash.requires(*platform.have_caps("vdenc", "avc"))
 class AVCEncoderLPTest(AVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
       caps      = platform.get_caps("vdenc", "avc"),
+      gstencoder= "vah264lpenc",
       lowpower  = True,
     )
 


### PR DESCRIPTION
The gst-va lowpower encode cases were not actually doing
lowpower encode!

Properly setup gst-va lp tests to ensure we are calling
the lpenc variant of the encoder elements.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>