### PR TITLE
Mtl parametrize vp9 8bit enc

### DIFF
--- a/lib/parameters.py
+++ b/lib/parameters.py
@@ -612,17 +612,17 @@ def gen_vp9_cqp_variants(spec):
     variants = params.get("variants", dict()).get("cqp", None)
 
     if variants is None:
-      keys = ["ipmode", "qp", "quality", "refmode", "looplvl", "loopshp"]
-      product = itertools.product([0, 1], [14, 28], [1, 4, 7], [0, 1], [0, 16, 63], [0, 4, 7])
+      keys = ["ipmode", "qp", "quality", "slices", "refmode", "looplvl", "loopshp"]
+      product = itertools.product([0, 1], [14, 28], [1, 4, 7], [1, 3], [0, 1], [0, 16, 63], [0, 4, 7])
       variants = [dict(zip(keys, vals)) for vals in product]
 
     for variant in variants:
       yield [
-        case, variant["ipmode"], variant["qp"], variant["quality"],
+        case, variant["ipmode"], variant["qp"], variant["quality"], variant.get("slices", 1),
         variant["refmode"], variant["looplvl"], variant["loopshp"]]
 
 def gen_vp9_cqp_parameters(spec):
-  keys = ("case", "ipmode", "qp", "quality", "refmode", "looplvl", "loopshp")
+  keys = ("case", "ipmode", "qp", "quality", "slices", "refmode", "looplvl", "loopshp")
   params = gen_vp9_cqp_variants(spec)
   return keys, params
 
@@ -633,12 +633,12 @@ def gen_vp9_cbr_variants(spec):
         # Optional: gop, fps, refmode, looplvl, loopshp
         yield [
           case, variant.get("gop", 30), variant["bitrate"],
-          variant.get("fps", 30), variant.get("refmode", 0),
+          variant.get("fps", 30), variant.get("slices", 1), variant.get("refmode", 0),
           variant.get("looplvl", 0), variant.get("loopshp", 0),
         ]
 
 def gen_vp9_cbr_parameters(spec):
-  keys = ("case", "gop", "bitrate", "fps", "refmode", "looplvl", "loopshp")
+  keys = ("case", "gop", "bitrate", "fps", "slices", "refmode", "looplvl", "loopshp")
   params = gen_vp9_cbr_variants(spec)
   return keys, params
 
@@ -649,13 +649,13 @@ def gen_vp9_vbr_variants(spec):
         # Optional: gop, fps, refmode, quality, looplvl, loopshp
         yield [
           case, variant.get("gop", 30), variant["bitrate"],
-          variant.get("fps", 30), variant.get("refmode", 0),
+          variant.get("fps", 30), variant.get("slices", 1), variant.get("refmode", 0),
           variant.get("quality", 4), variant.get("looplvl", 0),
           variant.get("loopshp", 0),
         ]
 
 def gen_vp9_vbr_parameters(spec):
-  keys = ("case", "gop", "bitrate", "fps", "refmode", "quality", "looplvl", "loopshp")
+  keys = ("case", "gop", "bitrate", "fps", "slices", "refmode", "quality", "looplvl", "loopshp")
   params = gen_vp9_vbr_variants(spec)
   return keys, params
 

--- a/test/ffmpeg-qsv/encode/vp9.py
+++ b/test/ffmpeg-qsv/encode/vp9.py
@@ -79,7 +79,7 @@ class cqp(VP9_8EncoderTest):
       quality   = quality,
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
@@ -99,7 +99,7 @@ class cbr(VP9_8EncoderTest):
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
@@ -120,7 +120,7 @@ class vbr(VP9_8EncoderTest):
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode', 'loopshp', 'looplvl'])
   def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices, quality)
     self.encode()

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -49,7 +49,7 @@ class VP9EncoderLPTest(VP9EncoderBaseTest):
     )
 
 class cqp(VP9EncoderTest):
-  def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):
+  def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       case      = case,
@@ -59,11 +59,12 @@ class cqp(VP9EncoderTest):
       qp        = qp,
       quality   = quality,
       rcmode    = "cqp",
+      slices    = slices,
     )
 
   @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode'])
-  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
-    self.init(spec, case, ipmode, qp, quality, looplvl, loopshp)
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, ipmode, qp, quality, slices, looplvl, loopshp)
     self.encode()
 
 class cqp_lp(VP9EncoderLPTest):
@@ -86,7 +87,7 @@ class cqp_lp(VP9EncoderLPTest):
     self.encode()
 
 class cbr(VP9EncoderTest):
-  def init(self, tspec, case, gop, bitrate, fps, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -99,11 +100,12 @@ class cbr(VP9EncoderTest):
       maxrate   = bitrate,
       minrate   = bitrate,
       rcmode    = "cbr",
+      slices    = slices,
     )
 
   @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode'])
-  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, looplvl, loopshp)
     self.encode()
 
 class cbr_lp(VP9EncoderLPTest):
