### PR TITLE
ffmpeg/decode: do not use explicit map

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -55,7 +55,7 @@ class Decoder(PropertyHandler, BaseFormatMapper):
   @property
   def ffoutput(self):
     if self.props.get("metric", dict()).get("type", None) == "md5":
-      return f"-f tee -map 0:v '{self.osdecoded}|[f=md5]pipe:1'"
+      return f"-f tee '{self.osdecoded}|[f=md5]pipe:1'"
     return f"{self.osdecoded}"
 
   @timefn("ffmpeg:decode")


### PR DESCRIPTION
The explicit "-map 0:v" does not capture unlabeled complex filtergraph outputs.

Thus, remove the explicit mapping so that the unlabeled filtergraph output will be automatically linked to the first output stream (in this case, the tee sink).

This is the intended behavior of a complex filtergraph according to ffmpeg documentation.  It was just broken until:

http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=0d821edb40d27848304a7354b1c64c2e30e00e7d

Also see https://trac.ffmpeg.org/ticket/9990 discussion.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>