### PR TITLE
[MTL] non-low power mode support for vp9 8bit encode

### DIFF
--- a/lib/caps/MTL/iHD
+++ b/lib/caps/MTL/iHD
@@ -27,6 +27,9 @@ caps = dict(
     av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
     av1_10  = dict(maxres = res8k , fmts = ["P010"]),
   ),
+  encode  = dict(
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+  ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
@@ -36,7 +39,6 @@ caps = dict(
       features  = dict(scc = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     av1_8  = dict(
       maxres    = res8k,

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -122,7 +122,10 @@ class EncoderTest(BaseEncoderTest):
 
     # lowpower
     if self.codec not in ["jpeg", "mpeg2"]:
-      vdenc = "ON" if vars(self).get("lowpower", 0) else "OFF"
+      if get_media()._get_gpu_gen() < 13:
+         vdenc = "ON" if vars(self).get("lowpower", 0) else "OFF"
+      else:
+         vdenc = "OFF" if vars(self).get("lowpower", 0) else "ON"
       m = re.search(f"VDENC: {vdenc}", self.output, re.MULTILINE)
       assert m is not None, "Possible incorrect VDENC/VME mode used"
 
@@ -379,6 +382,15 @@ class VP9_8EncoderBaseTest(EncoderTest):
 
   def get_file_ext(self):
     return "ivf"
+
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9_8EncoderTest(VP9_8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps = platform.get_caps("encode", "vp9_8"),
+      lowpower  = 0,
+    )
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class VP9_8EncoderLPTest(VP9_8EncoderBaseTest):

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -6,8 +6,7 @@
 
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
-from ....lib.ffmpeg.qsv.encoder import VP9_8EncoderLPTest
-
+from ....lib.ffmpeg.qsv.encoder import VP9_8EncoderLPTest, VP9_8EncoderTest
 spec = load_test_spec("vp9", "encode", "8bit")
 
 class cqp_lp(VP9_8EncoderLPTest):
@@ -48,6 +47,64 @@ class cbr_lp(VP9_8EncoderLPTest):
     self.encode()
 
 class vbr_lp(VP9_8EncoderLPTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      quality   = quality,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate * 2, # target percentage 50%
+      minrate   = bitrate,
+      rcmode    = "vbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, quality)
+    self.encode()
+
+class cqp(VP9_8EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      qp        = qp,
+      slices    = slices,
+      rcmode    = "cqp",
+      quality   = quality,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices)
+    self.encode()
+
+class cbr(VP9_8EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices)
+    self.encode()
+
+class vbr(VP9_8EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, slices, quality):
     vars(self).update(tspec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -29,6 +29,14 @@ class VP9EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("encode", "vp9_8"),
+    )
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class VP9EncoderLPTest(VP9EncoderBaseTest):
   def before(self):
@@ -89,6 +97,83 @@ class cbr_lp(VP9EncoderLPTest):
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      # target percentage 50%
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, slices)
+    self.encode()
+
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  def test_r2r(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec_r2r, case, gop, bitrate, fps, quality, slices)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cqp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices)
+    self.encode()
+
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  def test_r2r(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec_r2r, case, ipmode, qp, quality, slices)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class cbr(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices)
+    self.encode()
+
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  def test_r2r(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec_r2r, case, gop, bitrate, fps, slices)
+    vars(self).setdefault("r2r", 5)
+    self.encode()
+
+class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, slices):
     vars(self).update(tspec[case].copy())
     vars(self).update(

--- a/test/gst-va/encode/vp9.py
+++ b/test/gst-va/encode/vp9.py
@@ -26,6 +26,17 @@ class VP9EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+@slash.requires(*have_gst_element("vavp9enc"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("encode", "vp9_8"),
+      lowpower      = False,
+      gstencoder    = "vavp9enc",
+    )
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 @slash.requires(*have_gst_element("vavp9lpenc"))
 class VP9EncoderLPTest(VP9EncoderBaseTest):
@@ -77,6 +88,67 @@ class cbr_lp(VP9EncoderLPTest):
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+    )
+  
+  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices', 'refmode'])
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, looplvl, loopshp)
+    self.encode()
+
+class cqp(VP9EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      quality   = quality,
+      rcmode    = "cqp",
+      qp        = qp,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices', 'refmode'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, looplvl, loopshp)
+    self.encode()
+
+class cbr(VP9EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+    )
+  
+  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices', 'refmode'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
+    self.encode()
+
+class vbr(VP9EncoderTest):
   def init(self, tspec, case, gop, bitrate, fps, quality, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(


### PR DESCRIPTION
there will no lp mode for MTL encode
add non-lp mode support for vp9 8bit encode for ffmpeg and gstreamer