@@ -128,7 +130,7 @@ class cbr_lp(VP9EncoderLPTest):
     self.encode()
 
 class vbr(VP9EncoderTest):
-  def init(self, tspec, case, gop, bitrate, fps, quality, looplvl, loopshp):
+  def init(self, tspec, case, gop, bitrate, fps, slices, quality, looplvl, loopshp):
     vars(self).update(tspec[case].copy())
     vars(self).update(
       bitrate   = bitrate,
@@ -142,11 +144,12 @@ class vbr(VP9EncoderTest):
       minrate   = bitrate,
       quality   = quality,
       rcmode    = "vbr",
+      slices    = slices,
     )
 
   @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode'])
-  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
-    self.init(spec, case, gop, bitrate, fps, quality, looplvl, loopshp)
+  def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
+    self.init(spec, case, gop, bitrate, fps, slices, quality, looplvl, loopshp)
     self.encode()
 
 class vbr_lp(VP9EncoderLPTest):

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -136,12 +136,12 @@ class cqp(VP9EncoderTest):
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, slices)
     self.encode()
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
   def test_r2r(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec_r2r, case, ipmode, qp, quality, slices)
     vars(self).setdefault("r2r", 5)
@@ -162,12 +162,12 @@ class cbr(VP9EncoderTest):
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, slices)
     self.encode()
 
-  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
   def test_r2r(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec_r2r, case, gop, bitrate, fps, slices)
     vars(self).setdefault("r2r", 5)
@@ -190,12 +190,12 @@ class vbr(VP9EncoderTest):
       slices    = slices,
     )
 
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['refmode', 'looplvl', 'loopshp'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, slices)
     self.encode()
 
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec_r2r), ['refmode', 'looplvl', 'loopshp'])
   def test_r2r(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec_r2r, case, gop, bitrate, fps, quality, slices)
     vars(self).setdefault("r2r", 5)

--- a/test/gst-va/encode/vp9.py
+++ b/test/gst-va/encode/vp9.py
@@ -122,7 +122,7 @@ class cqp(VP9EncoderTest):
       qp        = qp,
     )
 
-  @parametrize_with_unused(*gen_vp9_cqp_lp_parameters(spec), ['slices', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['slices', 'refmode'])
   def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, looplvl, loopshp)
     self.encode()
@@ -143,7 +143,7 @@ class cbr(VP9EncoderTest):
       rcmode    = "cbr",
     )
   
-  @parametrize_with_unused(*gen_vp9_cbr_lp_parameters(spec), ['slices', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['slices', 'refmode'])
   def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, looplvl, loopshp)
     self.encode()
@@ -165,7 +165,7 @@ class vbr(VP9EncoderTest):
       rcmode    = "vbr",
     )
   
-  @parametrize_with_unused(*gen_vp9_vbr_lp_parameters(spec), ['slices', 'refmode'])
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['slices', 'refmode'])
   def test(self, case, gop, bitrate, fps, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, quality, looplvl, loopshp)
     self.encode()

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -60,8 +60,8 @@ class cqp(VP9EncoderTest):
       refmode   = refmode,
     )
 
-  @slash.parametrize(*gen_vp9_cqp_parameters(spec))
-  def test(self, case, ipmode, qp, quality, refmode, looplvl, loopshp):
+  @parametrize_with_unused(*gen_vp9_cqp_parameters(spec), ['slices'])
+  def test(self, case, ipmode, qp, quality, slices, refmode, looplvl, loopshp):
     self.init(spec, case, ipmode, qp, quality, refmode, looplvl, loopshp)
     self.encode()
 
@@ -82,8 +82,8 @@ class cbr(VP9EncoderTest):
       refmode   = refmode,
     )
  
-  @slash.parametrize(*gen_vp9_cbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, looplvl, loopshp):
+  @parametrize_with_unused(*gen_vp9_cbr_parameters(spec), ['slices'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, looplvl, loopshp)
     self.encode()
 
@@ -107,8 +107,8 @@ class vbr(VP9EncoderTest):
       refmode   = refmode,
     )
   
-  @slash.parametrize(*gen_vp9_vbr_parameters(spec))
-  def test(self, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp):
+  @parametrize_with_unused(*gen_vp9_vbr_parameters(spec), ['slices'])
+  def test(self, case, gop, bitrate, fps, slices, refmode, quality, looplvl, loopshp):
     self.init(spec, case, gop, bitrate, fps, refmode, quality, looplvl, loopshp)
     self.encode()
 


### PR DESCRIPTION
MTL replace non-low power encode parameters for ffmpeg/gstreamer
gen_vp9_cqp_lp_parameters -> gen_vp9_cqp_parameters
gen_vp9_cbr_lp_parameters -> gen_vp9_cbr_parameters
gen_vp9_vbr_lp_parameters -> gen_vp9_vbr_parameters