### PR TITLE
lib/ffmpeg: decouple encoder/decoder from test class

### DIFF
--- a/lib/ffmpeg/d3d11/decoder.py
+++ b/lib/ffmpeg/d3d11/decoder.py
@@ -7,14 +7,11 @@
 import slash
 
 from ....lib.common import get_media
-from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest, Decoder as FFDecoder
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 
-@slash.requires(*have_ffmpeg_hwaccel("d3d11va"))
-class DecoderTest(BaseDecoderTest):
-  def before(self):
-    super().before()
-    self.hwaccel = "d3d11va"
+class Decoder(FFDecoder):
+  hwaccel = property(lambda s: "d3d11va")
 
   def get_supported_format_map(self):
     return {
@@ -22,3 +19,7 @@ class DecoderTest(BaseDecoderTest):
       "NV12"  : "nv12",
       "P010"  : "p010le",
     }
+
+@slash.requires(*have_ffmpeg_hwaccel("d3d11va"))
+class DecoderTest(BaseDecoderTest):
+  DecoderClass = Decoder

--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -12,37 +12,58 @@ from ...lib.ffmpeg.util import have_ffmpeg, BaseFormatMapper
 from ...lib.parameters import format_value
 from ...lib.util import skip_test_if_missing_features
 from ...lib.metrics import md5, check_metric
+from ...lib.properties import PropertyHandler
+
+class Decoder(PropertyHandler, BaseFormatMapper):
+  # required properties
+  frames    = property(lambda s: s.props["frames"])
+  format    = property(lambda s: s.map_format(s.props["format"]))
+  hwformat  = property(lambda s: s.map_best_hw_format(s.props["format"], s.props["caps"]["fmts"]))
+  source    = property(lambda s: s.props["source"])
+  ossource  = property(lambda s: filepath2os(s.source))
+  decoded   = property(lambda s: s.props["decoded"])
+  osdecoded = property(lambda s: filepath2os(s.decoded))
+  hwaccel   = property(lambda s: s.props["hwaccel"])
+  hwdevice  = property(lambda s: get_media().render_device)
+
+  # optional properties
+  ffdecoder   = property(lambda s: s.ifprop("ffdecoder", "-c:v {ffdecoder}"))
+
+  @property
+  def scale_range(self):
+    # NOTE: If test has requested scale in/out range, then apply it only when
+    # hw and sw formats differ (i.e. when csc is necessary).
+    if self.hwformat != self.format:
+      return self.ifprop("ffscale_range",
+        "-vf 'scale=in_range={ffscale_range}:out_range={ffscale_range}'")
+    return ""
+
+  @property
+  def hwinit(self):
+    return (
+      f"-hwaccel {self.hwaccel}"
+      f" -init_hw_device {self.hwaccel}=hw:{self.hwdevice}"
+      f" -hwaccel_output_format {self.hwformat}"
+      f" -hwaccel_flags allow_profile_mismatch"
+    )
+
+  @timefn("ffmpeg-decode")
+  def decode(self):
+    return call(
+      f"{exe2os('ffmpeg')} -v verbose {self.hwinit}"
+      f" {self.ffdecoder} -i {self.ossource} {self.scale_range}"
+      f" -c:v rawvideo -pix_fmt {self.format} -fps_mode passthrough"
+      f" -autoscale 0 -vframes {self.frames} -y {self.osdecoded}"
+    )
 
 @slash.requires(have_ffmpeg)
 class BaseDecoderTest(slash.Test, BaseFormatMapper):
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     self.refctx = []
-    self.renderDevice = get_media().render_device
     self.post_validate = lambda: None
-
-  @timefn("ffmpeg")
-  def call_ffmpeg(self):
-    # NOTE: If test has requested scale in/out range, then apply it only when
-    # hw and sw formats differ (i.e. when csc is necessary).
-    scale_range = ""
-    if hasattr(self, "ffscale_range") and self.hwformat != self.mformat:
-      scale_range = f"-vf 'scale=in_range={self.ffscale_range}:out_range={self.ffscale_range}'"
-
-    return call(
-      (
-        f"{exe2os('ffmpeg')} -hwaccel {self.hwaccel}"
-        f" -init_hw_device {self.hwaccel}=hw:{self.renderDevice}"
-        f" -hwaccel_output_format {self.hwformat}"
-        f" -hwaccel_flags allow_profile_mismatch -v verbose"
-      ) + (
-        " -c:v {ffdecoder}" if hasattr(self, "ffdecoder") else ""
-      ).format(**vars(self)) + (
-        f" -i {filepath2os(self.source)} {scale_range}"
-        f" -pix_fmt {self.mformat} -f rawvideo -vsync passthrough -autoscale 0"
-        f" -vframes {self.frames} -y {filepath2os(self.decoded)}"
-      )
-    )
 
   def gen_name(self):
     name = "{case}_{width}x{height}_{format}"
