### PR TITLE
lib/ffmpeg: add hwinit_format for the base class

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -26,7 +26,6 @@ class Decoder(PropertyHandler, BaseFormatMapper):
   decoded   = property(lambda s: s._decoded)
   osdecoded = property(lambda s: filepath2os(s.decoded))
   hwaccel   = property(lambda s: s.props["hwaccel"])
-  hwdevice  = property(lambda s: get_media().render_device)
 
   # optional properties
   ffdecoder   = property(lambda s: s.ifprop("ffdecoder", "-c:v {ffdecoder}"))
@@ -44,10 +43,14 @@ class Decoder(PropertyHandler, BaseFormatMapper):
       "scale=in_range={ffscale_range}:out_range={ffscale_range}") or "null"
 
   @property
+  def hwdevice(self):
+    return f'hw:{get_media().render_device}'
+
+  @property
   def hwinit(self):
     return (
       f"-hwaccel {self.hwaccel}"
-      f" -init_hw_device {self.hwaccel}=hw:{self.hwdevice}"
+      f" -init_hw_device {self.hwaccel}={self.hwdevice}"
       f" -hwaccel_output_format {self.hwformat}"
       f" -hwaccel_flags allow_profile_mismatch"
     )

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -25,7 +25,6 @@ class Encoder(PropertyHandler, BaseFormatMapper):
   frames        = property(lambda s: s.props["frames"])
   format        = property(lambda s: s.map_format(s.props["format"]))
   hwaccel       = property(lambda s: s.props["hwaccel"])
-  hwdevice      = property(lambda s: get_media().render_device)
   source        = property(lambda s: s.props["source"])
   ossource      = property(lambda s: filepath2os(s.source))
   width         = property(lambda s: s.props["width"])
@@ -90,10 +89,14 @@ class Encoder(PropertyHandler, BaseFormatMapper):
     return self.ifprop("intref", inner)
 
   @property
+  def hwdevice(self):
+    return f'hw:{get_media().render_device}'
+
+  @property
   def hwinit(self):
     return (
       f"-hwaccel {self.hwaccel}"
-      f" -init_hw_device {self.hwaccel}=hw:{self.hwdevice}"
+      f" -init_hw_device {self.hwaccel}={self.hwdevice}"
       f" -hwaccel_output_format {self.hwaccel}"
     )
 

--- a/lib/ffmpeg/qsv/decoder.py
+++ b/lib/ffmpeg/qsv/decoder.py
@@ -15,6 +15,10 @@ from ....lib.ffmpeg.qsv.util import using_compatible_driver
 class Decoder(FFDecoder):
   hwaccel = property(lambda s: "qsv")
 
+  @property
+  def hwdevice(self):
+    return f'qsv,child_device={get_media().render_device}'
+
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class DecoderTest(BaseDecoderTest):

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -24,6 +24,10 @@ class Encoder(FFEncoder):
     return f"{super().hwupload}=extra_hw_frames=120"
 
   @property
+  def hwdevice(self):
+    return f'qsv,child_device={get_media().render_device}'
+
+  @property
   def qp(self):
     def inner(qp):
       if self.codec in ["mpeg2"]:

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -10,6 +10,7 @@ from ....lib import platform
 from ....lib.ffmpeg.transcoderbase import BaseTranscoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_decoder, have_ffmpeg_encoder, have_ffmpeg_hwaccel, have_ffmpeg_filter
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
+from ....lib.common import get_media
 
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
@@ -74,3 +75,4 @@ class TranscoderTest(BaseTranscoderTest):
     super().before()
     self.hwaccel = "qsv"
     self.hwframes = 64
+    self.hwdevice = f'qsv,child_device={get_media().render_device}'

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -18,7 +18,7 @@ class VppTest(BaseVppTest):
   def before(self):
     super().before()
     self.hwaccel = "qsv"
