### PR TITLE
Add Max/min qp for I/P/B in ffmpeg-qsv/encode/avc

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -63,6 +63,19 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   hwupload      = property(lambda s: ",hwupload")
 
   @property
+  def rqp(self):
+    def inner(rqp):
+      return (
+        f" -max_qp_i {rqp['MaxQPI']}"
+        f" -min_qp_i {rqp['MinQPI']}"
+        f" -max_qp_p {rqp['MaxQPP']}"
+        f" -min_qp_p {rqp['MinQPP']}"
+        f" -max_qp_b {rqp['MaxQPB']}"
+        f" -min_qp_b {rqp['MinQPB']}"
+      )
+    return self.ifprop("rqp", inner)
+
+  @property
   def intref(self):
     def inner(intref):
       return (
@@ -87,7 +100,7 @@ class Encoder(PropertyHandler, BaseFormatMapper):
       f"{self.bframes}{self.slices}{self.minrate}{self.maxrate}{self.refs}"
       f"{self.extbrc}{self.loopshp}{self.looplvl}{self.tilecols}{self.tilerows}"
       f"{self.level}{self.ladepth}{self.forced_idr}{self.intref}{self.lowpower}"
-      f"{self.maxframesize}{self.pict}"
+      f"{self.maxframesize}{self.pict}{self.rqp}"
     )
 
   @timefn("ffmpeg-encode")
@@ -159,6 +172,8 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       name += "-pict-0"
     if vars(self).get("roi", None) is not None:
       name += "-roi"
+    if vars(self).get("rqp", None) is not None:
+      name += "-rqp"
     if vars(self).get("r2r", None) is not None:
       name += "-r2r"
 

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -107,3 +107,19 @@ class EncoderTest(BaseEncoderTest):
       for pattern in patterns:
         m = re.search(pattern, self.output, re.MULTILINE)
         assert m is not None, f"'{pattern}' missing in output"
+
+    # Max/min qp
+    if vars(self).get("rqp", None) is not None:
+      patterns = [
+        f"MinQPI: {self.rqp['MinQPI']};",
+        f"MaxQPI: {self.rqp['MaxQPI']};",
+        f"MinQPP: {self.rqp['MinQPP']};",
+        f"MaxQPP: {self.rqp['MaxQPP']};",
+        f"MinQPB: {self.rqp['MinQPB']};",
+        f"MaxQPB: {self.rqp['MaxQPB']}",
+      ]
+
+      for pattern in patterns:
+        m = re.search(pattern, self.output, re.MULTILINE)
+        assert m is not None, f"'{pattern}' missing in output"
+

--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -347,6 +347,36 @@ def gen_avc_roi_lp_parameters(spec, profiles):
   params = gen_avc_roi_lp_variants(spec, profiles)
   return keys, params
 
+def gen_avc_rqp_variants(spec, profiles):
+  for case, params in spec.items():
+    for variant in copy.deepcopy(params.get("variants", dict()).get("rqp", [])):
+      uprofile = variant.get("profile", None)
+      cprofiles = [uprofile] if uprofile else profiles
+      gop     = variant.get("gop", None)
+      bframes = variant.get("bframes", None)
+      bitrate = variant.get("bitrate", None)
+      rcmode  = variant["rcmode"]
+      maxi    = variant.get("maxi", None)
+      mini    = variant.get("mini", None)
+      maxp    = variant.get("maxp", None)
+      minp    = variant.get("minp", None)
+      maxb    = variant.get("maxb", None)
+      minb    = variant.get("minb", None)
+      if "cbr" == rcmode:
+        variant.update(maxrate = bitrate)
+      elif "vbr" == rcmode:
+        variant.update(maxrate = bitrate * 2)
+      for profile in cprofiles:
+        yield [
+          case, gop, bframes, bitrate, variant["maxrate"],
+          profile, rcmode, maxi, mini, maxp, minp, maxb, minb,
+        ]
+
+def gen_avc_rqp_parameters(spec, profiles):
+  keys = ("case", "gop", "bframes", "bitrate", "maxrate", "profile", "rcmode", "maxi", "mini", "maxp", "minp", "maxb", "minb")
+  params = gen_avc_rqp_variants(spec, profiles)
+  return keys, params
+
 def gen_hevc_pict_variants(spec, profiles):
   for case, params in spec.items():
     for variant in copy.deepcopy(params.get("variants", dict()).get("pict", [])):

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -341,3 +341,23 @@ class roi_lp(AVCEncoderLPTest):
   def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode):
     self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode)
     self.encode()
+
+class rqp(AVCEncoderTest):
+  def init(self, tspec, case, gop, bframes, bitrate, maxrate, profile, rcmode, maxi, mini, maxp, minp, maxb, minb):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      rcmode     = rcmode,
+      bframes    = bframes,
+      bitrate    = bitrate,
+      case       = case,
+      maxrate    = maxrate,
+      minrate    = bitrate,
+      profile    = profile,
+      gop        = gop,
+      rqp        = dict(MaxQPI = maxi, MinQPI = mini, MaxQPP = maxp, MinQPP = minp, MaxQPB = maxb, MinQPB = minb),
+    )
+
+  @slash.parametrize(*gen_avc_rqp_parameters(spec, ['main']))
+  def test(self, case, gop, bframes, bitrate, maxrate, profile, rcmode, maxi, mini, maxp, minp, maxb, minb):
+    self.init(spec, case, gop, bframes, bitrate, maxrate, profile, rcmode, maxi, mini, maxp, minp, maxb, minb)
+    self.encode()


### PR DESCRIPTION
Add max/min qp for I/P/B frame in ffmpeg-qsv/encode/avc.
Signed-off-by: Li Fan <fan1x.li@intel.com>