### PR TITLE
Add ROI cases for ffmpeg-qsv/vaapi encode

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -59,6 +59,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   forced_idr    = property(lambda s: s.ifprop("vforced_idr", " -forced_idr 1 -force_key_frames expr:1"))
   maxframesize  = property(lambda s: s.ifprop("maxframesize", " -max_frame_size {maxframesize}k"))
   pict          = property(lambda s: s.ifprop("vpict", " -pic_timing_sei 0"))
+  roi           = property(lambda s: s.ifprop("vroi", ",addroi=0:0:{width}/2:{height}/2:-1/3"))
   hwupload      = property(lambda s: ",hwupload")
 
   @property
@@ -102,7 +103,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
       f"{exe2os('ffmpeg')} -v verbose {self.hwinit}"
       f" -f rawvideo -pix_fmt {self.format} -s:v {self.width}x{self.height}"
       f" {self.fps} -i {self.ossource}"
-      f" -vf 'format={self.hwformat}{self.hwupload}'"
+      f" -vf 'format={self.hwformat}{self.hwupload}{self.roi}'"
       f" -an -c:v {self.ffencoder} {self.encparams}"
       f" -vframes {self.frames} -y {self.osencoded}"
     )
@@ -163,6 +164,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       name += "-intref-{intref[type]}-{intref[size]}-{intref[dist]}"
     if vars(self).get("vpict", None) is not None:
       name += "-pict-0"
+    if vars(self).get("vroi", None) is not None:
+      name += "-roi"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"
 

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -59,7 +59,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   forced_idr    = property(lambda s: s.ifprop("vforced_idr", " -forced_idr 1 -force_key_frames expr:1"))
   maxframesize  = property(lambda s: s.ifprop("maxframesize", " -max_frame_size {maxframesize}k"))
   pict          = property(lambda s: s.ifprop("vpict", " -pic_timing_sei 0"))
-  roi           = property(lambda s: s.ifprop("vroi", ",addroi=0:0:{width}/2:{height}/2:-1/3"))
+  roi           = property(lambda s: s.ifprop("roi", ",addroi=0:0:{width}/2:{height}/2:-1/3"))
   hwupload      = property(lambda s: ",hwupload")
 
   @property
@@ -164,7 +164,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       name += "-intref-{intref[type]}-{intref[size]}-{intref[dist]}"
     if vars(self).get("vpict", None) is not None:
       name += "-pict-0"
-    if vars(self).get("vroi", None) is not None:
+    if vars(self).get("roi", None) is not None:
       name += "-roi"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -299,6 +299,54 @@ def gen_avc_max_frame_size_parameters(spec, profiles):
   params = gen_avc_max_frame_size_variants(spec, profiles)
   return keys, params
 
+def gen_avc_roi_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("variants", dict()).get("roi", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      gop     = variant.get("gop", None)
+      bframes = variant.get("bframes", None)
+      bitrate = variant.get("bitrate", None)
+      rcmode  = variant["rcmode"]
+      if "cbr" == rcmode:
+        variant.update(maxrate = bitrate)
+      elif "vbr" == rcmode:
+        variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, gop, bframes, bitrate, variant["maxrate"],
+          profile, rcmode,
+        ]
+
+def gen_avc_roi_parameters(spec, profiles):
+  keys = ("case", "gop", "bframes", "bitrate", "maxrate", "profile", "rcmode")
+  params = gen_avc_roi_variants(spec, profiles)
+  return keys, params
+
+def gen_avc_roi_lp_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("variants", dict()).get("roi_lp", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      gop     = variant.get("gop", None)
+      bframes = variant.get("bframes", None)
+      bitrate = variant.get("bitrate", None)
+      rcmode  = variant["rcmode"]
+      if "cbr" == rcmode:
+        variant.update(maxrate = bitrate)
+      elif "vbr" == rcmode:
+        variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, gop, bframes, bitrate, variant["maxrate"],
+          profile, rcmode,
+        ]
+
+def gen_avc_roi_lp_parameters(spec, profiles):
+  keys = ("case", "gop", "bframes", "bitrate", "maxrate", "profile", "rcmode")
+  params = gen_avc_roi_lp_variants(spec, profiles)
+  return keys, params
+
 def gen_hevc_pict_variants(spec, profiles):
   for case, params in spec.items():
     for variant in copy.deepcopy(params.get("variants", dict()).get("pict", [])):
