### PR TITLE
caps: remove rotation and transpose filter from dxva2 caps

### DIFF
--- a/lib/caps/RKL/dxva2
+++ b/lib/caps/RKL/dxva2
@@ -56,11 +56,6 @@ caps = dict(
       ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
       ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
     ),
-    # mirroring and rotation
-    transpose   = dict(
-      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",                 "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
-    ),
     crop        = dict(
       ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
       ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],

--- a/lib/caps/TGL/dxva2
+++ b/lib/caps/TGL/dxva2
@@ -56,11 +56,6 @@ caps = dict(
       ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
       ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
     ),
-    # mirroring and rotation
-    transpose   = dict(
-      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12",                 "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
-    ),
     crop        = dict(
       ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
       ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],


### PR DESCRIPTION
These filters are not supported by d3d9. Now remove them.

Signed-off-by: Tong Wu <tong1.wu@intel.com>