### PR TITLE
lib/mfx/runtime: skip windows detect runtime

### DIFF
--- a/lib/mfx/runtime.py
+++ b/lib/mfx/runtime.py
@@ -21,6 +21,9 @@ class MFXRuntimeTest(slash.Test):
     return None
 
   def check(self, command):
+    if get_media()._get_os() == 'wsl':
+      return
+
     proc = startproc(command)
 
     def readproc():


### PR DESCRIPTION
The original design for the Linux
on the windows side don't need ffmpeg-qsv runtime detect