### PR TITLE
vpp/sharpen: normalize vpp sharpen levels

### DIFF
--- a/lib/caps/DG2/iHD
+++ b/lib/caps/DG2/iHD
@@ -63,8 +63,8 @@ caps = dict(
       ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     sharpen     = dict(
-      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
-      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+      ifmts = ["NV12", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
     ),
     deinterlace = dict(
       bob             = dict(

--- a/lib/ffmpeg/qsv/vpp.py
+++ b/lib/ffmpeg/qsv/vpp.py
@@ -10,6 +10,7 @@ from ....lib.common import get_media, mapRangeInt, mapRangeWithDefault
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
 from ....lib.ffmpeg.util import have_ffmpeg_hwaccel, have_ffmpeg_filter
 from ....lib.ffmpeg.vppbase import BaseVppTest
+from ....lib.mfx.util import mapsharp
 
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(*have_ffmpeg_filter("vpp_qsv"))
@@ -57,6 +58,8 @@ class VppTest(BaseVppTest):
       if self.vpp_op in procamp:
         self.mlevel = mapRangeWithDefault(
           self.level, [0.0, 50.0, 100.0], procamp[self.vpp_op])
+      elif self.vpp_op in ["sharpen"]:
+        self.mlevel = mapsharp(self.level)
 
       if self.vpp_op not in ["csc", "tonemap", "range"]:
         vpfilter.append("format={ihwformat}|qsv")
@@ -73,7 +76,7 @@ class VppTest(BaseVppTest):
           denoise     = "vpp_qsv=denoise={level}",
           scale       = "vpp_qsv=w={scale_width}:h={scale_height}",
           scale_qsv   = "scale_qsv=w={scale_width}:h={scale_height}",
-          sharpen     = "vpp_qsv=detail={level}",
+          sharpen     = "vpp_qsv=detail={mlevel}",
           deinterlace = "vpp_qsv=deinterlace={mmethod}",
           csc         = "vpp_qsv=format={ohwformat}",
           transpose   = "vpp_qsv=transpose={direction}",

--- a/lib/ffmpeg/vaapi/vpp.py
+++ b/lib/ffmpeg/vaapi/vpp.py
@@ -53,7 +53,8 @@ class VppTest(BaseVppTest):
       elif self.vpp_op in ["denoise"]:
         self.mlevel = mapRange(self.level, [0.0, 100.0], [0.0, 64.0])
       elif self.vpp_op in ["sharpen"]:
-        self.mlevel = mapRangeInt(self.level, [0, 100], [0, 64])
+        self.mlevel = int(mapRangeWithDefault(
+          self.level, [0, 50, 100], [0, 44, 64]))
 
       if self.vpp_op not in ["csc", "tonemap", "range"]:
         vpfilter.append("format={ihwformat}|vaapi")

--- a/lib/gstreamer/msdk/vpp.py
+++ b/lib/gstreamer/msdk/vpp.py
@@ -12,6 +12,7 @@ from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.msdk.util import using_compatible_driver
 from ....lib.gstreamer.msdk.util import map_best_hw_format, mapformat, mapformatu
 from ....lib.common import get_media, mapRange, mapRangeWithDefault
+from ....lib.mfx.util import mapsharp
 
 @slash.requires(*have_gst_element("msdk"))
 @slash.requires(*have_gst_element("msdkvpp"))
@@ -56,7 +57,8 @@ class VppTest(BaseVppTest):
     elif self.vpp_op in ["denoise"]:
       opts += " denoise={level}"
     elif self.vpp_op in ["sharpen"]:
-      opts += " detail={level}"
+      self.mlevel = mapsharp(self.level)
+      opts += " detail={mlevel}"
     elif self.vpp_op in ["transpose"]:
       opts += " video-direction={direction}"
     elif self.vpp_op in ["crop"]:

--- a/lib/gstreamer/va/vpp.py
+++ b/lib/gstreamer/va/vpp.py
@@ -48,11 +48,16 @@ class VppTest(BaseVppTest):
         self.level, [0.0, 50.0, 100.0], procamp[self.vpp_op]
       )
       opts += " {vpp_op}={mlevel}"
-    elif self.vpp_op in ["denoise", "sharpen"]:
+    elif self.vpp_op in ["denoise"]:
       oprange = dict(
         i965 = [0.0, 1.0],
       ).get(get_media()._get_driver_name(), [0.0, 64.0])
       self.mlevel = mapRange(self.level, [0, 100], oprange)
+      opts += " {vpp_op}={mlevel}"
+    elif self.vpp_op in ["sharpen"]:
+      self.mlevel = mapRangeWithDefault(
+        self.level, [0.0, 50.0, 100.0], [0.0, 44.0, 64.0]
+      )
       opts += " {vpp_op}={mlevel}"
     elif self.vpp_op in ["transpose"]:
       opts += " video-direction={direction}"

--- a/lib/gstreamer/vaapi/vpp.py
+++ b/lib/gstreamer/vaapi/vpp.py
@@ -50,7 +50,9 @@ class VppTest(BaseVppTest):
       self.mlevel = mapRange(ilevel, [0, 64], [0.0, 1.0])
       opts += " denoise={mlevel}"
     elif self.vpp_op in ["sharpen"]:
-      self.mlevel = mapRange(self.level, [0, 100], [-1.0, 1.0])
+      self.mlevel = mapRangeWithDefault(
+        self.level, [0.0, 50.0, 100.0], [-1.0, 0.0, 1.0]
+      )
       opts += " sharpen={mlevel}"
     elif self.vpp_op in ["deinterlace"]:
       opts += " deinterlace-mode=1 deinterlace-method={mmethod}"

--- a/lib/mfx/util.py
+++ b/lib/mfx/util.py
@@ -1,0 +1,35 @@
+###
+### Copyright (C) 2018-2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ...lib.common import memoize
+
+@memoize
+def mapsharp(level):
+  ###
+  # MSDK uses the floor function to map the VPP scale range into the vaapi
+  # driver VPP scale range.  The floor function is not invertible and therefore
+  # we can't just reverse MSDK's mapping function with a simple mathematical
+  # equation.  Additionally, MSDK does not take the default value (passthrough)
+  # into account.  And, thus, we map 50 -> 0 directly to achieve normalization
+  # at the expected passthrough/default level.
+  #
+  # This lookup table specifies the MSDK value to use from our normalized range
+  # to produce the same result as if we were to map our normalized range
+  # directly to the iHD driver range (i.e. [0, 50, 100] -> [0, 44, 64]).
+  ###
+  return {
+                                        5: 6,  6: 8,  7: 9,  8:11,  9:11,
+    10:12, 11:14, 12:15, 13:17, 14:18, 15:20, 16:22, 17:22, 18:23, 19:25,
+    20:26, 21:28, 22:29, 23:31, 24:33, 25:34, 26:34, 27:36, 28:37, 29:39,
+    30:40, 31:42, 32:43, 33:45, 34:45, 35:47, 36:48, 37:50, 38:51, 39:53,
+    40:54, 41:56, 42:56, 43:58, 44:59, 45:61, 46:62, 47:64, 48:65, 49:67,
+    50: 0, 51:68, 52:68, 53:70, 54:70, 55:72, 56:72, 57:72, 58:73, 59:73,
+    60:75, 61:75, 62:75, 63:76, 64:76, 65:78, 66:78, 67:78, 68:79, 69:79,
+    70:81, 71:81, 72:81, 73:83, 74:83, 75:84, 76:84, 77:84, 78:86, 79:86,
+    80:87, 81:87, 82:87, 83:89, 84:89, 85:90, 86:90, 87:90, 88:92, 89:92,
+    90:93, 91:93, 92:93, 93:95, 94:95, 95:97, 96:97, 97:97, 98:98, 99:98,
+    100:98,
+  }.get(level, level)


### PR DESCRIPTION
Normalize the test framework sharpen levels so the specified user config vpp level ultimately maps to the same value that middleware sends to the libva driver.

This will enable sharpen refs to be shared across components.

For ffmpeg-vaapi, the passthrough/default level currently fails until the following upstream patches are finished:

  https://patchwork.ffmpeg.org/project/ffmpeg/list/?series=9025