### PR TITLE
Metrics2

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -235,3 +235,15 @@ def filepath2os(file_path):
     return os.sep.join(path[1:])
   else:
     return file_path
+
+class Singleton(type):
+  _instances = {}
+  _lock = threading.RLock()
+  def __call__(cls, *args, **kwargs):
+    try:
+      cls._lock.acquire()
+      if cls not in cls._instances:
+        cls._instances[cls] = super().__call__(*args, **kwargs)
+      return cls._instances[cls]
+    finally:
+      cls._lock.release()

--- a/lib/ffmpeg/transcoderbase.py
+++ b/lib/ffmpeg/transcoderbase.py
@@ -8,8 +8,9 @@ import re
 import slash
 
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
-from ...lib.metrics import calculate_psnr
 from ...lib.ffmpeg.util import have_ffmpeg, ffmpeg_probe_resolution
+
+from ...lib import metrics2
 
 @slash.requires(have_ffmpeg)
 class BaseTranscoderTest(slash.Test):
@@ -217,10 +218,9 @@ class BaseTranscoderTest(slash.Test):
     assert expect == actual
 
   def check_metrics(self, yuv, refctx):
-    get_media().baseline.check_psnr(
-      psnr = calculate_psnr(
-        self.srcyuv, yuv,
-        self.width, self.height,
-        self.frames),
-      context = self.refctx + refctx,
-    )
+    metrics2.check(
+      metric = dict(type = "psnr"),
+      filetrue = self.srcyuv, filetest = yuv,
+      width = self.width, height = self.height,
+      frames = self.frames, format = "I420",
+      refctx = self.refctx + refctx)

--- a/lib/ffmpeg/vppbase.py
+++ b/lib/ffmpeg/vppbase.py
@@ -8,8 +8,9 @@ import slash
 
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.ffmpeg.util import have_ffmpeg, BaseFormatMapper
-from ...lib.metrics import md5
 from ...lib.mixin.vpp import VppMetricMixin
+
+from ...lib import metrics2
 
 @slash.requires(have_ffmpeg)
 class BaseVppTest(slash.Test, BaseFormatMapper, VppMetricMixin):
@@ -123,16 +124,22 @@ class BaseVppTest(slash.Test, BaseFormatMapper, VppMetricMixin):
 
     if vars(self).get("r2r", None) is not None:
       assert type(self.r2r) is int and self.r2r > 1, "invalid r2r value"
-      md5ref = md5(self.decoded)
-      get_media()._set_test_details(md5_ref = md5ref)
+
+      metric = metrics2.factory.create(metric = dict(type = "md5", numbytes = -1))
+      metric.update(filetest = self.decoded)
+      metric.expect = metric.actual # the first run is our reference for r2r
+      metric.check()
+
+      get_media()._purge_test_artifact(self.decoded)
 
       for i in range(1, self.r2r):
         self.decoded = get_media()._test_artifact(f"{name}_{i}.yuv")
         self.osdecoded = filepath2os(self.decoded)
         self.call_ffmpeg(iopts.format(**vars(self)), oopts.format(**vars(self)))
-        result = md5(self.decoded)
-        get_media()._set_test_details(**{ f"md5_{i:03}" : result})
-        assert result == md5ref, "r2r md5 mismatch"
+
+        metric.update(filetest = self.decoded)
+        metric.check()
+
         #delete output file after each iteration
         get_media()._purge_test_artifact(self.decoded)
     else:

--- a/lib/gstreamer/transcoderbase.py
+++ b/lib/gstreamer/transcoderbase.py
@@ -7,8 +7,9 @@
 import slash
 
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
-from ...lib.metrics import calculate_psnr
 from ...lib.gstreamer.util import have_gst, have_gst_element, gst_discover
+
+from ...lib import metrics2
 
 @slash.requires(have_gst)
 @slash.requires(*have_gst_element("checksumsink2"))
