### PR TITLE
msdk: Enable HDR transcoding case

### DIFF
--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -61,8 +61,8 @@ class TranscoderTest(BaseTranscoderTest):
       ),
       "hevc-8" : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
-        hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! video/x-h265,profile=main ! h265parse"),
-        lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc tune=low-power ! video/x-h265,profile=main ! h265parse"),
+        hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! h265parse"),
+        lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc tune=low-power ! h265parse"),
       ),
       "mpeg2" : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),

--- a/lib/gstreamer/util.py
+++ b/lib/gstreamer/util.py
@@ -7,6 +7,7 @@
 import re
 
 from ...lib.common import memoize, try_call, call, exe2os
+from ...lib.formats import FormatMapper
 
 def parse_inline_md5(msglog):
   return parse_inline_md5.pattern.search(msglog).group("actual")
@@ -42,3 +43,24 @@ def get_elements(plugin):
     result = call(f"{exe2os('gst-inspect-1.0')} --print-plugin-auto-install-info {plugin}")
   finally:
     return pattern.findall(result)
+
+class BaseFormatMapper(FormatMapper):
+  def get_supported_format_map(self):
+    return {
+      "I420"  : "I420",
+      "NV12"  : "NV12",
+      "YV12"  : "YV12",
+      "AYUV"  : "VUYA", #we use microsoft's definition of AYUV,https://docs.microsoft.com/en-us/windows/win32/medfound/recommended-8-bit-yuv-formats-for-video-rendering#ayuv
+      "YUY2"  : "YUY2",
+      "ARGB"  : "ARGB",
+      "BGRA"  : "BGRA",
+      "422H"  : "Y42B",
+      "444P"  : "Y444",
+      "P010"  : "P010_10LE",
+      "P012"  : "P012_LE",
+      "I010"  : "I420_10LE",
+      "Y210"  : "Y210",
+      "Y212"  : "Y212_LE",
+      "Y410"  : "Y410",
+      "Y412"  : "Y412_LE",
+    }


### PR DESCRIPTION
Also found that there is no format mapping in gstreamer transcoding, e.g. we always set "P010" in test case but we need "P010_10LE" or "p010-10le" in gstreamer pipeline.

Besides, in transcoder get_encoder, profile is always set to "main" for hevc encoder, which cannot work with 10bit, 12bit-like format... So remove that profile hardcode in gst_encoder for transcoding and let gstreamer negotiation to handle the profile.