@@ -51,11 +72,10 @@ class BaseDecoderTest(slash.Test, BaseFormatMapper):
     return name
 
   def validate_caps(self):
-    self.hwformat = self.map_best_hw_format(self.format, self.caps["fmts"])
-    self.mformat = self.map_format(self.format)
+    self.decoder = self.DecoderClass(**vars(self))
 
-    if None in [self.hwformat, self.mformat]:
-      slash.skip_test("{format} format not supported".format(**vars(self)))
+    if None in [self.decoder.hwformat, self.decoder.format]:
+      slash.skip_test(f"{self.format} format not supported")
 
     maxw, maxh = self.caps["maxres"]
     if self.width > maxw or self.height > maxh:
@@ -73,22 +93,23 @@ class BaseDecoderTest(slash.Test, BaseFormatMapper):
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
     name = self.gen_name().format(**vars(self))
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    self.output = self.call_ffmpeg()
+    self.decoder.update(decoded = get_media()._test_artifact(f"{name}.yuv"))
+    self.output = self.decoder.decode()
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.decoded)
+      md5ref = md5(self.decoder.decoded)
       get_media()._set_test_details(md5_ref = md5ref)
       for i in range(1, self.r2r):
-        self.decoded = get_media()._test_artifact("{}_{}.yuv".format(name, i))
-        self.call_ffmpeg()
-        result = md5(self.decoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i) : result})
+        self.decoder.update(decoded = get_media()._test_artifact(f"{name}_{i}.yuv"))
+        self.decoder.decode()
+        result = md5(self.decoder.decoded)
+        get_media()._set_test_details(**{f"md5_{i:03}" : result})
         assert result == md5ref, "r2r md5 mismatch"
         # delete decoded file after each iteration
-        get_media()._purge_test_artifact(self.decoded)
+        get_media()._purge_test_artifact(self.decoder.decoded)
     else:
+      self.decoded = self.decoder.decoded
       self.check_output()
       self.check_metrics()
 

--- a/lib/ffmpeg/dxva2/decoder.py
+++ b/lib/ffmpeg/dxva2/decoder.py
@@ -7,14 +7,11 @@
 import slash
 
 from ....lib.common import get_media
-from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest, Decoder as FFDecoder
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 
-@slash.requires(*have_ffmpeg_hwaccel("dxva2"))
-class DecoderTest(BaseDecoderTest):
-  def before(self):
-    super().before()
-    self.hwaccel = "dxva2"
+class Decoder(FFDecoder):
+  hwaccel = property(lambda s: "dxva2")
 
   def get_supported_format_map(self):
     return {
@@ -22,3 +19,7 @@ class DecoderTest(BaseDecoderTest):
       "NV12"  : "nv12",
       "P010"  : "p010le",
     }
+
+@slash.requires(*have_ffmpeg_hwaccel("dxva2"))
+class DecoderTest(BaseDecoderTest):
+  DecoderClass = Decoder

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -10,99 +10,120 @@ import slash
 
 from ...lib.common import get_media, timefn, call, exe2os, filepath2os
 from ...lib.ffmpeg.util import have_ffmpeg, BaseFormatMapper
-from ...lib.parameters import format_value
-from ...lib.util import skip_test_if_missing_features
+from ...lib.ffmpeg.decoderbase import Decoder
 from ...lib.metrics import md5, calculate_psnr