@@ -188,10 +189,9 @@ class BaseTranscoderTest(slash.Test):
     assert "Height: {}".format(height) in props
 
   def check_metrics(self, yuv, refctx):
-    get_media().baseline.check_psnr(
-      psnr = calculate_psnr(
-        self.srcyuv, yuv,
-        self.width, self.height,
-        self.frames, self.format),
-      context = self.refctx + refctx,
-    )
+    metrics2.check(
+      metric = dict(type = "psnr"),
+      filetrue = self.srcyuv, filetest = yuv,
+      width = self.width, height = self.height,
+      frames = self.frames, format = self.format,
+      refctx = self.refctx + refctx)

--- a/lib/metrics2/__init__.py
+++ b/lib/metrics2/__init__.py
@@ -1,0 +1,11 @@
+###
+### Copyright (C) 2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from . import factory
+from . import filesize, md5, mse, nrmse, psnr, ssim
+
+def check(**params):
+  factory.create(**params).check()

--- a/lib/metrics2/factory.py
+++ b/lib/metrics2/factory.py
@@ -1,0 +1,60 @@
+###
+### Copyright (C) 2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ..common import Singleton
+from ..properties import PropertyHandler
+from .util import get_framesize
+
+class Metric(PropertyHandler):
+  filetest  = property(lambda self: self.ifprop("filetest", "{filetest}") or self.props["decoded"])
+  width     = property(lambda self: self.props["width"])
+  height    = property(lambda self: self.props["height"])
+  frames    = property(lambda self: self.props["frames"])
+  format    = property(lambda self: self.props["format"])
+  expect    = property(lambda self: self.props["metric"].get("expect", None))
+  context   = property(lambda self: self.props.get("refctx", []))
+  framesize = property(lambda self: get_framesize(self.width, self.height, self.format))
+
+  def update(self, **properties):
+    super().update(**properties)
+    # Invalidate "actual". It needs recalculated when properties changed.
+    self._actual = None
+
+  @property # getter
+  def actual(self):
+    if self._actual is None:
+      self.actual = self.calculate()
+    return self._actual
+
+  @actual.setter
+  def actual(self, value):
+    self._actual = value
+
+  @expect.setter
+  def expect(self, value):
+    self.props["metric"]["expect"] = value
+
+  def calculate(self):
+    raise NotImplementedError
+
+class MetricFactory(metaclass = Singleton):
+  def __init__(self):
+    self.metrics = dict()
+
+  def register(self, metric):
+    key = metric.__name__.lower()
+    assert issubclass(metric, Metric), f"{metric.__name__} is not a Metric"
+    assert key not in self.metrics, f"metric '{key}' is already registered"
+    self.metrics[key] = metric
+    return self
+
+  def create(self, **config):
+    key = config["metric"]["type"]
+    metric = self.metrics[key]
+    return metric(**config)
+
+register  = MetricFactory().register
+create    = MetricFactory().create

--- a/lib/metrics2/filesize.py
+++ b/lib/metrics2/filesize.py
@@ -1,0 +1,25 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+
+from ..common import get_media
+from .util import get_framesize
+from . import factory
+
+class Filesize(factory.Metric):
+  def calculate(self):
+    return os.stat(self.filetest).st_size
+
+  def check(self):
+    expected = self.framesize * self.frames
+
+    get_media()._set_test_details(**{"filesize:expect" : expected})
+    get_media()._set_test_details(**{"filesize:actual" : self.actual})
+
+    assert expected == self.actual
+
+factory.register(Filesize)

