### PR TITLE
vpp/dn: normalize vaapi vpp dn levels

### DIFF
--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -9,7 +9,7 @@ from .util import *
 
 import slash
 
-from ....lib.common import get_media, mapRangeInt, mapRangeWithDefault
+from ....lib.common import get_media, mapRange, mapRangeInt, mapRangeWithDefault
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel
 from ....lib.ffmpeg.vppbase import BaseVppTest
 
@@ -47,7 +47,9 @@ class VppTest(BaseVppTest):
       if self.vpp_op in procamp:
         self.mlevel = mapRangeWithDefault(
           self.level, [0.0, 50.0, 100.0], procamp[self.vpp_op])
-      elif self.vpp_op in ["denoise", "sharpen"]:
+      elif self.vpp_op in ["denoise"]:
+        self.mlevel = mapRange(self.level, [0.0, 100.0], [0.0, 64.0])
+      elif self.vpp_op in ["sharpen"]:
         self.mlevel = mapRangeInt(self.level, [0, 100], [0, 64])
 
       if self.vpp_op not in ["csc"]:

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -4,6 +4,7 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+import math
 import os
 import slash
 
@@ -45,7 +46,8 @@ class VppTest(BaseVppTest):
       )
       opts += " {vpp_op}={mlevel}"
     elif self.vpp_op in ["denoise"]:
-      self.mlevel = mapRange(self.level, [0, 100], [0.0, 1.0])
+      ilevel = math.floor(mapRange(self.level, [0, 100], [0.0, 64.0]) + 0.5)
+      self.mlevel = mapRange(ilevel, [0, 64], [0.0, 1.0])
       opts += " denoise={mlevel}"
     elif self.vpp_op in ["sharpen"]:
       self.mlevel = mapRange(self.level, [0, 100], [-1.0, 1.0])


### PR DESCRIPTION
Normalize test framework DN levels for ffmpeg-vaapi and gst-vaapi so the specified user config vpp level ultimately maps to the same value that middleware
sends to the libva driver.

The mfx middleware plugins are already specified in the same range as the test framework.

This will enable DN refs to be shared across components.

cc: @tong1wu 