### PR TITLE
ffmpeg-qsv:Delete avc/hevc/10bit.hevc maxrate = bitrate * 1.01

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -245,7 +245,10 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
 
     elif "vbr" == self.rcmode and vars(self).get("maxframesize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
-      assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
+      if vars(self).get("maxrate", None) is not None:
+        assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
+      else:
+        assert(self.minrate * 0.75 <= bitrate_actual <= self.minrate * 1.10)
 
   def check_metrics(self):
     vars(self).update(metric = dict(type = "psnr"))

--- a/test/ffmpeg-qsv/encode/10bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/10bit/hevc.py
@@ -214,7 +214,6 @@ class vbr_lp(HEVC10EncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -213,7 +213,6 @@ class vbr_lp(AVCEncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required

--- a/test/ffmpeg-qsv/encode/hevc.py
+++ b/test/ffmpeg-qsv/encode/hevc.py
@@ -214,7 +214,6 @@ class vbr_lp(HEVC8EncoderLPTest):
       case    = case,
       fps     = fps,
       ldb     = 1, # required
-      maxrate = bitrate * 1.01,
       minrate = bitrate,
       profile = profile,
       strict  = -1, # required


### PR DESCRIPTION
When maxrate = bitrate * 1.01 is set, it will not work on hevc. maxrate = bitrate is required.
However, if ffmpeg is set to maxrate = bitrate, CBR will be called, so maxrate must not be set.
Let VPL runtime set maxrate to use VBR and maxrate=bitrate. Also modify the bitrate detection function.

Signed-off-by: Wang Hangjie <hangjiex.wang@intel.com>