### PR TITLE
gst-va Encode VBR Bitrate fix

### DIFF
--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -48,7 +48,14 @@ class Encoder(GstEncoder):
     return self.ifprop("quality", inner)
 
   @property
-  def minrate(self):
+  def maxrate(self):
+    ## From gstreamer/subprojects/gst-plugins-bad/sys/va/gstvah264enc.c
+    ##
+    ## VBR mode: "rate-control=VBR", then the "bitrate" specify the
+    ## target bit rate, "target-percentage" is used to calculate the
+    ## max bit rate of VBR mode by ("bitrate" * 100) /
+    ## "target-percentage".
+    ##
     if super().rcmode in ["vbr"]:
       tp = self.props["minrate"] / self.props["maxrate"]
       return f" target-percentage={int(tp * 100)}"
@@ -66,7 +73,7 @@ class Encoder(GstEncoder):
   gop     = property(lambda s: s.ifprop("gop", " key-int-max={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
   bframes = property(lambda s: s.ifprop("bframes", " b-frames={bframes}"))
-  maxrate = property(lambda s: s.ifprop("maxrate", " bitrate={maxrate}"))
+  minrate = property(lambda s: s.ifprop("minrate", " bitrate={minrate}"))
   refmode = property(lambda s: s.ifprop("refmode", " ref-pic-mode={refmode}"))
   refs    = property(lambda s: s.ifprop("refs", " ref-frames={refs}"))
   loopshp = property(lambda s: s.ifprop("loopshp", " sharpness-level={loopshp}"))

--- a/test/gst-va/encode/avc.py
+++ b/test/gst-va/encode/avc.py
@@ -158,8 +158,6 @@ class vbr(AVCEncoderTest):
       case      = case,
       fps       = fps,
       gop       = gop,
-      ## target percentage 70% (hard-coded in gst-va)
-      ## gst-va sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate   = int(bitrate / 0.7),
       minrate   = bitrate,
       profile   = profile,
@@ -188,8 +186,6 @@ class vbr_lp(AVCEncoderLPTest):
       case      = case,
       fps       = fps,
       gop       = gop,
-      ## target percentage 70% (hard-coded in gst-va)
-      ## gst-va sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
       maxrate   = int(bitrate / 0.7),
       minrate   = bitrate,
       profile   = profile,


### PR DESCRIPTION
From [gstreamer/subprojects/gst-plugins-bad/sys/va/gstvah264enc.c](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gst-plugins-bad/sys/va/gstvah264enc.c):

VBR mode: "rate-control=VBR", then the "bitrate" specify the
target bit rate, "target-percentage" is used to calculate the
max bit rate of VBR mode by ("bitrate" * 100) /
"target-percentage".

NOTE: this is opposite from gst-vaapi interpretation.