### PR TITLE
ffmpeg: no dump for inline psnr/ssim

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -81,8 +81,7 @@ class Decoder(PropertyHandler, BaseFormatMapper):
         f" -f rawvideo -pix_fmt {self.format} -s:v {self.width}x{self.height}"
         f" -r:v {fps} -i {self.osreference}"
         f" -lavfi \"{self.scale_range},{mtype}=f=\\'{self.osstatsfile}\\':shortest=1\""
-        f" -c:v rawvideo -pix_fmt {self.format} -fps_mode passthrough"
-        f" -autoscale 0 -vframes {self.frames} -y {self.ffoutput}"
+        f" -fps_mode passthrough -autoscale 0 -vframes {self.frames} -f null -"
       )
 
     return call(


### PR DESCRIPTION
When doing inline psnr/ssim, the raw conversion and output file dump is unnecessary and only adds runtime overhead.

Remove the conversion and file dump to improve inline psnr/ssim speed.