### PR TITLE
Factor out the "gen_name" functions

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -180,6 +180,12 @@ class MediaPlugin(slash.plugins.PluginInterface):
       os.remove(tstfile)
     return tstfile
 
+  def _test_artifact2(self, ext):
+    count = self._test_state_value((self._test_artifact2, ext), 0)
+    count.value += 1
+    filename = f"{slash.context.test.id}_{count.value}.{ext}"
+    return self._test_artifact(filename)
+
   def _purge_test_artifact(self, filename):
     result = slash.context.result
 


### PR DESCRIPTION
The "gen_name" functions are a maintenance headache... easy to forget to update when new properties are added and cause filenames to not be unique.

Thus, use the unique test id and a counter to generate test artifact filenames.  Remove all gen_name functions.