--- a/lib/metrics2/md5.py
+++ b/lib/metrics2/md5.py
@@ -1,0 +1,62 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import hashlib
+import os
+
+from ..common import get_media, timefn
+from . import factory
+
+@timefn("md5:calculate")
+def calculate(filename, chunksize = 4096, numbytes = -1):
+  if numbytes < 0: # calculate checksum on entire file
+    numbytes = os.stat(filename).st_size
+
+  numbytesread = 0
+  m = hashlib.md5()
+  with open(filename, "rb") as f:
+    # read numchunks of size chunksize
+    numchunks = int(numbytes / chunksize)
+    if numchunks > 0:
+      for n, chunk in enumerate(iter(lambda: f.read(chunksize), b""), 1):
+        numbytesread += len(chunk)
+        m.update(chunk)
+        if n == numchunks:
+          break
+
+    # read remainder of bytes < chunksize
+    lastchunk = f.read(numbytes % chunksize)
+    numbytesread += len(lastchunk)
+    m.update(lastchunk)
+
+  # fail if we did not read exactly numbytes
+  assert numbytesread == numbytes, f"md5: expected {numbytes} bytes, got {numbytesread}"
+
+  return m.hexdigest()
+
+class MD5(factory.Metric):
+  numbytes  = property(lambda self: self.props["metric"].get("numbytes", None))
+  format    = property(lambda self: self.props.get("format2", super().format))
+
+  @numbytes.setter
+  def numbytes(self, value):
+    self.props["metric"]["numbytes"] = value
+
+  def update(self, **properties):
+    super().update(**properties)
+    if self.numbytes is not None and self.numbytes >= 0:
+      self.numbytes = None
+
+  def calculate(self):
+    if self.numbytes is None:
+      self.numbytes = self.framesize * self.frames
+    return calculate(filename = self.filetest, numbytes = self.numbytes)
+
+  def check(self):
+    get_media().baseline.check_md5(
+      md5 = self.actual, expect = self.expect, context = self.context)
+
+factory.register(MD5)

--- a/lib/metrics2/mse.py
+++ b/lib/metrics2/mse.py
@@ -1,0 +1,43 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+try:
+  # try skimage >= 0.16, first
+  from skimage.metrics import mean_squared_error as skimage_mse
+except:
+  from skimage.measure import compare_mse as skimage_mse
+
+from ..common import get_media, timefn
+from .util import RawFileFrameReader, RawMetricAggregator
+from . import factory
+
+@timefn("mse:calculate")
+def calculate(filetrue, filetest, width, height, frames, format):
+  return RawMetricAggregator(max).calculate(
+    RawFileFrameReader(filetrue, width, height, frames, format),
+    RawFileFrameReader(filetest, width, height, frames, format),
+    frames, compare)
+
+def compare(planes):
+  a, b = planes
+  return skimage_mse(a, b)
+
+class MSE(factory.Metric):
+  filetrue  = property(lambda self: self.ifprop("filetrue", "{filetrue}") or self.props["reference"])
+  avgrange  = property(lambda self: self.props["metric"].get("avg_range", [(0, 256)] * 3))
+
+  def calculate(self):
+    return calculate(
+      self.filetrue, self.filetest, self.width, self.height,
+      self.frames, self.format)
+
+  def check(self):
+    get_media()._set_test_details(mse = self.actual)
+    assert self.avgrange[0][0] <= self.actual[-3] <= self.avgrange[0][1]
+    assert self.avgrange[1][0] <= self.actual[-2] <= self.avgrange[1][1]
+    assert self.avgrange[2][0] <= self.actual[-1] <= self.avgrange[2][1]
+
+factory.register(MSE)

