### PR TITLE
[i965] disable avc lp bframes support

### DIFF
--- a/lib/caps/APL/i965
+++ b/lib/caps/APL/i965
@@ -25,7 +25,7 @@ caps = dict(
     vp8     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False),
+    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False, bframes = False),
     jpeg    = dict(maxres = res8k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vpp    = dict(

--- a/lib/caps/CFL/i965
+++ b/lib/caps/CFL/i965
@@ -30,7 +30,7 @@ caps = dict(
     vp9_10  = dict(maxres = res4k, fmts = ["P010"]),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False),
+    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False, bframes = False),
     jpeg    = dict(maxres = res8k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vpp    = dict(

--- a/lib/caps/KBL/i965
+++ b/lib/caps/KBL/i965
@@ -30,7 +30,7 @@ caps = dict(
     vp9_10  = dict(maxres = res4k, fmts = ["P010"]),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False),
+    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False, bframes = False),
     jpeg    = dict(maxres = res8k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vpp    = dict(

--- a/lib/caps/SKL/i965
+++ b/lib/caps/SKL/i965
@@ -24,7 +24,7 @@ caps = dict(
     vp8     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False),
+    avc     = dict(maxres = res4k, fmts = ["NV12", "YV12", "I420", "YUY2"], multislice = False, cbr = False, vbr = False, bframes = False),
     jpeg    = dict(maxres = res8k, fmts = ["NV12", "YV12", "I420", "YUY2"]),
   ),
   vpp    = dict(


### PR DESCRIPTION
disable avc lp bframes support on APL, CFL, KBL
and SKL which has avc vdenc support platforms
for i965