@@ -362,9 +410,11 @@ def gen_hevc_pict_lp_parameters(spec, profiles):
 gen_hevc_cqp_parameters = gen_avc_cqp_parameters
 gen_hevc_cbr_parameters = gen_avc_cbr_parameters
 gen_hevc_vbr_parameters = gen_avc_vbr_parameters
+gen_hevc_roi_parameters = gen_avc_roi_parameters
 gen_hevc_cqp_lp_parameters = gen_avc_cqp_lp_parameters
 gen_hevc_cbr_lp_parameters = gen_avc_cbr_lp_parameters
 gen_hevc_vbr_lp_parameters = gen_avc_vbr_lp_parameters
+gen_hevc_roi_lp_parameters = gen_avc_roi_lp_parameters
 gen_hevc_forced_idr_parameters = gen_avc_forced_idr_parameters
 gen_hevc_intref_lp_parameters = gen_avc_intref_lp_parameters
 gen_hevc_max_frame_size_parameters = gen_avc_max_frame_size_parameters

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -243,3 +243,43 @@ class pict_lp(HEVC10EncoderLPTest):
   def test(self, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode):
     self.init(spec, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode)
     self.encode()
+
+class roi(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main10']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(HEVC10EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -256,7 +256,7 @@ class roi(HEVC10EncoderTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main10']))
@@ -276,7 +276,7 @@ class roi_lp(HEVC10EncoderLPTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main10']))

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -314,7 +314,7 @@ class roi(AVCEncoderTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_avc_roi_parameters(spec, ['main']))
@@ -334,7 +334,7 @@ class roi_lp(AVCEncoderLPTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_avc_roi_lp_parameters(spec, ['main']))

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -301,3 +301,43 @@ class max_frame_size(AVCEncoderTest):
   def test(self, case, bitrate, maxrate, fps, maxframesize, profile):
     self.init(spec, case, bitrate, maxrate, fps, maxframesize, profile)
     self.encode()
+
+class roi(AVCEncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_avc_roi_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(AVCEncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_avc_roi_lp_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -303,3 +303,44 @@ class pict_lp(HEVC8EncoderLPTest):
   def test(self, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode):
     self.init(spec, case, gop, bframes, bitrate, qp, maxrate, profile, rcmode)
     self.encode()
+
+class roi(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(HEVC8EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      vroi      = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -316,7 +316,7 @@ class roi(HEVC8EncoderTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main']))
@@ -336,7 +336,7 @@ class roi_lp(HEVC8EncoderLPTest):
       minrate    = bitrate,
       profile    = profile,
       gop        = gop,
-      vroi      = 1,
+      roi        = 1,
     )
 
   @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main']))

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -205,3 +205,44 @@ class vbr_lp(HEVC10EncoderLPTest):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class roi(HEVC10EncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main10']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(HEVC10EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main10']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -206,3 +206,43 @@ class vbr_lp(AVCEncoderLPTest):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class roi(AVCEncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_avc_roi_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(AVCEncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_avc_roi_lp_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -213,3 +213,43 @@ class vbr_lp(HEVC8EncoderLPTest):
     self.init(spec_r2r, case, gop, slices, bitrate, fps, quality, refs, profile)
     vars(self).setdefault("r2r", 5)
     self.encode()
+
+class roi(HEVC8EncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()
+
+class roi_lp(HEVC8EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      roi        = 1,
+    )
+
+  @slash.parametrize(*gen_hevc_roi_lp_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
+    self.encode()


### PR DESCRIPTION
 1. Add ROI cases for ffmpeg-qsv/vaapi encode avc/hevc.
 2. ROI does not work on cqp, so I didn't add cqp test.

