### PR TITLE
FFmpeg: use inline metrics

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -9,7 +9,7 @@ import slash
 
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.ffmpeg.util import have_ffmpeg, ffmpeg_probe_fps, BaseFormatMapper
-from ...lib.ffmpeg.util import parse_inline_md5, parse_ssim_stats
+from ...lib.ffmpeg.util import parse_inline_md5, parse_ssim_stats, parse_psnr_stats
 from ...lib.parameters import format_value
 from ...lib.util import skip_test_if_missing_features
 from ...lib.properties import PropertyHandler
@@ -69,7 +69,7 @@ class Decoder(PropertyHandler, BaseFormatMapper):
     self._decoded = get_media()._test_artifact2("yuv")
 
     mtype = self.props.get("metric", dict()).get("type", None)
-    if mtype in ["ssim"]:
+    if mtype in ["ssim", "psnr"]:
       fps = ffmpeg_probe_fps(self.ossource)
 
       if vars(self).get("_statsfile", None) is not None:
@@ -159,5 +159,7 @@ class BaseDecoderTest(slash.Test, BaseFormatMapper):
       metric.actual = parse_inline_md5(self.output)
     elif metric.__class__ is metrics2.ssim.SSIM:
       metric.actual = parse_ssim_stats(self.decoder.statsfile, self.frames)
+    elif metric.__class__ is metrics2.ssim.PSNR:
+      metric.actual = parse_psnr_stats(self.decoder.statsfile, self.frames)
 
     metric.check()

--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -4,8 +4,14 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+import re
+
 from ...lib.common import memoize, try_call, call, exe2os
 from ...lib.formats import FormatMapper
+
+def parse_inline_md5(msglog):
+  return parse_inline_md5.pattern.search(msglog).group("actual")
+parse_inline_md5.pattern = re.compile("MD5=(?P<actual>[0-9a-fA-F]{32})$", re.MULTILINE)
 
 @memoize
 def have_ffmpeg():

--- a/lib/ffmpeg/util.py
+++ b/lib/ffmpeg/util.py
@@ -32,6 +32,29 @@ def parse_ssim_stats(filename, frames):
   ]
 parse_ssim_stats.pattern = re.compile(r"Y:(?P<y>\d+.\d+) U:(?P<u>\d+.\d+) V:(?P<v>\d+.\d+)", re.M)
 
+def parse_psnr_stats(filename, frames):
+  with open(filename, "r") as f:
+    # replace inf with 100.0 to match metrics2 averages
+    data = f.read().replace(":inf", ":100.0")
+  m = parse_psnr_stats.pattern.findall(data)
+  assert len(m) == frames
+  result = [float(v) for v in itertools.chain(*m)]
+  return [
+    float(round(v, 4)) for v in (
+      min(result[0::3]),
+      min(result[1::3]),
+      min(result[2::3]),
+      sum(result[0::3]) / frames,
+      sum(result[1::3]) / frames,
+      sum(result[2::3]) / frames,
+    )
+  ]
+parse_psnr_stats.pattern = re.compile(
+  r"psnr_y:(?P<y>\d+\.\d+) "
+  r"psnr_u:(?P<u>\d+\.\d+) "
+  r"psnr_v:(?P<v>\d+\.\d+)", re.M
+)
+
 @memoize
 def have_ffmpeg():
   return try_call(f"which {exe2os('ffmpeg')}")


### PR DESCRIPTION
Writing raw data to file, then reading into internal metric function adds unnecessary runtime overhead.

Instead, we can have FFmpeg calculate the MD5,SSIM, or PSNR concurrently.
