### PR TITLE
[win] disable avc lp bframes for windows on TGL/RKL

### DIFF
--- a/lib/caps/RKL/d3d11
+++ b/lib/caps/RKL/d3d11
@@ -42,7 +42,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/RKL/d3d12
+++ b/lib/caps/RKL/d3d12
@@ -42,7 +42,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/RKL/dxva2
+++ b/lib/caps/RKL/dxva2
@@ -39,7 +39,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/RKL/vaon12
+++ b/lib/caps/RKL/vaon12
@@ -42,7 +42,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/TGL/d3d11
+++ b/lib/caps/TGL/d3d11
@@ -42,7 +42,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/TGL/d3d12
+++ b/lib/caps/TGL/d3d12
@@ -43,6 +43,7 @@ caps = dict(
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,

--- a/lib/caps/TGL/dxva2
+++ b/lib/caps/TGL/dxva2
@@ -39,7 +39,7 @@ caps = dict(
     ),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"], bframes = False),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
     hevc_8  = dict(
       maxres    = res8k,


### PR DESCRIPTION
disable avc lp bframes for wind on TGL/RKL
d3d11, d3d12, dxva vaon