### PR TITLE
Remove vpp/sharpen/yv12 on >= gen12 platform

### DIFF
--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -67,7 +67,7 @@ caps = dict(
     ),
     sharpen     = dict(
       ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -66,8 +66,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -71,7 +71,7 @@ caps = dict(
     ),
     sharpen     = dict(
       ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -70,8 +70,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -71,7 +71,7 @@ caps = dict(
     ),
     sharpen     = dict(
       ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/RKL/iHD
+++ b/lib/caps/RKL/iHD
@@ -70,8 +70,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -71,7 +71,7 @@ caps = dict(
     ),
     sharpen     = dict(
       ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -70,8 +70,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -72,7 +72,7 @@ caps = dict(
     ),
     sharpen     = dict(
       ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -71,8 +71,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12",         "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",         "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(


### PR DESCRIPTION
1. According to media-driver wiki, vpp/sharpen/yv12 input/output format does not support on >= gen12 platform. Remove vpp/sharpen/yv12 output format on >= gen12 platform
2. Remove vpp/sharpen/I420 input/output format on >= gen12 platform