--- a/lib/metrics2/nrmse.py
+++ b/lib/metrics2/nrmse.py
@@ -1,0 +1,43 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+try:
+  # try skimage >= 0.16, first
+  from skimage.metrics import normalized_root_mse as skimage_nrmse
+except:
+  from skimage.measure import compare_nrmse as skimage_nrmse
+
+from ..common import get_media, timefn
+from .util import RawFileFrameReader, RawMetricAggregator
+from . import factory
+
+@timefn("nrmse:calculate")
+def calculate(filetrue, filetest, width, height, frames, format):
+  return RawMetricAggregator(max).calculate(
+    RawFileFrameReader(filetrue, width, height, frames, format),
+    RawFileFrameReader(filetest, width, height, frames, format),
+    frames, compare)
+
+def compare(planes):
+  a, b = planes
+  return skimage_nrmse(a, b)
+
+class NRMSE(factory.Metric):
+  filetrue  = property(lambda self: self.ifprop("filetrue", "{filetrue}") or self.props["reference"])
+  avgrange  = property(lambda self: self.props["metric"].get("avg_range", [(0, 0.07)] * 3))
+
+  def calculate(self):
+    return calculate(
+      self.filetrue, self.filetest, self.width, self.height,
+      self.frames, self.format)
+
+  def check(self):
+    get_media()._set_test_details(nrmse = self.actual)
+    assert self.avgrange[0][0] <= self.actual[-3] <= self.avgrange[0][1]
+    assert self.avgrange[1][0] <= self.actual[-2] <= self.avgrange[1][1]
+    assert self.avgrange[2][0] <= self.actual[-1] <= self.avgrange[2][1]
+
+factory.register(NRMSE)

--- a/lib/metrics2/psnr.py
+++ b/lib/metrics2/psnr.py
@@ -1,0 +1,53 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+try:
+  # try skimage >= 0.16, first
+  from skimage.metrics import peak_signal_noise_ratio as skimage_psnr
+except:
+  from skimage.measure import compare_psnr as skimage_psnr
+
+from ..common import get_media, timefn
+from ..formats import get_bit_depth
+from .util import RawFileFrameReader, RawMetricAggregator, MetricWithDataRange
+from . import factory
+
+@timefn("psnr:calculate")
+def calculate(filetrue, filetest, width, height, frames, fmttrue, fmttest):
+  bitdepth = get_bit_depth(fmttrue)
+  assert get_bit_depth(fmttest) == bitdepth
+
+  return RawMetricAggregator(min).calculate(
+    RawFileFrameReader(filetrue, width, height, frames, fmttrue),
+    RawFileFrameReader(filetest, width, height, frames, fmttest),
+    frames, MetricWithDataRange(compare_planes, bitdepth))
+
+def compare_planes(planes, data_range = None):
+  a, b = planes
+  if (a == b).all():
+    # Avoid "Warning: divide by zero encountered in double_scalars" generated
+    # by skimage.measure.compare_psnr when a and b are exactly the same.
+    return 100
+  return skimage_psnr(a, b, data_range = data_range)
+
+def compare_actual(k, ref, actual):
+  assert ref is not None, "Invalid reference value"
+  assert all(map(lambda r,a: a > (r * 0.98), ref[3:], actual[3:]))
+
+class PSNR(factory.Metric):
+  filetrue  = property(lambda self: self.ifprop("filetrue", "{filetrue}") or self.props["reference"])
+  compare   = property(lambda self: self.props.get("compare", compare_actual))
+
+  def calculate(self):
+    return calculate(
+      self.filetrue, self.filetest, self.width, self.height,
+      self.frames, self.format, self.format)
+
+  def check(self):
+    get_media().baseline.check_result(
+      psnr = self.actual, compare = self.compare, context = self.context)
+
+factory.register(PSNR)