+from ...lib.parameters import format_value
+from ...lib.properties import PropertyHandler
+from ...lib.util import skip_test_if_missing_features
+
+class Encoder(PropertyHandler, BaseFormatMapper):
+  # required properties
+  ffencoder     = property(lambda s: s.props["ffencoder"])
+  codec         = property(lambda s: s.props["codec"])
+  frames        = property(lambda s: s.props["frames"])
+  format        = property(lambda s: s.map_format(s.props["format"]))
+  hwaccel       = property(lambda s: s.props["hwaccel"])
+  hwdevice      = property(lambda s: get_media().render_device)
+  source        = property(lambda s: s.props["source"])
+  ossource      = property(lambda s: filepath2os(s.source))
+  width         = property(lambda s: s.props["width"])
+  height        = property(lambda s: s.props["height"])
+  rcmode        = property(lambda s: f" -rc_mode {s.props['rcmode'].upper()}")
+  encoded       = property(lambda s: s.props["encoded"])
+  osencoded     = property(lambda s: filepath2os(s.encoded))
+
+  @property
+  def hwformat(self):
+    # BUG: It appears there's a ffmpeg bug with yuv420p hwupload when using
+    # i965 driver.  Need to report upstream ffmpeg!
+    ifmts = self.props["caps"]["fmts"]
+    if "i965" == get_media()._get_driver_name():
+      ifmts = list(set(ifmts) - set(["I420"]))
+    return self.map_best_hw_format(self.props["format"], ifmts)
+
+  # optional properties
+  fps           = property(lambda s: s.ifprop("fps", " -r:v {fps}"))
+  profile       = property(lambda s: s.ifprop("profile", " -profile:v {profile}"))
+  gop           = property(lambda s: s.ifprop("gop", " -g {gop}"))
+  extbrc        = property(lambda s: s.ifprop("extbrc", " -extbrc {extbrc}"))
+  slices        = property(lambda s: s.ifprop("slices", " -slices {slices}"))
+  tilecols      = property(lambda s: s.ifprop("tilecols", " -tile_cols {tilecols}"))
+  tilerows      = property(lambda s: s.ifprop("tilerows", " -tile_rows {tilerows}"))
+  bframes       = property(lambda s: s.ifprop("bframes", " -bf {bframes}"))
+  minrate       = property(lambda s: s.ifprop("minrate", " -b:v {minrate}k"))
+  maxrate       = property(lambda s: s.ifprop("maxrate", " -maxrate {maxrate}k"))
+  refs          = property(lambda s: s.ifprop("refs", " -refs {refs}"))
+  lowpower      = property(lambda s: s.ifprop("lowpower", " -low_power {lowpower}"))
+  loopshp       = property(lambda s: s.ifprop("loopshp", " -loop_filter_sharpness {loopshp}"))
+  looplvl       = property(lambda s: s.ifprop("looplvl", " -loop_filter_level {looplvl}"))
+  level         = property(lambda s: s.ifprop("level", " -level {level}"))
+  ladepth       = property(lambda s: s.ifprop("ladepth", " -look_ahead 1 -look_ahead_depth {ladepth}"))
+  forced_idr    = property(lambda s: s.ifprop("vforced_idr", " -forced_idr 1 -force_key_frames expr:1"))
+  maxframesize  = property(lambda s: s.ifprop("maxframesize", " -max_frame_size {maxframesize}k"))
+  pict          = property(lambda s: s.ifprop("vpict", " -pic_timing_sei 0"))
+  hwupload      = property(lambda s: ",hwupload")
+
+  @property
+  def intref(self):
+    def inner(intref):
+      return (
+        f" -int_ref_type {intref['type']}"
+        f" -int_ref_cycle_size {intref['size']}"
+        f" -int_ref_cycle_dist {intref['dist']}"
+      )
+    return self.ifprop("intref", inner)
+
+  @property
+  def bstrategy(self):
+    ## WA: LDB is not enabled by default for HEVCe on gen11+, yet.
+    if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
+      return " -b_strategy 1"
+    return ""
+
+  @property
+  def hwinit(self):
+    return (
+      f"-hwaccel {self.hwaccel}"
+      f" -init_hw_device {self.hwaccel}=hw:{self.hwdevice}"
+      f" -hwaccel_output_format {self.hwaccel}"
+    )
+
+  @property
+  def encparams(self):
+    return (
+      f"{self.profile}{self.rcmode}{self.qp}{self.quality}{self.gop}"
+      f"{self.bframes}{self.slices}{self.minrate}{self.maxrate}{self.refs}"
+      f"{self.extbrc}{self.loopshp}{self.looplvl}{self.tilecols}{self.tilerows}"
+      f"{self.level}{self.ladepth}{self.forced_idr}{self.intref}{self.lowpower}"
+      f"{self.maxframesize}{self.bstrategy}{self.pict}"
+    )
+
+  @timefn("ffmpeg-encode")
+  def encode(self):
+    return call(
+      f"{exe2os('ffmpeg')} -v verbose {self.hwinit}"
+      f" -f rawvideo -pix_fmt {self.format} -s:v {self.width}x{self.height}"
+      f" {self.fps} -i {self.ossource}"
+      f" -vf 'format={self.hwformat}{self.hwupload}'"
+      f" -an -c:v {self.ffencoder} {self.encparams}"
+      f" -vframes {self.frames} -y {self.osencoded}"
+    )
 
 @slash.requires(have_ffmpeg)
 class BaseEncoderTest(slash.Test, BaseFormatMapper):
