### PR TITLE
VP8e trendline model support

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -409,8 +409,10 @@ class MPEG2EncoderTest(EncoderTest):
   def get_file_ext(self):
     return "m2v"
 
+############################
 ## VP9 10 Bit Encoders    ##
 ############################
+
 @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
 @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
 class VP9_10EncoderBaseTest(EncoderTest):

--- a/model/encode/vp8.py
+++ b/model/encode/vp8.py
@@ -1,0 +1,38 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import os
+import slash
+
+from ...lib.ffmpeg.vaapi.util import *
+from ...lib.ffmpeg.vaapi.encoder import VP8EncoderTest
+from .util import TrendModelMixin
+
+spec = load_test_spec("vp8", "encode")
+
+class trend(VP8EncoderTest, TrendModelMixin):
+  #MRO overrides
+  check_metrics = TrendModelMixin.check_metrics
+
+  def parse_psnr(self):
+    if os.path.exists(self.decoder.statsfile):
+      return parse_psnr_stats(self.decoder.statsfile, self.frames)
+
+  def initvars(self, _):
+    super().initvars("version0_3")
+
+  @slash.parametrize(*TrendModelMixin.filter_spec(spec))
+  def test(self, case):
+    vars(self).update(case = case, ffencoder = self.ffenc)
+    vars(self).update(
+      modelqps = range(1, 128, 6),
+      modelfns = ["powernc", "powerc", "powern", "power"], # don't use cubic
+    )
+    vars(self).update(spec[case].copy())
+    self.fit()
+  
+  def check_output(self):
+    pass

--- a/test/ffmpeg-vaapi/encode/vp8.py
+++ b/test/ffmpeg-vaapi/encode/vp8.py
@@ -6,33 +6,9 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.ffmpeg.vaapi.encoder import VP8EncoderTest
 
 spec = load_test_spec("vp8", "encode")
-
-@slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
-class VP8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = "vp8",
-      ffenc   = "vp8_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return "VAProfileVP8Version0_3"
-
-@slash.requires(*platform.have_caps("encode", "vp8"))
-class VP8EncoderTest(VP8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp8"),
-      lowpower  = 0,
-    )
 
 class cqp(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))


### PR DESCRIPTION
This one uses ffmpeg-vaapi since qsv does not have vp8e support.