--- a/lib/metrics2/ssim.py
+++ b/lib/metrics2/ssim.py
@@ -1,0 +1,53 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+try:
+  # try skimage >= 0.16, first
+  from skimage.metrics import structural_similarity as skimage_ssim
+except:
+  from skimage.measure import compare_ssim as skimage_ssim
+
+from ..common import get_media, timefn
+from ..formats import get_bit_depth
+from .util import RawFileFrameReader, RawMetricAggregator, MetricWithDataRange
+from . import factory
+
+@timefn("ssim:calculate")
+def calculate(filetrue, filetest, width, height, frames, fmttrue, fmttest):
+  bitdepth = get_bit_depth(fmttrue)
+  assert get_bit_depth(fmttest) == bitdepth
+
+  return RawMetricAggregator(min).calculate(
+    RawFileFrameReader(filetrue, width, height, frames, fmttrue),
+    RawFileFrameReader(filetest, width, height, frames, fmttest),
+    frames, MetricWithDataRange(compare, bitdepth))
+
+def compare(planes, data_range = None):
+  a, b = planes
+  if a is None or b is None: # handle Y800 case
+    return 1.0
+  return skimage_ssim(a, b, win_size = 3, data_range = data_range)
+
+class SSIM(factory.Metric):
+  format    = property(lambda self: self.props.get("format2", super().format))
+  filetrue  = property(lambda self: self.ifprop("filetrue", "{filetrue}") or self.props["reference"])
+  fmttrue   = property(lambda self: super().format)
+  miny      = property(lambda self: self.props["metric"].get("miny", 1.0))
+  minu      = property(lambda self: self.props["metric"].get("minu", 1.0))
+  minv      = property(lambda self: self.props["metric"].get("minv", 1.0))
+
+  def calculate(self):
+    return calculate(
+      self.filetrue, self.filetest, self.width, self.height,
+      self.frames, self.fmttrue, self.format)
+
+  def check(self):
+    get_media()._set_test_details(ssim = self.actual)
+    assert 1.0 >= self.actual[0] >= self.miny
+    assert 1.0 >= self.actual[1] >= self.minu
+    assert 1.0 >= self.actual[2] >= self.minv
+
+factory.register(SSIM)

--- a/lib/metrics2/util.py
+++ b/lib/metrics2/util.py
@@ -1,0 +1,127 @@
+###
+### Copyright (C) 2018-2022 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import itertools
+import os
+
+from ..common import get_media, memoize
+from ..framereader import FrameReaders
+
+class RawFileFrameReader:
+  def __init__(self, filename, width, height, nframes, fourcc):
+    self.filename = filename
+    self.width    = width
+    self.height   = height
+    self.nframes  = nframes
+    self.fourcc   = fourcc
+    self.reader   = FrameReaders[self.fourcc]
+
+  # to support "with" syntax
+  def __enter__(self):
+    self.nreads = 0
+    self.fd = open(self.filename, "rb")
+    return self
+
+  # to support "with" syntax
+  def __exit__(self, type, value, tb):
+    self.fd.close()
+
+  def next_frame(self):
+    try:
+      return self.reader(self.fd, self.width, self.height)
+    except Exception as e:
+      e.args += tuple(["frame {}/{}".format(self.nreads, self.nframes)])
+      raise
+    finally:
+      self.nreads += 1
+
+class RawMetricAggregator:
+  def __init__(self, biggest_deviator = min):
+    self.results = list()
+    self.biggest_deviator = biggest_deviator;
+
+    # 50% of physical memory (i.e. 25% in main process and 25% in async pool)
+    self.async_thresh = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') / 4
+    self.async_results = list()
+    self.async_bytes = 0
+
+  def __collect_async(self):
+    self.results.extend([r.get() for r in self.async_results])
+    self.async_bytes = 0
+    self.async_results = list()
+
+  def __append(self, func, iterable):
+    if get_media().metrics_pool is not None:
+      self.async_results.append(
+        get_media().metrics_pool.map_async(func, iterable))
+
+      # Update bytes of yuv data that is being held by async_results
+      self.async_bytes += sum([i.nbytes for i in itertools.chain(*iterable) if i is not None])
+
+      # If we are holding onto too much yuv data, then we need to collect and
+      # purge the current async_results to release the data
+      if self.async_bytes >= self.async_thresh:
+        self.__collect_async()
+    else:
+      self.results.append([func(i) for i in iterable])
+
+  def __get(self):
+    self.__collect_async()
+    result = list(itertools.chain(*self.results))
+    return [
+      float(round(v, 4)) for v in (
+        self.biggest_deviator(result[0::3]),
+        self.biggest_deviator(result[1::3]),
+        self.biggest_deviator(result[2::3]),
+        sum(result[0::3]) / len(self.results),
+        sum(result[1::3]) / len(self.results),
+        sum(result[2::3]) / len(self.results),
+      )
+    ]
+
+  def calculate(self, file1, file2, nframes, compare):
+    with file1, file2: # this opens the files for reading
+      for i in range(nframes):
+        y1, u1, v1 = file1.next_frame()
+        y2, u2, v2 = file2.next_frame()
+        self.__append(compare, ((y1, y2), (u1, u2), (v1, v2)))
+    return self.__get()
+
+class MetricWithDataRange:
+  def __init__(self, func, bitdepth):
+    self.func = func
+    self.data_range = pow(2, bitdepth) - 1
+
+  def __call__(self, planes):
+    return self.func(planes, self.data_range)
+
+@memoize
+def get_framesize(w, h, fourcc):
+  w2  = (w + (w & 1)) >> 1;
+  h2  = (h + (h & 1)) >> 1;
+  szs = {
+    "I420" : lambda: (w * h) + (w2 * h2 * 2),
+    "422H" : lambda: (w * h) + (w2 * h * 2),
+    "422V" : lambda: (w * h) + (w * h2 * 2),
+    "444P" : lambda: w * h * 3,
+    "NV12" : lambda: szs["I420"](),
+    "YV12" : lambda: szs["I420"](),
+    "P010" : lambda: szs["I420"]() * 2,
+    "P012" : lambda: szs["I420"]() * 2,
+    "I010" : lambda: szs["P010"](),
+    "Y800" : lambda: w * h,
+    "YUY2" : lambda: w * h * 2,
+    "AYUV" : lambda: w * h * 4,
+    "VUYA" : lambda: w * h * 4,
+    "ARGB" : lambda: w * h * 4,
+    "Y210" : lambda: w * h * 4,
+    "Y212" : lambda: w * h * 4,
+    "Y410" : lambda: w * h * 4,
+    "Y412" : lambda: w * h * 8,
+    "BGRA" : lambda: w * h * 4,
+    "BGRX" : lambda: w * h * 4,
+  }
+  return szs[fourcc]()

