### PR TITLE
gst-msdk: Add surface sharing cases between va and msdk

### DIFF
--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -21,10 +21,12 @@ class TranscoderTest(BaseTranscoderTest):
       "avc" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("openh264dec"), "h264parse ! openh264dec ! videoconvert"),
         hw = (platform.get_caps("decode", "avc"), have_gst_element("msdkh264dec"), "h264parse ! msdkh264dec"),
+        va_hw = (platform.get_caps("decode", "avc"), have_gst_element("vah264dec"), "h264parse ! vah264dec"),
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("libde265dec"), "h265parse ! libde265dec ! videoconvert"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("msdkh265dec"), "h265parse ! msdkh265dec"),
+        va_hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vah265dec"), "h265parse ! vah265dec"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("mpeg2dec"), "mpegvideoparse ! mpeg2dec ! videoconvert"),

--- a/lib/gstreamer/transcoderbase.py
+++ b/lib/gstreamer/transcoderbase.py
@@ -54,7 +54,7 @@ class BaseTranscoderTest(slash.Test):
 
   def validate_caps(self):
     assert len(self.outputs), "Invalid test case specification, outputs data empty"
-    assert self.mode in ["sw", "hw"], "Invalid test case specification as mode type not valid"
+    assert self.mode in ["sw", "hw", "va_hw"], "Invalid test case specification as mode type not valid"
 
     icaps, ireq, _ = self.get_requirements_data("decode", self.codec, self.mode)
     requires = [ireq,]
@@ -108,7 +108,8 @@ class BaseTranscoderTest(slash.Test):
     self.ossource = filepath2os(self.source)
     opts =  "filesrc location={ossource}"
     opts += " ! " + self.get_decoder(self.codec, self.mode)
-    opts += " ! video/x-raw,format={format}"
+    if self.mode != "va_hw":
+      opts += " ! video/x-raw,format={format}"
     return opts.format(**vars(self))
 
   def gen_output_opts(self):
@@ -141,6 +142,8 @@ class BaseTranscoderTest(slash.Test):
       "src_{case}.yuv".format(**vars(self)))
     self.ossrcyuv = filepath2os(self.srcyuv)
     opts += " ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0"
+    if self.mode == "va_hw":
+      opts += " ! vapostproc ! video/x-raw,format={format}"
     opts += " ! checksumsink2 file-checksum=false qos=false eos-after={frames}"
     opts += " frame-checksum=false plane-checksum=false dump-output=true"
     opts += " dump-location={ossrcyuv}"


### PR DESCRIPTION
These cases are about implicit va surface sharing between va and msdk, i.e. "vah264dec ! msdkh264enc ! h264parse", in which vah264dec and msdkh264enc sharing va surface via negotiated va memory caps.