### PR TITLE
caps: skip main10sp cases on SG1

### DIFF
--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -39,7 +39,7 @@ caps = dict(
     hevc_10 = dict(
       maxres = res8k ,
       fmts = ["P010", "Y410"],
-      features  = dict(msp = True)
+      features  = dict(msp = False)
     ),
   ),
   vdenc   = dict(


### PR DESCRIPTION
SG1 is not a VPL GPU and libmfx-gen.so doesn't support main10sp, so we should skip main10sp test cases on SG1.

Signed-off-by: Li Fan <fan1x.li@intel.com>