### PR TITLE
lib/ffmpeg/unti change format

### DIFF
--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -55,7 +55,7 @@ class BaseFormatMapper(FormatMapper):
       "BGRA"  : "bgra",
       "Y210"  : "y210",
       "Y212"  : "y212",
-      "Y410"  : "y410",
-      "Y412"  : "y412",
+      "Y410"  : "xv30",
+      "Y412"  : "xv36",
       "AYUV"  : "vuyx", # vuyx is same as microsoft AYUV except the alpha channel
     }


### PR DESCRIPTION
upsteam patch:
d75c46: lavu/pixfmt: Add P012, Y212, XV30, and XV36 formats

y410 -> xv30
y412 -> xv36

Signed-off-by: Bin Wu <bin1.wu@intel.com>