### PR TITLE
ffmpeg/encode: move rc_mode option to vaapi only

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -28,7 +28,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   ossource      = property(lambda s: filepath2os(s.source))
   width         = property(lambda s: s.props["width"])
   height        = property(lambda s: s.props["height"])
-  rcmode        = property(lambda s: f" -rc_mode {s.props['rcmode'].upper()}")
+  rcmode        = property(lambda s: s.props['rcmode'].upper())
   encoded       = property(lambda s: s.props["encoded"])
   osencoded     = property(lambda s: filepath2os(s.encoded))
 
@@ -91,7 +91,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   @property
   def encparams(self):
     return (
-      f"{self.profile}{self.rcmode}{self.qp}{self.quality}{self.gop}"
+      f"{self.profile}{self.qp}{self.quality}{self.gop}"
       f"{self.bframes}{self.slices}{self.minrate}{self.maxrate}{self.refs}"
       f"{self.extbrc}{self.loopshp}{self.looplvl}{self.tilecols}{self.tilerows}"
       f"{self.level}{self.ladepth}{self.forced_idr}{self.intref}{self.lowpower}"

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -17,10 +17,6 @@ class Encoder(FFEncoder):
   hwaccel = property(lambda s: "vaapi")
 
   @property
-  def rcmode(self):
-    return "" if self.codec in ["jpeg"] else super().rcmode
-
-  @property
   def qp(self):
     def inner(qp):
       if self.codec in ["vp8", "vp9"]:
@@ -38,6 +34,12 @@ class Encoder(FFEncoder):
         return " -global_quality {quality}"
       return " -compression_level {quality}"
     return self.ifprop("quality", inner)
+
+  @property
+  def encparams(self):
+    if self.codec not in ["jpeg"]:
+      return f"-rc_mode {self.rcmode}{super().encparams}"
+    return super().encparams
 
 @slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class EncoderTest(BaseEncoderTest):


### PR DESCRIPTION
The -rc_mode command-line option is only valid for
vaapi encode plugins in ffmpeg.

Since...

commit b663377584320edf0dd19e6bdd86afee0f8c6090
Author: U. Artie Eoff <ullysses.a.eoff@intel.com>
Date:   Tue Jul 12 14:50:29 2022 -0400

    lib/ffmpeg: decouple encoder command-line from test class

...the rc_mode option was being added to all ffmpeg plugin
command-lines in ffmpeg/encoderbase.py.

On Linux, invalid options only generate warnings which ffmpeg
will ignore and gracefully proceed.  However, on Windows,
invalid options are treated as errors and ffmpeg aborts.

This fixes it so that the -rc_mode option is only applied
to the ffmpeg/vaapi/encoder.py specialization.

VIZ-17445

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>