### PR TITLE
Allow Slash 1.14

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -15,11 +15,6 @@ from slash.utils.traceback_utils import get_traceback_string
 import sys
 import xml.etree.cElementTree as et
 
-__required_slash_version__ = "1.12.0"
-assert slash.__version__ == __required_slash_version__, \
-  "Found slash {}, but slash {} is required.".format(
-    slash.__version__, __required_slash_version__)
-
 __SCRIPT_DIR__ = os.path.abspath(os.path.dirname(__file__))
 
 # LibVA used to load the i965 driver by default, but now it loads the iHD driver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slash==1.12.0
+slash>=1.12.0
 numpy
 scikit-image
 distro


### PR DESCRIPTION
Newer version of setuptools/pip throw error when trying
to install slash 1.12.0 due to more strict dependency
version syntax checks.

The syntax was fixed in slash 1.14.0 (slash commit 6ceffde64970).

Tested vaapi-fits with slash 1.14.0 and it still works well.
