### PR TITLE
Add gstreamer HEVC VME 12bit 420 and 422 tests

### DIFF
--- a/lib/caps/ADL/iHD
+++ b/lib/caps/ADL/iHD
@@ -37,6 +37,7 @@ caps = dict(
       features  = dict(scc = True, msp = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),

--- a/lib/caps/DG1/iHD
+++ b/lib/caps/DG1/iHD
@@ -41,6 +41,7 @@ caps = dict(
       fmts = ["P010", "Y410"],
       features  = dict(msp = True)
     ),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),

--- a/lib/caps/SG1/iHD
+++ b/lib/caps/SG1/iHD
@@ -41,6 +41,7 @@ caps = dict(
       fmts = ["P010", "Y410"],
       features  = dict(msp = False)
     ),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),

--- a/lib/caps/TGL/iHD
+++ b/lib/caps/TGL/iHD
@@ -9,6 +9,7 @@
 ###
 
 # https://github.com/intel/media-driver/blob/master/docs/media_features.md
+# https://github.com/intel/media-driver#decodingencoding-features
 caps = dict(
   decode  = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12"]),
@@ -42,6 +43,7 @@ caps = dict(
       fmts = ["P010", "Y410"],
       features  = dict(msp = True)
     ),
+    hevc_12 = dict(maxres = res8k, fmts = ["P012", "Y212"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),

--- a/lib/gstreamer/va/util.py
+++ b/lib/gstreamer/va/util.py
@@ -28,7 +28,7 @@ def get_supported_format_map():
     "Y210"  : ("y210", "Y210"),
     "Y212"  : ("y212-le", "Y212_LE"),
     "Y410"  : ("y410", "Y410"),
-    "Y412"  : ("y412", "Y412_LE"),
+    "Y412"  : ("y412-le", "Y412_LE"),
   }
 
 @memoize
@@ -81,6 +81,11 @@ def mapprofile(codec, profile):
     "hevc-10"   : {
       "main10"                : "main-10",
       "main444-10"            : "main-444-10",
+    },
+    "hevc-12"   : {
+      "main12"                : "main-12",
+      "main422-12"            : "main-422-12",
+      "main444-12"            : "main-444-12",
     },
   }.get(codec, {}).get(profile, None)
 

--- a/lib/gstreamer/vaapi/util.py
+++ b/lib/gstreamer/vaapi/util.py
@@ -29,7 +29,7 @@ def get_supported_format_map():
     "Y210"  : ("y210", "Y210"),
     "Y212"  : ("y212-le", "Y212_LE"),
     "Y410"  : ("y410", "Y410"),
-    "Y412"  : ("y412", "Y412_LE"),
+    "Y412"  : ("y412-le", "Y412_LE"),
   }
 
 @memoize

--- a/test/gst-msdk/encode/12bit/__init__.py
+++ b/test/gst-msdk/encode/12bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-msdk/encode/12bit/hevc.py
+++ b/test/gst-msdk/encode/12bit/hevc.py
@@ -1,0 +1,100 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.gstreamer.msdk.util import *
+from .....lib.gstreamer.msdk.encoder import EncoderTest
+
+spec = load_test_spec("hevc", "encode", "12bit")
+
+@slash.requires(*have_gst_element("msdkh265dec"))
+@slash.requires(*have_gst_element("msdkh265enc"))
+class HEVC12EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = "hevc-12",
+      gstdecoder    = "msdkh265dec",
+      gstencoder    = "msdkh265enc",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = False,
+    )
+
+class cqp(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+class cbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+class vbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "vbr",
+      refs      = refs,
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()

--- a/test/gst-va/encode/12bit/__init__.py
+++ b/test/gst-va/encode/12bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-va/encode/12bit/hevc.py
+++ b/test/gst-va/encode/12bit/hevc.py
@@ -1,0 +1,99 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.gstreamer.va.util import *
+from .....lib.gstreamer.va.encoder import EncoderTest
+
+spec = load_test_spec("hevc", "encode", "12bit")
+
+@slash.requires(*have_gst_element("vah265dec"))
+class HEVC12EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = "hevc-12",
+      gstdecoder    = "vah265dec",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*have_gst_element("vah265enc"))
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      gstencoder= "vah265enc",
+      lowpower  = False,
+    )
+
+class cqp(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+class cbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+class vbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "vbr",
+      refs      = refs,
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()

--- a/test/gst-vaapi/encode/12bit/__init__.py
+++ b/test/gst-vaapi/encode/12bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/gst-vaapi/encode/12bit/hevc.py
+++ b/test/gst-vaapi/encode/12bit/hevc.py
@@ -1,0 +1,99 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.gstreamer.vaapi.util import *
+from .....lib.gstreamer.vaapi.encoder import EncoderTest
+
+spec = load_test_spec("hevc", "encode", "12bit")
+
+@slash.requires(*have_gst_element("vaapih265dec"))
+@slash.requires(*have_gst_element("vaapih265enc"))
+class HEVC12EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = "hevc-12",
+      gstdecoder    = "vaapih265dec",
+      gstencoder    = "vaapih265enc",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = False,
+    )
+
+class cqp(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      case      = case,
+      gop       = gop,
+      profile   = profile,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+class cbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      profile   = profile,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+class vbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes   = bframes,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      gop       = gop,
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      profile   = profile,
+      quality   = quality,
+      rcmode    = "vbr",
+      refs      = refs,
+      slices    = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()


### PR DESCRIPTION
TGL, ADL, DG1, and SG1 support HEVC VME 12bit 4:2:0 and 4:2:2 encoding.

gst-va supports 4:2:0 and 4:2:2 12bit profiles.
gst-vaapi and gst-msdk only support 4:2:0 12bit profiles.