--- a/lib/mixin/vpp.py
+++ b/lib/mixin/vpp.py
@@ -4,15 +4,14 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
-from .. import metrics
+from .. import metrics2
 from ..common import get_media
 from ..util import format_value
 
 class VppMetricMixin:
-
   def compare_brightness(self, k, ref, actual):
     assert ref is not None, "Invalid reference value"
-    assert abs(ref[-3] - actual[-3]) <  0.2, "Luma (Y) out of baseline range"
+    assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
     assert actual[-2] == 100, "Cb(U) should not be affected by BRIGHTNESS filter"
     assert actual[-1] == 100, "Cr(V) should not be affected by BRIGHTNESS filter"
 
@@ -25,30 +24,32 @@ class VppMetricMixin:
   def compare_hue(self, k, ref, actual):
     assert ref is not None, "Invalid reference value"
     assert actual[-3] == 100, "Luma (Y) should not be affected by HUE filter"
-    assert abs(ref[-2] - actual[-2]) <  0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) <  0.2, "Cr (V) out of baseline range"
+    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
 
   def compare_saturation(self, k, ref, actual):
     assert ref is not None, "Invalid reference value"
     assert actual[-3] == 100, "Luma (Y) should not be affected by SATURATION filter"
-    assert abs(ref[-2] - actual[-2]) <  0.2, "Cb (U) out of baseline range"
-    assert abs(ref[-1] - actual[-1]) <  0.2, "Cr (V) out of baseline range"
+    assert abs(ref[-2] - actual[-2]) < 0.2, "Cb (U) out of baseline range"
+    assert abs(ref[-1] - actual[-1]) < 0.2, "Cr (V) out of baseline range"
 
   def check_procamp(self):
-    psnr = metrics.calculate_psnr(
-      self.source, self.decoded,
-      self.width, self.height,
-      self.frames, self.format)
-
     if 50 == self.level: # NOOP (default level)
