### PR TITLE
ffmpeg-qsv/ffmpeg-vaapi: encode split hwupload and hwdownload

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -42,9 +42,11 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     return opts
 
   def gen_output_opts(self):
-    opts = "-vf 'format={hwformat},hwupload"
-    if vars(self).get("hwframes", None) is not None:
-      opts += "=extra_hw_frames={hwframes}"
+    opts = "-vf 'format={hwformat}"
+    if vars(self).get("hwupload", False):
+      opts += ",hwupload"
+      if vars(self).get("hwframes", None) is not None:
+        opts += "=extra_hw_frames={hwframes}"
     opts += "' -an -c:v {ffencoder}"
 
     if vars(self).get("profile", None) is not None:
@@ -263,7 +265,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
     self.decoded = get_media()._test_artifact("{}.yuv".format(name))
     oopts = (
-      "-vf 'hwdownload,format={hwformat}' -pix_fmt {mformat} -f rawvideo"
+      f"-vf '{'hwdownload,' if vars(self).get('hwdownload', False) else ''}"
+      "format={hwformat}' -pix_fmt {mformat} -f rawvideo"
       " -vsync passthrough -vframes {frames}"
       f" -y {filepath2os(self.decoded)}")
     self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -16,6 +16,8 @@ class EncoderTest(BaseEncoderTest):
   def before(self):
     super().before()
     self.hwaccel = "vaapi"
+    self.hwupload = True
+    self.hwdownload = True
 
   def get_vaapi_profile(self):
     raise NotImplementedError


### PR DESCRIPTION
QSV: remove hwupload/hwdownload direct to use system memory
VAAPI: still need keep hwupload/hwdownload function

Signed-off-by: Bin Wu <bin1.wu@intel.com>