-    self.hwdevice = f"hw_any,child_device={self.renderDevice}"
+    self.hwdevice = f'qsv,child_device={get_media().render_device}'
 
   def get_output_formats(self):
     # MSDK does not support I420 and YV12 output formats even though

--- a/lib/ffmpeg/transcoderbase.py
+++ b/lib/ffmpeg/transcoderbase.py
@@ -18,7 +18,7 @@ class BaseTranscoderTest(slash.Test):
     super().before()
     self.refctx = []
     self.post_validate = lambda: None
-    self.renderDevice = get_media().render_device
+    self.hwdevice = f"hw:{get_media().render_device}"
 
   def get_requirements_data(self, ttype, codec, mode):
     return  self.requirements[ttype].get(
@@ -105,7 +105,7 @@ class BaseTranscoderTest(slash.Test):
     self.post_validate()
 
   def gen_input_opts(self):
-    opts = "-init_hw_device {hwaccel}=hw:{renderDevice}"
+    opts = "-init_hw_device {hwaccel}={hwdevice}"
     opts += " -hwaccel_output_format {hwaccel}"
     if "hw" == self.mode:
       opts += " -hwaccel {hwaccel}"

--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -18,7 +18,6 @@ class VppTest(BaseVppTest):
   def before(self):
     super().before()
     self.hwaccel = "vaapi"
-    self.hwdevice = self.renderDevice
 
   def gen_vpp_opts(self):
     vpfilter = []

--- a/lib/ffmpeg/vppbase.py
+++ b/lib/ffmpeg/vppbase.py
@@ -16,8 +16,8 @@ from ...lib import metrics2
 class BaseVppTest(slash.Test, BaseFormatMapper, VppMetricMixin):
   def before(self):
     self.refctx = []
-    self.renderDevice = get_media().render_device
     self.post_validate = lambda: None
+    self.hwdevice = f"hw:{get_media().render_device}"
 
   def get_input_formats(self):
     return self.caps.get("ifmts", [])
@@ -61,7 +61,7 @@ class BaseVppTest(slash.Test, BaseFormatMapper, VppMetricMixin):
 
     call(
       f"{exe2os('ffmpeg')} -hwaccel {self.hwaccel}"
-      f" -init_hw_device {self.hwaccel}=hw:{self.hwdevice}"
+      f" -init_hw_device {self.hwaccel}={self.hwdevice}"
       f" -hwaccel_output_format {self.hwaccel}"
       f" -v verbose {iopts} {oopts}"
     )

--- a/test/ffmpeg-qsv/general/runtime.py
+++ b/test/ffmpeg-qsv/general/runtime.py
@@ -16,13 +16,14 @@ from ....lib.mfx.runtime import MFXRuntimeTest
 class detect(MFXRuntimeTest):
   def before(self):
     super().before()
-    self.renderDevice = get_media().render_device
+    self.hwaccel = 'qsv'
+    self.hwdevice = f'qsv,child_device={get_media().render_device}'
 
   def test(self):
     self.check(
       "ffmpeg -nostats -v verbose"
-      " -init_hw_device qsv=qsv:hw_any,child_device={renderDevice}"
-      " -hwaccel qsv"
+      " -init_hw_device {hwaccel}={hwdevice}"
+      " -hwaccel {hwaccel}"
       " -f lavfi -i yuvtestsrc"
       " -f null /dev/null".format(**vars(self))
     )


### PR DESCRIPTION
QSV for the windows & linux standard init device format: 
`-init_hw_device qsv=qsv,child_device=xxx`
for the Windows the xxx is GPU order like 0,1
for the Linux the xxx is redner device like /dev/dri/renderD128

This value can recive by vaapi-fit `device` parameter

VAAPI/D3D11/DXVA2 still use init device format:
`-init_hw_device {self.hwaccel}=hw:{self.hwdevice}`

Signed-off-by: Bin Wu <bin1.wu@intel.com>