+  EncoderClass = Encoder
+  DecoderClass = Decoder
+
   def before(self):
     super().before()
     self.refctx = []
-    self.renderDevice = get_media().render_device
     self.post_validate = lambda: None
 
   def map_profile(self):
     raise NotImplementedError
 
-  def gen_qp_opts(self):
-    raise NotImplementedError
-
-  def gen_quality_opts(self):
-    raise NotImplementedError
-
   def get_file_ext(self):
     raise NotImplementedError
-
-  def gen_input_opts(self):
-    opts = "-f rawvideo -pix_fmt {mformat} -s:v {width}x{height}"
-    if vars(self).get("fps", None) is not None:
-      opts += " -r:v {fps}"
-    opts += f" -i {filepath2os(self.source)}"
-    return opts
-
-  def gen_output_opts(self):
-    opts = "-vf 'format={hwformat},hwupload"
-    if vars(self).get("hwframes", None) is not None:
-      opts += "=extra_hw_frames={hwframes}"
-    opts += "' -an -c:v {ffencoder}"
-
-    if vars(self).get("profile", None) is not None:
-      opts += " -profile:v {mprofile}"
-    if vars(self).get("rcmodeu", None) is not None:
-      opts += " -rc_mode {rcmodeu}"
-    if vars(self).get("qp", None) is not None:
-      opts += self.gen_qp_opts()
-    if vars(self).get("quality", None) is not None:
-      opts += self.gen_quality_opts()
-    if vars(self).get("gop", None) is not None:
-      opts += " -g {gop}"
-    if vars(self).get("extbrc", None) is not None:
-      opts += " -extbrc {extbrc}"
-    if vars(self).get("slices", None) is not None:
-      opts += " -slices {slices}"
-    if vars(self).get("tilecols", None) is not None:
-      opts += " -tile_cols {tilecols}"
-    if vars(self).get("tilerows", None) is not None:
-      opts += " -tile_rows {tilerows}"
-    if vars(self).get("bframes", None) is not None:
-      opts += " -bf {bframes}"
-    if vars(self).get("minrate", None) is not None:
-      opts += " -b:v {minrate}k"
-    if vars(self).get("maxrate", None) is not None:
-      opts += " -maxrate {maxrate}k"
-    if vars(self).get("refs", None) is not None:
-      opts += " -refs {refs}"
-    if vars(self).get("lowpower", None) is not None:
-      opts += " -low_power {lowpower}"
-    if vars(self).get("loopshp", None) is not None:
-      opts += " -loop_filter_sharpness {loopshp}"
-    if vars(self).get("looplvl", None) is not None:
-      opts += " -loop_filter_level {looplvl}"
-    if vars(self).get("level", None) is not None:
-      self.level /= 10.0
-      opts += " -level {level}"
-    if vars(self).get("ladepth", None) is not None:
-      opts += " -look_ahead 1"
-      opts += " -look_ahead_depth {ladepth}"
-    if vars(self).get("vforced_idr", None) is not None:
-      opts += " -force_key_frames expr:1 -forced_idr 1"
-    if vars(self).get("intref", None) is not None:
-      opts += " -int_ref_type {intref[type]}"
-      opts += " -int_ref_cycle_size {intref[size]}"
-      opts += " -int_ref_cycle_dist {intref[dist]}"
-    if vars(self).get("maxframesize", None) is not None:
-      opts += " -max_frame_size {maxframesize}k"
-    if vars(self).get("vpict", None) is not None:
-      opts += " -pic_timing_sei 0"
-
-    # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
-    if get_media()._get_gpu_gen() >= 11 and self.codec.startswith("hevc"):
-      opts += " -b_strategy 1"
-
-    opts += " -vframes {frames} -y {osencoded}"
-
-    return opts
 
   def gen_name(self):
     name = "{case}-{rcmode}"
@@ -150,19 +171,24 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     return name
 
   def validate_caps(self):
