### PR TITLE
lib/ffmpeg/transcoderbase: show all frame's HDR info

### DIFF
--- a/lib/ffmpeg/transcoderbase.py
+++ b/lib/ffmpeg/transcoderbase.py
@@ -271,7 +271,7 @@ class BaseTranscoderTest(slash.Test,BaseFormatMapper):
 
   def get_hdr_info(self, osfile):
     output = call(
-      f"{exe2os('ffmpeg')} -i {osfile}"
+      f"{exe2os('ffmpeg')} -an -i {osfile}"
       f" -vf 'showinfo' -vframes 1 -f null -"
     )
 


### PR DESCRIPTION
In case of input has audio stream which will influence frame number of output video. The other reason is that vframes for filter showinfo is not accurate. For example, when use 'vframes 1', the output of showinfo will be 2 frames' info. Use all frame number to make sure the otuput will be same for diffferent case.