-      get_media()._set_test_details(psnr = psnr, ref_psnr = "noop")
-      assert psnr[-3] == 100, "Luma (Y) should not be affected at NOOP level"
-      assert psnr[-2] == 100, "Cb (U) should not be affected at NOOP level"
-      assert psnr[-1] == 100, "Cr (V) should not be affected at NOOP level"
+      metric = metrics2.factory.create(
+        metric = dict(type = "md5"),
+        width = self.width, height = self.height,
+        frames = self.frames, format = self.format)
+      metric.update(filetest = self.source)
+      metric.expect = metric.actual
+      metric.update(filetest = self.decoded)
+      metric.check()
     else:
-      compare = getattr(self, "compare_{vpp_op}".format(**vars(self)))
-      get_media().baseline.check_result(
-        compare = compare, context = self.refctx, psnr = psnr)
+      metrics2.check(
+        metric = dict(type = "psnr"),
+        compare = getattr(self, "compare_{vpp_op}".format(**vars(self))),
+        filetrue = self.source, filetest = self.decoded,
+        width = self.width, height = self.height, frames = self.frames,
+        format = self.format, refctx = self.refctx)
 
   check_brightness  = check_procamp
   check_contrast    = check_procamp
@@ -56,23 +57,24 @@ class VppMetricMixin:
   check_saturation  = check_procamp
 
   def check_crop(self):
-    metrics.check_filesize(
-      self.decoded, self.crop_width, self.crop_height, self.frames, self.format)
+    metrics2.check(
+      metric = dict(type = "filesize"), filetest = self.decoded,
+      width = self.crop_width, height = self.crop_height,
+      frames = self.frames, format = self.format)
 
     params = vars(self).copy()
-    params["width"] = self.crop_width
-    params["height"] = self.crop_height
+    params.update(width = self.crop_width, height = self.crop_height)
 
-    metrics.check_metric(**params)
+    metrics2.check(**params)
 
   def check_csc(self):
-    metrics.check_metric(
+    metrics2.check(
       # if user specified metric, then use it.  Otherwise, use ssim metric with perfect score
       metric = vars(self).get("metric", dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0)),
       # If user specified reference, use it.  Otherwise, assume source is the reference.
-      reference = format_value(self.reference, **vars(self))
+      filetrue = format_value(self.reference, **vars(self))
         if vars(self).get("reference") else self.source,
-      decoded = self.decoded,
+      filetest = self.decoded,
       # if user specified reference, then assume it's format is the same as csc output format.
       # Otherwise, the format is the source format
       format = self.format if vars(self).get("reference", None) is None else self.csc,
@@ -82,14 +84,9 @@ class VppMetricMixin:
   def check_deinterlace(self):
     if vars(self).get("reference", None) is not None:
       self.reference = format_value(self.reference, **vars(self))
-    metrics.check_metric(**vars(self))
+    metrics2.check(**vars(self))
 
   def check_denoise(self):
-    psnr = metrics.calculate_psnr(
-      self.source, self.decoded,
-      self.width, self.height,
-      self.frames, self.format)
-
     def compare(k, ref, actual):
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) < 0.2, "Luma (Y) out of baseline range"
@@ -100,45 +97,38 @@ class VppMetricMixin:
         assert actual[-2] == 100, "Cb(U) changed, but caps don't support DENOISE chroma"
         assert actual[-1] == 100, "Cr(V) changed, but caps don't support DENOISE chroma"
 
-    get_media().baseline.check_result(
-      compare = compare, context = self.refctx, psnr = psnr)
+    metrics2.check(
+      metric = dict(type = "psnr"), compare = compare,
+      filetrue = self.source, filetest = self.decoded,
+      width = self.width, height = self.height, frames = self.frames,
+      format = self.format, refctx = self.refctx)
 
   def check_scale(self):
