### PR TITLE
lib/ffmpeg: escape and quote ssim/psnr filename for Windows support

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -81,7 +81,7 @@ class Decoder(PropertyHandler, BaseFormatMapper):
         f" {self.ffdecoder} -r:v {fps} -i {self.ossource}"
         f" -f rawvideo -pix_fmt {self.format} -s:v {self.width}x{self.height}"
         f" -r:v {fps} -i {self.osreference}"
-        f" -lavfi '{self.scale_range},{mtype}=f={self.osstatsfile}:shortest=1'"
+        f" -lavfi \"{self.scale_range},{mtype}=f=\\'{self.osstatsfile}\\':shortest=1\""
         f" -c:v rawvideo -pix_fmt {self.format} -fps_mode passthrough"
         f" -autoscale 0 -vframes {self.frames} -y {self.ffoutput}"
       )


### PR DESCRIPTION
When a file path is used in ffmpeg filter option, the drive letter separator on Windows, ":", needs to be escaped so the ffmpeg command can parse it correctly. Otherwise, it will be mistaken as a filter option
separator.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>