### PR TITLE
Gst-va add av1 8bit encode support

### DIFF
--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -29,6 +29,14 @@ class Encoder(GstEncoder):
     return f" rate-control={super().rcmode}"
 
   @property
+  def bframes(self):
+    def inner(bframes):
+      if self.codec in ["av1-8"]:
+        return " gf-group-size={bframes}"
+      return f" b-frames={bframes}"
+    return self.ifprop("bframes", inner)
+
+  @property
   def qp(self):
     def inner(qp):
       if self.codec in ["mpeg2"]:
@@ -36,6 +44,8 @@ class Encoder(GstEncoder):
         return f" qpi={mqp} qpp={mqp} qpb={mqp}"
       if self.codec in ["vp8", "vp9"]:
         return f" qpi={qp}"
+      if self.codec in ["av1-8"]:
+        return f" max-qp={qp} min-qp={qp} qp={qp}"
       return f" qpi={qp} qpp={qp} qpb={qp}"
     return self.ifprop("qp", inner)
 
@@ -72,7 +82,6 @@ class Encoder(GstEncoder):
 
   gop     = property(lambda s: s.ifprop("gop", " key-int-max={gop}"))
   slices  = property(lambda s: s.ifprop("slices", " num-slices={slices}"))
-  bframes = property(lambda s: s.ifprop("bframes", " b-frames={bframes}"))
   minrate = property(lambda s: s.ifprop("minrate", " bitrate={minrate}"))
   refmode = property(lambda s: s.ifprop("refmode", " ref-pic-mode={refmode}"))
   refs    = property(lambda s: s.ifprop("refs", " ref-frames={refs}"))

--- a/lib/gstreamer/va/util.py
+++ b/lib/gstreamer/va/util.py
@@ -87,6 +87,9 @@ def mapprofile(codec, profile):
       "main422-12"            : "main-422-12",
       "main444-12"            : "main-444-12",
     },
+    "av1-8"     : {
+      "profile0"               : "main",
+    },
   }.get(codec, {}).get(profile, None)
 
 def load_test_spec(*ctx):

--- a/test/gst-va/encode/av1.py
+++ b/test/gst-va/encode/av1.py
@@ -1,0 +1,125 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.gstreamer.va.util import *
+from ....lib.gstreamer.va.encoder import EncoderTest
+
+spec = load_test_spec("av1", "encode", "8bit")
+spec_r2r  = load_test_spec("av1", "encode", "8bit", "r2r")
+
+@slash.requires(*have_gst_element("vaav1dec"))
+class AV1EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = "av1-8",
+      gstdecoder    = "vaav1dec",
+      gstmediatype  = "video/x-av1",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+      gstparser     = "av1parse",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*have_gst_element("vaav1lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "av1_8"))
+class AV1EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_8"),
+      gstencoder    = "vaav1lpenc",
+      lowpower  = True,
+    )
+
+class cqp_lp(AV1EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = gop,
+      bframes   = bframes,
+      qp        = qp,
+      rcmode    = "cqp",
+      quality   = quality,
+      profile   = profile,
+      tilerows  = tilerows,
+      tilecols  = tilecols,
+    )
+
+  @slash.parametrize(*gen_av1_cqp_lp_parameters(spec))
+  def test(self, case, gop, bframes, tilecols, tilerows, qp, quality, profile):
+    self.init(spec, case, gop, bframes, tilecols, tilerows, qp, quality, profile)
+    self.encode()
+
+  @slash.parametrize(*gen_av1_cqp_lp_parameters(spec_r2r))
+  def test_r2r(self, case, gop, bframes, tilecols, tilerows, qp, quality, profile):
+    self.init(spec_r2r, case, gop, bframes, tilecols, tilerows, qp, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+
+class cbr_lp(AV1EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      maxrate = bitrate,
+      minrate = bitrate,
+      profile = profile,
+      rcmode  = "cbr",
+      tilerows  = tilerows,
+      tilecols  = tilecols,
+      quality   = quality,
+      bframes   = bframes,
+    )
+
+  @slash.parametrize(*gen_av1_cbr_lp_parameters(spec))
+  def test(self, case, gop, bframes, tilecols, tilerows, bitrate, quality, fps, profile):
+    self.init(spec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile)
+    self.encode()
+
+  @slash.parametrize(*gen_av1_cbr_lp_parameters(spec_r2r))
+  def test_r2r(self, case, gop, bframes, tilecols, tilerows, bitrate, quality, fps, profile):
+    self.init(spec_r2r, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class vbr_lp(AV1EncoderLPTest):
+  def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate = bitrate,
+      case    = case,
+      fps     = fps,
+      gop     = gop,
+      # target percentage 50%
+      maxrate = bitrate * 2,
+      minrate = bitrate,
+      profile = profile,
+      rcmode  = "vbr",
+      tilerows  = tilerows,
+      tilecols  = tilecols,
+      quality   = quality,
+      bframes   = bframes,
+    )
+
+  @slash.parametrize(*gen_av1_vbr_lp_parameters(spec))
+  def test(self, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
+    self.init(spec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile)
+    self.encode()
+
+  @slash.parametrize(*gen_av1_vbr_lp_parameters(spec_r2r))
+  def test_r2r(self, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
+    self.init(spec_r2r, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile)
+    vars(self).setdefault("r2r", 5)
+    self.encode()


### PR DESCRIPTION
1, map gf-group-size to bframes, because There is no B frame in AV1 spec. gst-va use gf-group-size to specify golden frame group, which is like the B frames within I/P from Junyan's input
2, add av1 8bit encode test implenent