-    metrics.check_filesize(
-      self.decoded, self.scale_width, self.scale_height,
-      self.frames, self.format)
-
-    fmtref = format_value(self.reference, **vars(self))
-
-    ssim = metrics.calculate_ssim(
-      fmtref, self.decoded,
-      self.scale_width, self.scale_height,
-      self.frames, self.format)
-
-    get_media()._set_test_details(ssim = ssim)
-
-    assert 1.0 >= ssim[0] >= 0.97
-    assert 1.0 >= ssim[1] >= 0.97
-    assert 1.0 >= ssim[2] >= 0.97
+    metrics2.check(
+      metric = dict(type = "filesize"),
+      filetest = self.decoded, width = self.scale_width,
+      height = self.scale_height, frames = self.frames, format = self.format)
+    metrics2.check(
+      metric = dict(type = "ssim", miny = 0.97, minu = 0.97, minv = 0.97),
+      filetrue = format_value(self.reference, **vars(self)),
+      filetest = self.decoded, width = self.scale_width,
+      height = self.scale_height, frames = self.frames, format = self.format)
 
   # FIXME: HACK: "generic" class should not have concept of "qsv"
   check_scale_qsv = check_scale
 
   def check_sharpen(self):
-    psnr = metrics.calculate_psnr(
-      self.source, self.decoded,
-      self.width, self.height,
-      self.frames, self.format)
-
-    assert psnr[-2] == 100, "Cb(U) should not be affected by SHARPEN filter"
-    assert psnr[-1] == 100, "Cr(V) should not be affected by SHARPEN filter"
-
     def compare(k, ref, actual):
+      assert actual[-2] == 100, "Cb(U) should not be affected by SHARPEN filter"
+      assert actual[-1] == 100, "Cr(V) should not be affected by SHARPEN filter"
       assert ref is not None, "Invalid reference value"
       assert abs(ref[-3] - actual[-3]) <  0.25, "Luma (Y) out of baseline range"
 
-    get_media().baseline.check_result(
-      compare = compare, context = self.refctx, psnr = psnr)
+    metrics2.check(
+      metric = dict(type = "psnr"), compare = compare,
+      filetrue = self.source, filetest = self.decoded,
+      width = self.width, height = self.height, frames = self.frames,
+      format = self.format, refctx = self.refctx)
 
   def check_composite(self):
     owidth, oheight = self.width, self.height
@@ -146,15 +136,18 @@ class VppMetricMixin:
       owidth = max(owidth, self.width + comp['x'])
       oheight = max(oheight, self.height + comp['y'])
 
-    params = vars(self).copy()
-    params["width"] = owidth
-    params["height"] = oheight
+    metrics2.check(
+      metric = dict(type = "filesize"),
+      filetest = self.decoded, width = owidth, height = oheight,
+      frames = self.frames, format = self.format)
 
-    metrics.check_filesize(self.decoded, owidth, oheight, self.frames, self.format)
-    metrics.check_metric(**params)
+    params = vars(self).copy()
+    params.update(width = owidth, height = oheight)
+
+    metrics2.check(**params)
 
   def check_default(self):
-    metrics.check_metric(**vars(self))
+    metrics2.check(**vars(self))
 
   def check_metrics(self):
     getattr(self, "check_{vpp_op}".format(**vars(self)), self.check_default)()


### PR DESCRIPTION
Introduce metrics as a module of classes that are registered into a factory.  A new Metric base class is introduced that intuitively handles `expect` and `actual` properties.

The `actual` property can be set programmatically by tests when they are capable of providing pre-calculated results (e.g. by using inline middleware plugins to do the calculation-- will be added later).  If the `actual` property is not set, then the metric will use it's own, internal code to calculate the result (i.e. the current functionality).

The `actual` property is protected such that a user test configuration is not able to set it/fake it easily.

The `expect` property is settable by user test configuration if they choose to bypass the baseline mechanism (e.g. see conformance configurations).

A test can also reuse a metric instance by updating the properties that are used as parameters in the calculation.  When these are updated, the `actual` property is automatically invalidated.  A demonstration of this type of usage can be seen in the R2R test routines.