### PR TITLE
MTL+ add encode vp9 10bit non-lowpower test path support

### DIFF
--- a/lib/caps/MTL/iHD
+++ b/lib/caps/MTL/iHD
@@ -37,6 +37,7 @@ caps = dict(
       maxres    = res8k,
       fmts      = ["P010"],
     ),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vdenc   = dict(
     avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
@@ -47,7 +48,6 @@ caps = dict(
       features  = dict(scc = True),
     ),
     hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
-    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -457,6 +457,15 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "ivf"
 
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = 0,
+    )
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
   def before(self):

--- a/test/ffmpeg-qsv/encode/10bit/vp9.py
+++ b/test/ffmpeg-qsv/encode/10bit/vp9.py
@@ -6,9 +6,67 @@
 
 from .....lib import *
 from .....lib.ffmpeg.qsv.util import *
-from .....lib.ffmpeg.qsv.encoder import VP9_10EncoderLPTest
+from .....lib.ffmpeg.qsv.encoder import VP9_10EncoderLPTest, VP9_10EncoderTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
+
+class cqp(VP9_10EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      qp        = qp,
+      slices    = slices,
+      rcmode    = "cqp",
+      quality   = quality,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices)
+    self.encode()
+
+class cbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices)
+    self.encode()
+
+class vbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      quality   = quality,
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      maxrate   = bitrate * 2, # target percentage 50%
+      minrate   = bitrate,
+      rcmode    = "vbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, quality)
+    self.encode()
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices):

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -30,6 +30,15 @@ class VP9_10EncoderBaseTest(EncoderTest):
       ("YUV444", 10) : "VAProfileVP9Profile3",
     }[subsampling[self.format]]
 
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = 0,
+    )
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
   def before(self):
@@ -38,6 +47,68 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "vp9_10"),
       lowpower  = 1,
     )
+
+class cqp(VP9_10EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, looplvl, loopshp)
+    self.encode()
+
+class cbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, slices, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, loopshp)
+    self.encode()
+
+class vbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, slices, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      loopshp   = loopshp,
+      maxrate   = bitrate * 2, # target percentage 50%
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      slices    = slices,
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode', 'looplvl'])
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, slices, loopshp)
+    self.encode()
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):

--- a/test/gst-va/encode/10bit/vp9.py
+++ b/test/gst-va/encode/10bit/vp9.py
@@ -26,6 +26,17 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*have_gst_element("vavp9enc"))
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      gstencoder    = "vavp9enc",
+      lowpower  = False,
+    )
+
 @slash.requires(*have_gst_element("vavp9lpenc"))
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
@@ -36,6 +47,68 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
       gstencoder    = "vavp9lpenc",
       lowpower  = True,
     )
+
+class cqp(VP9_10EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['slices','refmode'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, looplvl, loopshp)
+    self.encode()
+
+class cbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['slices','refmode'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
+    self.encode()
+
+class vbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      # target percentage 50%
+      maxrate   = bitrate * 2,
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['slices','refmode'])
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, looplvl, loopshp)
+    self.encode()
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -28,6 +28,15 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "webm"
 
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9_10EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = False,
+    )
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
   def before(self):
@@ -36,6 +45,72 @@ class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "vp9_10"),
       lowpower  = True,
     )
+
+class cqp(VP9_10EncoderTest):
+  def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      case      = case,
+      gop       = 30 if ipmode != 0 else 1,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      qp        = qp,
+      quality   = quality,
+      rcmode    = "cqp",
+      refmode   = refmode,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['slices'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
+    self.encode()
+
+class cbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      maxrate   = bitrate,
+      minrate   = bitrate,
+      rcmode    = "cbr",
+      refmode   = refmode,
+    )
+
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['slices'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
+    self.encode()
+
+class vbr(VP9_10EncoderTest):
+  def init(self, tspec, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp):
+    vars(self).update(tspec[case].copy())
+    vars(self).update(
+      bitrate   = bitrate,
+      case      = case,
+      fps       = fps,
+      frames    = vars(self).get("brframes", self.frames),
+      gop       = gop,
+      looplvl   = looplvl,
+      loopshp   = loopshp,
+      ## target percentage 70% (hard-coded in gst-vaapi)
+      ## gst-vaapi sets max-bitrate = bitrate and min-bitrate = bitrate * 0.70
+      maxrate   = int(bitrate / 0.7),
+      minrate   = bitrate,
+      quality   = quality,
+      rcmode    = "vbr",
+      refmode   = refmode,
+    )
+
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['slices'])
+  def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, quality, refmode, looplvl, loopshp)
+    self.encode()
 
 class cqp_lp(VP9_10EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):


### PR DESCRIPTION
1, ffmpeg/gstreamer test add vp9-10bit non-lowpower mode support
2, ffmpeg/gstreamer lib update check for vp9-10bit non-lowpower
3, MTL caps