### PR TITLE
[Trend Mode] add Vp9 8bit trendline support

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -361,3 +361,31 @@ class AV110EncoderLPTest(AV110EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "av1_10"),
       lowpower  = 1,
     )
+
+
+############################
+## VP9 8 Bit Encoders    ##
+############################
+@slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
+@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
+class VP9_8EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec     = "vp9",
+      ffencoder = "vp9_qsv",
+      ffdecoder = "vp9_qsv",
+    )
+
+  def get_file_ext(self):
+    return "ivf"
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+class VP9_8EncoderLPTest(VP9_8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = 1,
+    )
+

--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -69,6 +69,10 @@ def mapprofile(codec, profile):
     "av1-10"   : {
       "profile0"  : "main",
     },
+    "vp9"   : {
+      "profile0"  : "profile0",
+      "profile1"  : "profile1",
+    },
     "vp9-12" : {
       "profile3"  : "profile3",
     },

--- a/model/encode/vp9.py
+++ b/model/encode/vp9.py
@@ -1,0 +1,44 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+import slash
+
+from ...lib.ffmpeg.qsv.util import *
+from ...lib.ffmpeg.qsv.encoder import VP9_8EncoderLPTest
+from .util import TrendModelMixin
+
+spec = load_test_spec("vp9", "encode", "8bit")
+
+class trend(VP9_8EncoderLPTest, TrendModelMixin):
+  #MRO overrides
+  check_metrics = TrendModelMixin.check_metrics
+
+  def parse_psnr(self):
+    if os.path.exists(self.decoder.statsfile):
+      return parse_psnr_stats(self.decoder.statsfile, self.frames)
+
+  def initvars(self, _):
+    profile = "profile0"
+    if "AYUV" == self.format:
+      profile = "profile1"
+
+    super().initvars(profile)
+
+  @slash.parametrize(*TrendModelMixin.filter_spec(spec))
+  def test(self, case):
+    vars(self).update(case = case)
+    vars(self).update(
+      modelqps = list(range(1, 11, 2))
+        + list(range(11, 247, 30))
+        + list(range(247, 256, 2))
+    )
+    vars(self).update(spec[case].copy())
+    self.fit()
+  
+  def check_output(self):
+    # Ignore output checks for now to avoid VME/VDENC check.
+    pass

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -6,34 +6,11 @@
 
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
-from ....lib.ffmpeg.qsv.encoder import EncoderTest
+from ....lib.ffmpeg.qsv.encoder import VP9_8EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
-@slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
-@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = "vp9",
-      ffencoder = "vp9_qsv",
-      ffdecoder = "vp9_qsv",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_8"),
-      lowpower  = 1,
-    )
-
-class cqp_lp(VP9EncoderLPTest):
+class cqp_lp(VP9_8EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -50,7 +27,7 @@ class cqp_lp(VP9EncoderLPTest):
     self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
-class cbr_lp(VP9EncoderLPTest):
+class cbr_lp(VP9_8EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -70,7 +47,7 @@ class cbr_lp(VP9EncoderLPTest):
     self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
-class vbr_lp(VP9EncoderLPTest):
+class vbr_lp(VP9_8EncoderLPTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, quality):
     vars(self).update(tspec[case].copy())
     vars(self).update(


### PR DESCRIPTION
1, add ffmpeg-qsv vp9 8bit profile map
2, move ffmpeg-qsv vp9-8 encode test classes to lib
3, add support for vp9 8bit encode trendline models