### PR TITLE
vah265enc:add hevc-8 and modify bitrate for gst-va

### DIFF
--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -48,7 +48,7 @@ class Encoder(GstEncoder):
     return self.ifprop("quality", inner)
 
   @property
-  def minrate(self):
+  def maxrate(self):
     if super().rcmode in ["vbr"]:
       tp = self.props["minrate"] / self.props["maxrate"]
       return f" target-percentage={int(tp * 100)}"
@@ -57,7 +57,7 @@ class Encoder(GstEncoder):
   gop     = property(lambda s: s.ifprop("gop", " key-int-max={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " b-frames={bframes}"))
-  maxrate = property(lambda s: s.ifprop("maxrate", " bitrate={maxrate}"))
+  minrate = property(lambda s: s.ifprop("minrate", " bitrate={minrate}"))
   refmode = property(lambda s: s.ifprop("refmode", " ref-pic-mode={refmode}"))
   refs    = property(lambda s: s.ifprop("refs", " ref-frames={refs}"))
   loopshp = property(lambda s: s.ifprop("loopshp", " sharpness-level={loopshp}"))

--- a/lib/gstreamer/va/util.py
+++ b/lib/gstreamer/va/util.py
@@ -72,6 +72,13 @@ def mapprofile(codec, profile):
       "multiview-high"        : "multiview-high",
       "stereo-high"           : "stereo-high",
     },
+    "hevc-8"   : {
+      "main"                  : "main",
+      "main-10"               : "main-10",
+      "main-12"               : "main-12",
+      "main-422-10"           : "main-422-10",
+      "main-422-12"           : "main-422-12",
+    },
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):


### PR DESCRIPTION
1. add hevc-8 into mapprofile.
2. change the value of bitrate from maxrate to minrate.

Signed-off-by: Xu Yefeng <yefengx.xu@intel.com>