### PR TITLE
Add Trendline Model Support for AVCe

### DIFF
--- a/lib/baseline.py
+++ b/lib/baseline.py
@@ -40,6 +40,13 @@ class Baseline:
         with open(self.filename, "r") as fd:
           self.references = json.load(fd)
 
+  def lookup(self, key, *context):
+    reference = self.references.get(key, None)
+    for c in get_media()._expand_context(context):
+      if reference is None: break
+      reference = reference.get(c, None)
+    return reference
+
   def __get_reference(self, context = []):
     addr = get_media()._get_ref_addr(context)
     reference = self.references.setdefault(addr, dict())

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -264,11 +264,17 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
         assert(self.minrate * 0.75 <= bitrate_actual <= self.minrate * 1.10)
 
   def check_metrics(self):
-    vars(self).update(metric = dict(type = "psnr"))
+    vars(self).setdefault("metric", dict(type = "psnr"))
+
     self.decoder.update(source = self.encoder.encoded, metric = self.metric)
     self.decoder.decode()
 
     metric = metrics2.factory.create(**vars(self))
+    metric.update(
+      filecoded = self.encoder.encoded,
+      filetest  = self.decoder.decoded,
+      filetrue  = self.source,
+    )
     metric.actual = parse_psnr_stats(self.decoder.statsfile, self.frames)
 
     metric.check()

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -164,12 +164,17 @@ class BaseEncoderTest(slash.Test):
     self.check_metrics()
 
   def check_metrics(self):
-    vars(self).update(metric = dict(type = "psnr"))
+    vars(self).setdefault("metric", dict(type = "psnr"))
+
     self.decoder.update(source = self.encoder.encoded, metric = self.metric)
     self.decoder.decode()
 
     metric = metrics2.factory.create(**vars(self))
-    metric.update(filetest = self.decoder.decoded, reference = self.source)
+    metric.update(
+      filecoded = self.encoder.encoded,
+      filetest  = self.decoder.decoded,
+      filetrue  = self.source,
+    )
     if os.path.exists(self.decoder.statsfile):
       metric.actual = parse_psnr_stats(self.decoder.statsfile, self.frames)
     metric.check()

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/model/encode/__init__.py
+++ b/model/encode/__init__.py
@@ -1,0 +1,5 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###

--- a/model/encode/avc.py
+++ b/model/encode/avc.py
@@ -1,0 +1,28 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+import slash
+
+from ...lib.ffmpeg.qsv.util import *
+from ...lib.ffmpeg.qsv.encoder import AVCEncoderTest
+from .util import TrendModelMixin
+
+spec = load_test_spec("avc", "encode")
+
+class trend(AVCEncoderTest, TrendModelMixin):
+  # MRO overrides
+  check_metrics = TrendModelMixin.check_metrics
+
+  def parse_psnr(self):
+    if os.path.exists(self.decoder.statsfile):
+      return parse_psnr_stats(self.decoder.statsfile, self.frames)
+
+  @slash.parametrize(*TrendModelMixin.filter_spec(spec))
+  def test(self, case):
+    vars(self).update(case = case)
+    vars(self).update(spec[case].copy())
+    self.fit()

