### PR TITLE
[Caps] MTL move avc and hevc from vdenc to encode

### DIFF
--- a/lib/caps/MTL/iHD
+++ b/lib/caps/MTL/iHD
@@ -28,6 +28,13 @@ caps = dict(
     av1_10  = dict(maxres = res8k , fmts = ["P010"]),
   ),
   encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "AYUV"],
+      features  = dict(scc = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
     vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
     av1_8  = dict(
       maxres    = res8k,
@@ -40,14 +47,7 @@ caps = dict(
     vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
     jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
-    hevc_8  = dict(
-      maxres    = res8k,
-      fmts      = ["NV12", "AYUV"],
-      features  = dict(scc = True),
-    ),
-    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
   ),
   vpp    = dict(
     # brightness, contrast, hue and saturation


### PR DESCRIPTION
move avc and hevc 8bit/10bit from vdenc test mode to non-lp encode mode