### PR TITLE
ffmpeg/qsv/vpp: add h2s tonemap tests

### DIFF
--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -55,10 +55,12 @@ class VppTest(BaseVppTest):
         self.mlevel = mapRangeWithDefault(
           self.level, [0.0, 50.0, 100.0], procamp[self.vpp_op])
 
-      if self.vpp_op not in ["csc"]:
+      if self.vpp_op not in ["csc", "tonemap"]:
         vpfilter.append("format={ihwformat}|qsv")
 
-      vpfilter.append("hwupload=extra_hw_frames=16")
+      if self.vpp_op not in ["tonemap"]:
+        vpfilter.append("hwupload=extra_hw_frames=16")
+
       vpfilter.append(
         dict(
           brightness  = "vpp_qsv=procamp=1:brightness={mlevel}",
@@ -72,6 +74,7 @@ class VppTest(BaseVppTest):
           deinterlace = "vpp_qsv=deinterlace={mmethod}",
           csc         = "vpp_qsv=format={ohwformat}",
           transpose   = "vpp_qsv=transpose={direction}",
+          tonemap     = "vpp_qsv=tonemap=1:format={ohwformat}",
         )[self.vpp_op]
       )
 

--- a/test/ffmpeg-qsv/vpp/tonemap.py
+++ b/test/ffmpeg-qsv/vpp/tonemap.py
@@ -1,0 +1,37 @@
+###
+### Copyright (C) 2018-2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.ffmpeg.qsv.util import *
+from ....lib.ffmpeg.qsv.vpp import VppTest
+
+@slash.requires(*platform.have_caps("vpp", "tonemap"))
+class TonemapTest(VppTest):
+  def before(self):
+    vars(self).update(
+      vpp_op  = "tonemap",
+    )
+    super().before()
+
+  def init(self, tspec, case, mode, csc):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(case = case, mode = mode, csc = csc)
+    self.caps = platform.get_caps("vpp", "tonemap", mode)
+
+spec_hevc = load_test_spec("vpp", "tonemap", "hevc_10")
+@slash.requires(*platform.have_caps("decode", "hevc_10"))
+@slash.requires(*have_ffmpeg_filter_options("vpp_qsv", "tonemap", "format"))
+@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
+class hevc(TonemapTest):
+  def before(self):
+    self.ffdecoder = "hevc_qsv"
+    super().before()
+
+  @slash.requires(*platform.have_caps("vpp", "tonemap", "h2s"))
+  @slash.parametrize(*gen_vpp_h2s_parameters(spec_hevc))
+  def test_h2s(self, case, csc):
+    self.init(spec_hevc, case, "h2s", csc)
+    self.vpp()


### PR DESCRIPTION
This is used to check HDR-to-SDR added in https://github.com/intel-media-ci/ffmpeg/pull/518