### PR TITLE
ffmpeg: add HEVCe VME 12bit tests

### DIFF
--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -60,7 +60,8 @@ def mapprofile(codec, profile):
       "main444-10" : "rext"
     },
     "hevc-12" : {
-      "main12"                : "main-12",
+      "main12"      : "rext",
+      "main422-12"  : "rext",
     },
     "av1-8"   : {
       "profile0"  : "main",

--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -57,7 +57,8 @@ def mapprofile(codec, profile):
       "main444-10"            : "rext",
     },
     "hevc-12" : {
-      "main12"                : "main-12",
+      "main12"                : "rext",
+      "main422-12"            : "rext",
     },
     "jpeg"     : {
       "baseline"              : "baseline",

--- a/test/ffmpeg-qsv/encode/12bit/__init__.py
+++ b/test/ffmpeg-qsv/encode/12bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-qsv/encode/12bit/hevc.py
+++ b/test/ffmpeg-qsv/encode/12bit/hevc.py
@@ -1,0 +1,97 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.qsv.util import *
+from .....lib.ffmpeg.qsv.encoder import EncoderTest
+
+spec = load_test_spec("hevc", "encode", "12bit")
+
+@slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+class HEVC12EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec     = "hevc-12",
+      ffencoder = "hevc_qsv",
+      ffdecoder = "hevc_qsv",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = 0,
+    )
+
+class cqp(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      case    = case,
+      gop     = gop,
+      profile = profile,
+      qp      = qp,
+      quality = quality,
+      rcmode  = "cqp",
+      slices  = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+class cbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      minrate = bitrate,
+      maxrate = bitrate,
+      profile = profile,
+      rcmode  = "cbr",
+      slices  = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+class vbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      maxrate = bitrate * 2, # target percentage 50%
+      minrate = bitrate,
+      profile = profile,
+      quality = quality,
+      rcmode  = "vbr",
+      refs    = refs,
+      slices  = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()

--- a/test/ffmpeg-vaapi/encode/12bit/__init__.py
+++ b/test/ffmpeg-vaapi/encode/12bit/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/test/ffmpeg-vaapi/encode/12bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/12bit/hevc.py
@@ -1,0 +1,101 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from .....lib import *
+from .....lib.ffmpeg.vaapi.util import *
+from .....lib.ffmpeg.vaapi.encoder import EncoderTest
+
+spec = load_test_spec("hevc", "encode", "12bit")
+
+@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+class HEVC12EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec   = "hevc-12",
+      ffenc   = "hevc_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+  def get_vaapi_profile(self):
+    return {
+      "main12"      : "VAProfileHEVCMain12",
+      "main422-12"  : "VAProfileHEVCMain422_12",
+    }[self.profile]
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = 0,
+    )
+
+class cqp(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      case    = case,
+      gop     = gop,
+      profile = profile,
+      qp      = qp,
+      quality = quality,
+      rcmode  = "cqp",
+      slices  = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cqp_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, qp, quality, profile):
+    self.init(spec, case, gop, slices, bframes, qp, quality, profile)
+    self.encode()
+
+class cbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case = case,
+      fps = fps,
+      gop = gop,
+      minrate = bitrate,
+      maxrate = bitrate,
+      profile = profile,
+      rcmode = "cbr",
+      slices = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_cbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, profile)
+    self.encode()
+
+class vbr(HEVC12EncoderTest):
+  def init(self, tspec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bframes = bframes,
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      maxrate = bitrate * 2, # target percentage 50%
+      minrate = bitrate,
+      profile = profile,
+      quality = quality,
+      rcmode  = "vbr",
+      refs    = refs,
+      slices  = slices,
+    )
+
+  @slash.parametrize(*gen_hevc_vbr_parameters(spec, ['main12']))
+  def test(self, case, gop, slices, bframes, bitrate, fps, quality, refs, profile):
+    self.init(spec, case, gop, slices, bframes, bitrate, fps, quality, refs, profile)
+    self.encode()


### PR DESCRIPTION
HEVCe VME 12bit 4:2:0 and 4:2:2 support