### PR TITLE
encode: add option to skip bitrate gap check

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -239,6 +239,11 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       size_encoded = encsize,
       bitrate_actual = "{:-.2f}".format(bitrate_actual))
 
+    if "bitrate_gap" in vars(self).get("skip_checks", []):
+      if "cqp" != self.rcmode: # only warn for brc modes
+        slash.logger.warn("skipped bitrate gap check")
+      return
+
     if "cbr" == self.rcmode:
       bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
       get_media()._set_test_details(bitrate_gap = "{:.2%}".format(bitrate_gap))

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -176,6 +176,11 @@ class BaseEncoderTest(slash.Test):
       size_encoded = encsize,
       bitrate_actual = "{:-.2f}".format(bitrate_actual))
 
+    if "bitrate_gap" in vars(self).get("skip_checks", []):
+      if "cqp" != self.rcmode: # only warn for brc modes
+        slash.logger.warn("skipped bitrate gap check")
+      return
+
     if "cbr" == self.rcmode:
       bitrate_gap = abs(bitrate_actual - self.bitrate) / self.bitrate
       get_media()._set_test_details(bitrate_gap = "{:.2%}".format(bitrate_gap))


### PR DESCRIPTION
Some user-defined cases may not have enough frames to effectively achieve the desired bitrate.

For such cases, this enables the user to add
skip_checks = ['bitrate_gap'] to the case definition.

This supersedes #486 