--- a/model/encode/util.py
+++ b/model/encode/util.py
@@ -1,0 +1,118 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ...lib import *
+from ...lib import metrics2
+from ...lib.metrics2.psnr import trend_models
+
+import itertools
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+from scipy.optimize import curve_fit
+
+plt.rcParams['figure.figsize'] = [25, 15]
+
+class TrendModelMixin:
+  @classmethod
+  def filter_spec(cls, spec):
+    def has_trend_metric(val):
+      metric = val.get("metric", dict())
+      return (
+        metric.get("type", None) == "psnr" and
+        metric.get("mode", None) == "trendline"
+      )
+    return "case", [k for k,v in spec.items() if has_trend_metric(v)]
+
+  def initvars(self, default_profile):
+    vars(self).update(
+      rcmode  = "cqp",
+      bframes = 2,
+      slices  = 1,
+      quality = 4,
+    )
+    vars(self).setdefault("profile", default_profile)
+
+  def fit(self):
+    self.initvars("main")
+
+    platform = get_media()._get_platform_name()
+    tolerance = vars(self).get("metric", dict()).get("tolerance", 5.0)
+    qps = [1, 2, 4, 7, 10, 13, 16, 23, 31, 40, 42, 45, 48, 49, 51]
+
+    for gop, bf, tu in itertools.product([1, 30], [2], [4]):
+      get_media()._set_test_details(gop = gop, bframes = bf, tu = tu)
+      vars(self).update(gop = gop, bframes = bf, quality = tu)
+
+      self.xdata = list()
+      self.ydata = list()
+
+      for qp in qps:
+        get_media()._set_test_details(qp = qp)
+        vars(self).update(qp = qp)
+        self.encode()
+
+      label = f"{platform}:{self.codec}:{self.rcmode}:{self.case}:gop={gop}:bf={bf}:tu={tu}"
+
+      plt.ylabel("PSNR")
+      plt.xlabel("Compression Ratio (ln x)")
+
+      plt.scatter(self.xdata, self.ydata, label = label)
+
+      for fn in ["powernc", "powerc", "powern", "power"]:
+        try:
+          popt, pcov = curve_fit(trend_models[fn], self.xdata, self.ydata)
+        except:
+          continue
+
+        ydata = np.array(self.ydata)
+        xdata = np.array(self.xdata)
+
+        # calculate R-squared
+        residuals = ydata - trend_models[fn](xdata, *popt)
+        ss_res = np.sum(residuals**2)
+        ss_tot = np.sum((ydata - np.mean(ydata))**2)
+        rsq = 1 - (ss_res / ss_tot)
+
+        if rsq < 0.9: continue # not a very good fit
+
+        get_media().baseline.update_reference(
+          fx = fn, popt = list(popt), rsq = rsq,
+          context = ["key:model.encode", f"{self.codec}", f"gop.{gop}"],
+        )
+
+        power_x = np.linspace(min(self.xdata), max(self.xdata), 100)
+        power_y = trend_models[fn](power_x, *popt)
+        power_y = [max(20, p - tolerance) for p in power_y]
+        sopt = tuple(float(f"{p:.2f}") for p in popt)
+
+        plt.plot(
+          power_x, power_y,
+          label = f"{label}.{fn}{sopt}(r2={rsq:.4f}, T={tolerance})"
+        )
+
+        break # only need one trend model function
+
+    plt.ylim([15, 100])
+    plt.legend()
+    plt.savefig(get_media()._test_artifact2("svg"))
+    # plt.show()
+    plt.clf()
+
+  def check_metrics(self):
+    self.decoder.update(source = self.encoder.encoded, metric = self.metric)
+    self.decoder.decode()
+
+    metric = metrics2.factory.create(**vars(self))
+    metric.update(
+      filecoded = self.encoder.encoded,
+      filetrue  = self.source,
+      filetest  = self.decoder.decoded,
+    )
+    metric.actual = self.parse_psnr()
+    get_media()._set_test_details(psnr = metric.actual, apsnr = metric.average)
+    self.xdata.append(metric.logratio)
+    self.ydata.append(metric.average)

--- a/test/ffmpeg-qsv/encode/avc.py
+++ b/test/ffmpeg-qsv/encode/avc.py
@@ -6,42 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
-from ....lib.ffmpeg.qsv.encoder import EncoderTest
+from ....lib.ffmpeg.qsv.encoder import AVCEncoderTest, AVCEncoderLPTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("h264_qsv"))
-@slash.requires(*have_ffmpeg_decoder("h264_qsv"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = "avc",
-      ffencoder = "h264_qsv",
-      ffdecoder = "h264_qsv",
-    )
-
-  def get_file_ext(self):
-    return "h264"
-
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = 1,
-    )
 
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):


### PR DESCRIPTION
User can add `metric = dict(type='psnr',mode='trendline')` to test case configuration and run tests in the `model/encode` directory.  The model tests will encode the cases using ffmpeg-qsv CQP over various QP and attempt a curve_fit of LN compression ratio  vs. PSNR to find a trendline.  The trendline model parameters will be stored in the baseline directory with `--rebase` flag and then used as the test metric for standard testing in the `test/<mw>/encode` directory.

Additionally, the model trendlines and datapoints are plotted and saved as SVG file in the artifacts.  Those can be retained for further inspection by using the `--artifact-retention 2` flag.

Example:
```shell
vaapi-fits run model/encode/avc.py --pl TGL -vv --rebase --artifact-retention 2
vaapi-fits run test/ffmpeg-qsv/encode/avc.py --pl TGL -vv
```