### PR TITLE
gst/decode: link avvideocompare to fakevideosink

### DIFF
--- a/lib/gstreamer/decoderbase.py
+++ b/lib/gstreamer/decoderbase.py
@@ -66,7 +66,8 @@ class Decoder(PropertyHandler):
       fps = gst_discover_fps(self.ossource)
       return (
         f"avvideocompare method={mtype} stats-file={self.osstatsfile} name=cmp"
-        f" ! fakesink filesrc location={self.osreference} num-buffers={self.frames}"
+        f" ! fakevideosink qos=false num-buffers={self.frames} max-lateness=-1"
+        f" filesrc location={self.osreference} num-buffers={self.frames}"
         f" ! rawvideoparse format={self.pformat} width={self.width}"
         f" height={self.height} framerate={fps} ! videoconvert chroma-mode=none"
         f" dither=0 ! video/x-raw,format={self.format} ! cmp."


### PR DESCRIPTION
The avvideocompare does not work properly if the data is not aligned.  To force alignment, downstream needs to advertise video meta.  Thus, link avvideocompare to fakevideosink to inject video meta into the pipeline.