-    ifmts = self.caps["fmts"]
-
-    ## BUG: It appears there's a ffmpeg bug with yuv420p hwupload when using
-    ## i965 driver.  Need to report upstream ffmpeg!
-    if "i965" == get_media()._get_driver_name():
-      ifmts = list(set(ifmts) - set(["I420"]))
-
-    self.hwformat = self.map_best_hw_format(self.format, ifmts)
-    self.mformat = self.map_format(self.format)
-    if None in [self.hwformat, self.mformat]:
-      slash.skip_test("{format} not supported".format(**vars(self)))
-
     skip_test_if_missing_features(self)
+
+    if vars(self).get("level", None) is not None:
+      self.level /= 10.0
+
+    # FIXME: handle brframes for bitrate rcmodes (see ffmpeg/qsv/encoder.py)
+    # May require rebaseline for other components/elements
+
+    self.encoder = self.EncoderClass(**vars(self))
+    self.decoder = self.DecoderClass(
+      caps      = self.caps,
+      ffdecoder = vars(self).get("ffdecoder", None),
+      frames    = self.frames,
+      format    = self.format,
+    )
+
+    if None in [self.encoder.hwformat, self.encoder.format, self.decoder.hwformat, self.decoder.format]:
+      slash.skip_test("{format} not supported".format(**vars(self)))
 
     maxw, maxh = self.caps["maxres"]
     if self.width > maxw or self.height > maxh:
@@ -184,20 +210,9 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       self.mprofile = self.map_profile()
       if self.mprofile is None:
         slash.skip_test("{profile} profile is not supported".format(**vars(self)))
+      self.encoder.update(profile = self.mprofile)
 
     self.post_validate()
-
-  @timefn("ffmpeg")
-  def call_ffmpeg(self, iopts, oopts):
-    return call(
-      (
-        f"{exe2os('ffmpeg')}"
-        " -hwaccel {hwaccel} -init_hw_device {hwaccel}=hw:{renderDevice}"
-        " -hwaccel_output_format {hwaccel}"
-      ).format(**vars(self)) + (
-        " -v verbose {iopts} {oopts}"
-      ).format(iopts = iopts, oopts = oopts)
-    )
 
   def encode(self):
     self.validate_caps()
@@ -207,27 +222,21 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     name  = self.gen_name().format(**vars(self))
     ext   = self.get_file_ext()
 
-    self.encoded = get_media()._test_artifact("{}.{}".format(name, ext))
-    self.osencoded = filepath2os(self.encoded)
-
-    iopts = self.gen_input_opts()
-    oopts = self.gen_output_opts()
-
-    self.output = self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
+    self.encoder.update(encoded = get_media()._test_artifact(f"{name}.{ext}"))
+    self.output = self.encoder.encode()
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.encoded)
+      md5ref = md5(self.encoder.encoded)
       get_media()._set_test_details(md5_ref = md5ref)
       for i in range(1, self.r2r):
-        self.encoded = get_media()._test_artifact("{}_{}.{}".format(name, i, ext))
-        self.osencoded = filepath2os(self.encoded)
-        self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.encoded)
-        get_media()._set_test_details(**{"md5_{:03}".format(i) : result})
+        self.encoder.update(encoded = get_media()._test_artifact(f"{name}_{i}.{ext}"))
+        self.encoder.encode()
+        result = md5(self.encoder.encoded)
+        get_media()._set_test_details(**{f"md5_{i:03}" : result})
         assert result == md5ref, "r2r md5 mismatch"
         # delete encoded file after each iteration
-        get_media()._purge_test_artifact(self.encoded)
+        get_media()._purge_test_artifact(self.encoder.encoded)
     else:
       self.check_output()
       self.check_bitrate()
@@ -240,7 +249,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     pass
 
   def check_bitrate(self):
