### PR TITLE
ffmpeg: WA: force in/out range for jpeg enc and dec

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -40,12 +40,8 @@ class Decoder(PropertyHandler, BaseFormatMapper):
 
   @property
   def scale_range(self):
-    # NOTE: If test has requested scale in/out range, then apply it only when
-    # hw and sw formats differ (i.e. when csc is necessary).
-    if self.hwformat != self.format:
-      return self.ifprop("ffscale_range",
-        "scale=in_range={ffscale_range}:out_range={ffscale_range}") or "null"
-    return "null"
+    return self.ifprop("ffscale_range",
+      "scale=in_range={ffscale_range}:out_range={ffscale_range}") or "null"
 
   @property
   def hwinit(self):

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -164,6 +164,9 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       reference = self.source,
     )
 
+    if self.codec in ["jpeg"]:
+      self.decoder.update(ffscale_range = "jpeg")
+
     if None in [self.encoder.hwformat, self.encoder.format, self.decoder.hwformat, self.decoder.format]:
       slash.skip_test("{format} not supported".format(**vars(self)))
 


### PR DESCRIPTION
In addition to previous WA 46e1964c1e189fb, jpeg enc also needs this for proper inline metric calc.

So apply it unconditionally during decode when set.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>