### PR TITLE
Ffmpeg-vaapi: fail when av1d hw not support warning emitted

### DIFF
--- a/lib/ffmpeg/transcoderbase.py
+++ b/lib/ffmpeg/transcoderbase.py
@@ -181,6 +181,11 @@ class BaseTranscoderTest(slash.Test,BaseFormatMapper):
       "hwaccel initialisation returned error", self.output, re.MULTILINE)
     assert m is None, "Failed to use hardware decode"
 
+    m = re.search(
+      "Your platform doesn't support hardware accelerated .* decoding",
+      self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"
+
   @timefn("ffmpeg")
   def call_ffmpeg(self, iopts, oopts):
     return call(f"{exe2os('ffmpeg')}"

--- a/lib/ffmpeg/vaapi/decoder.py
+++ b/lib/ffmpeg/vaapi/decoder.py
@@ -4,6 +4,7 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+import re
 import slash
 
 from ....lib.common import get_media
@@ -16,3 +17,11 @@ class Decoder(FFDecoder):
 @slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class DecoderTest(BaseDecoderTest):
   DecoderClass = Decoder
+
+  def check_output(self):
+    super().check_output()
+
+    m = re.search(
+      "Your platform doesn't support hardware accelerated .* decoding",
+      self.output, re.MULTILINE)
+    assert m is None, "Failed to use hardware decode"


### PR DESCRIPTION
ffmpeg-vaapi reports warning for av1d hw accel:
```
[2023-01-23 17:50:13] [av1 @ 0x1698680] Your platform doesn't support hardware accelerated AV1 decoding.
[2023-01-23 17:50:13] [av1 @ 0x1698680] Failed to get pixel format.
[2023-01-23 17:50:13] [av1 @ 0x1698680] Your platform doesn't support hardware accelerated AV1 decoding.
[2023-01-23 17:50:13] [av1 @ 0x1698680] Failed to get pixel format.
[2023-01-23 17:50:13] [ivf @ 0x1697180] Stream #0: not enough frames to estimate rate; consider increasing probesize
[2023-01-23 17:50:13] [ivf @ 0x1697180] Could not find codec parameters for stream 0 (Video: av1 (Main), 1 reference frame (AV01 / 0x31305641), none(tv, left), 8192x4352 [SAR 1:1 DAR 32:17]): unspecified pixel format
```

... it appears that ffmpeg-vaapi can still decode it with hwaccel, thus the warning is erroneous.  Fail cases because this is a deceiving warning that needs to be removed.