### PR TITLE
lib/ffmpeg: map AYUV->vuya

### DIFF
--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -57,5 +57,5 @@ class BaseFormatMapper(FormatMapper):
       "Y212"  : "y212",
       "Y410"  : "y410",
       "Y412"  : "y412",
-      "AYUV"  : "0yuv", # 0yuv is same as microsoft AYUV except the alpha channel
+      "AYUV"  : "vuya", # vuya is same as microsoft AYUV except the alpha channel
     }

--- a/lib/framereader.py
+++ b/lib/framereader.py
@@ -123,10 +123,8 @@ def read_frame_AYUV(fd, width, height):
   # For yuv 444 8bit format:
   #   1) on test cases define in vaapi-fits-full/vaapi-fits, we follow to use mircosoft ayuv 
   #   2) on iHD, it uses as ayuv, and follows Mircosoft definition ayuv;
-  #   3) on ffmpeg, it uses as 0yuv, which is same as microsoft AYUV except the alpha channel. 
-  #      Actually FFmpeg doesn't define AYUV pixel format, but it defined AYUV decoder and 
-  #      encoder which follows microsoft AYUV definition
-  #   4) on gstreamer, it use as yuva, it is byte order define; 
+  #   3) on ffmpeg, it uses as vuya, which is same as microsoft AYUV except the alpha channel.
+  #   4) on gstreamer, it use as vuya, it is byte order define;
   #      so we will do map from ayuv->vuya  
   a = ayuv[3::4].reshape((height, width))
   y = ayuv[2::4].reshape((height, width))


### PR DESCRIPTION
Since:
 https://github.com/intel-media-ci/cartwheel-ffmpeg/pull/170
 https://github.com/FFmpeg/FFmpeg/commit/6ab8a9d375ca922b2a94cd7160a4e3c5abe6339c

0yuv is no longer provided.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>