-    encsize = os.path.getsize(self.encoded)
+    encsize = os.path.getsize(self.encoder.encoded)
     bitrate_actual = encsize * 8 * vars(self).get("fps", 25) / 1024.0 / self.frames
     get_media()._set_test_details(
       size_encoded = encsize,
@@ -258,23 +267,16 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
 
   def check_metrics(self):
-    iopts = ""
-    if vars(self).get("ffdecoder", None) is not None:
-      iopts += "-c:v {ffdecoder} "
-    iopts += "-i {osencoded}"
-
-
     name = (self.gen_name() + "-{width}x{height}-{format}").format(**vars(self))
-    self.decoded = get_media()._test_artifact("{}.yuv".format(name))
-    oopts = (
-      "-vf 'hwdownload,format={hwformat}' -pix_fmt {mformat} -f rawvideo"
-      " -vsync passthrough -vframes {frames}"
-      f" -y {filepath2os(self.decoded)}")
-    self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
+    self.decoder.update(
+      source  = self.encoder.encoded,
+      decoded = get_media()._test_artifact(f"{name}.yuv"),
+    )
+    self.decoder.decode()
 
     get_media().baseline.check_psnr(
       psnr = calculate_psnr(
-        self.source, self.decoded,
+        self.source, self.decoder.decoded,
         self.width, self.height,
         self.frames, self.format),
       context = self.refctx,
@@ -286,8 +288,9 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     output = call(
       f"{exe2os('ffprobe')}"
-      " -i {osencoded} -v quiet -show_entries stream=level"
-      " -of default=nk=1:nw=1".format(**vars(self)))
+      f" -i {self.encoder.osencoded} -v quiet -show_entries stream=level"
+      f" -of default=nk=1:nw=1"
+    )
     assert float(output)/30 == self.level, "fail to set target level"
 
   def check_forced_idr(self):
@@ -299,9 +302,9 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     output = call(
       f"{exe2os('ffmpeg')}"
-      " -v verbose -i {osencoded} -c:v copy"
-      " -vframes {frames} -bsf:v trace_headers"
-      f" -f null - 2>&1 | grep 'nal_unit_type.*{judge}' | wc -l".format(**vars(self)))
+      f" -v verbose -i {self.encoder.osencoded} -c:v copy -bsf:v trace_headers"
+      f" -f null - 2>&1 | grep 'nal_unit_type.*{judge}' | wc -l"
+    )
     assert str(self.frames) == output.strip(), "It appears that the forced_idr did not work"
 
   def check_max_frame_size(self):
@@ -310,7 +313,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     output = call(
       f"{exe2os('ffprobe')}"
-      " -i {osencoded} -show_frames | grep pkt_size".format(**vars(self)))
+      f" -i {self.encoder.osencoded} -show_frames | grep pkt_size"
+    )
     frameSizes = re.findall(r'(?<=pkt_size=).[0-9]*', output)
     for frameSize in frameSizes:
       assert (self.maxframesize * 1000) >= int(frameSize), "It appears that the max_frame_size did not work"

--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -8,16 +8,17 @@ import re
 import slash
 
 from ....lib.common import get_media
-from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest, Decoder as FFDecoder
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
+
+class Decoder(FFDecoder):
+  hwaccel = property(lambda s: "qsv")
 
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class DecoderTest(BaseDecoderTest):
-  def before(self):
-    super().before()
-    self.hwaccel = "qsv"
+  DecoderClass = Decoder
 
   def check_output(self):
     super().check_output()

--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -7,11 +7,12 @@
 import slash
 
 from ....lib.common import get_media
-from ....lib.ffmpeg.decoderbase import BaseDecoderTest
+from ....lib.ffmpeg.decoderbase import BaseDecoderTest, Decoder as FFDecoder
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
+
+class Decoder(FFDecoder):
+  hwaccel = property(lambda s: "vaapi")
 
 @slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class DecoderTest(BaseDecoderTest):
-  def before(self):
-    super().before()
-    self.hwaccel = "vaapi"
+  DecoderClass = Decoder

--- a/test/ffmpeg-qsv/encode/mpeg2.py
+++ b/test/ffmpeg-qsv/encode/mpeg2.py
@@ -34,7 +34,6 @@ class cqp(MPEG2EncoderTest):
       bframes = bframes,
       case    = case,
       gop     = gop,
-      mqp     = mapRangeInt(qp, [0, 100], [1, 51]),
       qp      = qp,
       quality = quality,
       rcmode  = "cqp",

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -37,7 +37,6 @@ class cqp(MPEG2EncoderTest):
       gop     = gop,
       qp      = qp,
       quality = quality,
-      mqp     = mapRangeInt(qp, [0, 100], [1, 31]),
       rcmode  = "cqp",
     )
 


### PR DESCRIPTION
The encode/decode command line generator code is split into their own classes.  This allows them to be reused easier in different contexts/tests.  It also allows for simpler override for various properties based on plugin component differences.

cc: @wenbinc-Bin