### PR TITLE
ffmepg-qsv:Update TCBRC maxrate and bframes

### DIFF
--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -214,10 +214,11 @@ class vbr_lp(HEVC10EncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.5,
+      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required
+      bframes = 0,
     )
     self.encode()
 

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -213,10 +213,11 @@ class vbr_lp(AVCEncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.5,
+      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required
+      bframes = 0,
     )
     self.encode()
 

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -214,10 +214,11 @@ class vbr_lp(HEVC8EncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.5,
+      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required
+      bframes = 0,
     )
     self.encode()
 


### PR DESCRIPTION
 If you don't set this parameter, h264 encode will automatically set to 0 but h265 won't,so need to set to 0 manually. maxrate needs to be equal to bitrate, but if maxrate is set to bitrate on ffmpeg, CBR will be used, so set maxrate=bitrate * 1.01.

Signed-off-by: Wang Hangjie <hangjiex.wang@intel.com>