### PR TITLE
Set tile parameters respectively on ffmpeg-qsv/vaapi

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -47,8 +47,6 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   gop           = property(lambda s: s.ifprop("gop", " -g {gop}"))
   extbrc        = property(lambda s: s.ifprop("extbrc", " -extbrc {extbrc}"))
   slices        = property(lambda s: s.ifprop("slices", " -slices {slices}"))
-  tilecols      = property(lambda s: s.ifprop("tilecols", " -tile_cols {tilecols}"))
-  tilerows      = property(lambda s: s.ifprop("tilerows", " -tile_rows {tilerows}"))
   bframes       = property(lambda s: s.ifprop("bframes", " -bf {bframes}"))
   minrate       = property(lambda s: s.ifprop("minrate", " -b:v {minrate}k"))
   maxrate       = property(lambda s: s.ifprop("maxrate", " -maxrate {maxrate}k"))

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -15,6 +15,8 @@ from ....lib.common import mapRangeInt
 
 class Encoder(FFEncoder):
   hwaccel = property(lambda s: "qsv")
+  tilecols = property(lambda s: s.ifprop("tilecols", " -tile_cols {tilecols}"))
+  tilerows = property(lambda s: s.ifprop("tilerows", " -tile_rows {tilerows}"))
 
   @property
   def hwupload(self):

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -15,6 +15,8 @@ from ....lib.common import mapRangeInt
 
 class Encoder(FFEncoder):
   hwaccel = property(lambda s: "vaapi")
+  tilecols = property(lambda s: s.ifprop("tilecols", " -tile_cols_log2 {tilecols}"))
+  tilerows = property(lambda s: s.ifprop("tilerows", " -tile_rows_log2 {tilerows}"))
 
   @property
   def rcmode(self):

--- a/test/ffmpeg-qsv/encode/av1.py
+++ b/test/ffmpeg-qsv/encode/av1.py
@@ -69,6 +69,7 @@ class cbr_lp(AV1EncoderLPTest):
       case    = case,
       fps     = fps,
       gop     = gop,
+      bframes = bframes,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,

--- a/test/ffmpeg-vaapi/encode/av1.py
+++ b/test/ffmpeg-vaapi/encode/av1.py
@@ -62,6 +62,7 @@ class cbr_lp(AV1EncoderLPTest):
       case    = case,
       fps     = fps,
       gop     = gop,
+      bframes = bframes,
       maxrate = bitrate,
       minrate = bitrate,
       profile = profile,


### PR DESCRIPTION
1. Add bframes in ffmpeg/encode/av1 cbr_lp 
2. Set tile parameters respectively on ffmpeg-qsv/vaapi


