### PR TITLE
Define PixelFormat and Codec as enums

### DIFF
--- a/lib/codecs.py
+++ b/lib/codecs.py
@@ -1,0 +1,24 @@
+###
+### Copyright (C) 2023 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+import enum
+
+@enum.unique
+class Codec(str, enum.Enum):
+  NONE  = "none"
+  RAW   = "raw"
+  AVC   = "avc"
+  HEVC  = "hevc"
+  AV1   = "av1"
+  VP9   = "vp9"
+  VP8   = "vp8"
+  JPEG  = "jpeg"
+  MJPEG = "mjpeg"
+  MPEG2 = "mpeg2"
+  VC1   = "vc1"
+
+  def __str__(self):
+    return self.value

--- a/lib/formats.py
+++ b/lib/formats.py
@@ -1,8 +1,67 @@
 ###
-### Copyright (C) 2019-2022 Intel Corporation
+### Copyright (C) 2019-2023 Intel Corporation
 ###
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
+
+import enum
+
+@enum.unique
+class Subsampling(str, enum.Enum):
+  NONE    = "NONE"
+  YUV400  = "YUV400"
+  YUV420  = "YUV420"
+  YUV422  = "YUV422"
+  YUV444  = "YUV444"
+
+@enum.unique
+class PixelFormat(str, enum.Enum):
+  def __new__(cls, value, ss = Subsampling.NONE, bitdepth = 0):
+    obj = str.__new__(cls, value)
+    obj._value_ = value
+    obj.__subsampling = ss
+    obj.__bitdepth = bitdepth
+    return obj
+
+  NONE  = "NONE"
+  _Y800 = "Y800", Subsampling.YUV400,  8
+  _I420 = "I420", Subsampling.YUV420,  8
+  _NV12 = "NV12", Subsampling.YUV420,  8
+  _YV12 = "YV12", Subsampling.YUV420,  8
+  _P010 = "P010", Subsampling.YUV420, 10
+  _I010 = "I010", Subsampling.YUV420, 10
+  _P012 = "P012", Subsampling.YUV420, 12
+  _422H = "422H", Subsampling.YUV422,  8
+  _422V = "422V", Subsampling.YUV422,  8
+  _YUY2 = "YUY2", Subsampling.YUV422,  8
+  _Y210 = "Y210", Subsampling.YUV422, 10
+  _Y212 = "Y212", Subsampling.YUV422, 12
+  _444P = "444P", Subsampling.YUV444,  8
+  _AYUV = "AYUV", Subsampling.YUV444,  8
+  _VUYA = "VUYA", Subsampling.YUV444,  8
+  _Y410 = "Y410", Subsampling.YUV444, 10
+  _Y412 = "Y412", Subsampling.YUV444, 12
+  _BGRA = "BGRA", Subsampling.NONE,    8
+  _BGRX = "BGRX", Subsampling.NONE,    8
+  _ARGB = "ARGB", Subsampling.NONE,    8
+
+  def __str__(self):
+    return self.value
+
+  @property
+  def subsampling(self):
+    return self.__subsampling
+
+  @property
+  def bitdepth(self):
+    return self.__bitdepth
+
+  def is_compatible(self, other):
+    pf = PixelFormat(other)
+    return (
+      self.subsampling == pf.subsampling
+      and self.bitdepth == pf.bitdepth
+    )
 
 subsampling = {
   "Y800" : ("YUV400",  8),
@@ -27,16 +86,14 @@ subsampling = {
 def match_best_format(fmt, choices):
   if fmt in choices:
     return fmt
-  matches = set([k for k,v in subsampling.items() if v == subsampling[fmt]])
+  matches = set(filter(lambda pf: pf.is_compatible(fmt), PixelFormat))
   matches &= set(choices)
   if len(matches) == 0:
     return None
   return list(matches)[0]
 
 def get_bit_depth(fmt):
-  if fmt in ["BGRA", "BGRX", "ARGB"]:
-    return 8
-  return subsampling[fmt][1]
+  return PixelFormat(fmt).bitdepth
 
 class FormatMapper:
   def get_supported_format_map(self):

--- a/lib/formats.py
+++ b/lib/formats.py
@@ -63,26 +63,6 @@ class PixelFormat(str, enum.Enum):
       and self.bitdepth == pf.bitdepth
     )
 
-subsampling = {
-  "Y800" : ("YUV400",  8),
-  "I420" : ("YUV420",  8),
-  "NV12" : ("YUV420",  8),
-  "YV12" : ("YUV420",  8),
-  "P010" : ("YUV420", 10),
-  "P012" : ("YUV420", 12),
-  "I010" : ("YUV420", 10),
-  "422H" : ("YUV422",  8),
-  "422V" : ("YUV422",  8),
-  "YUY2" : ("YUV422",  8),
-  "Y210" : ("YUV422", 10),
-  "Y212" : ("YUV422", 12),
-  "444P" : ("YUV444",  8),
-  "AYUV" : ("YUV444",  8),
-  "VUYA" : ("YUV444",  8),
-  "Y410" : ("YUV444", 10),
-  "Y412" : ("YUV444", 12),
-}
-
 def match_best_format(fmt, choices):
   if fmt in choices:
     return fmt

--- a/lib/formats.py
+++ b/lib/formats.py
@@ -72,9 +72,6 @@ def match_best_format(fmt, choices):
     return None
   return list(matches)[0]
 
-def get_bit_depth(fmt):
-  return PixelFormat(fmt).bitdepth
-
 class FormatMapper:
   def get_supported_format_map(self):
     raise NotImplementedError

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -145,9 +145,9 @@ class RawMetricAggregator:
 
 class MetricWithDataRange:
   def __init__(self, func, fourcc):
-    from .formats import get_bit_depth
+    from .formats import PixelFormat
     self.func = func
-    self.data_range = pow(2, get_bit_depth(fourcc)) - 1
+    self.data_range = pow(2, PixelFormat(fourcc).bitdepth) - 1
 
   def __call__(self, planes):
     return self.func(planes, self.data_range)

--- a/lib/metrics2/psnr.py
+++ b/lib/metrics2/psnr.py
@@ -15,7 +15,7 @@ import os
 import statistics
 
 from ..common import get_media, timefn
-from ..formats import get_bit_depth
+from ..formats import PixelFormat
 from .util import RawFileFrameReader, RawMetricAggregator, MetricWithDataRange
 from . import factory
 
@@ -30,8 +30,8 @@ trend_models = dict(
 
 @timefn("psnr:calculate")
 def calculate(filetrue, filetest, width, height, frames, fmttrue, fmttest):
-  bitdepth = get_bit_depth(fmttrue)
-  assert get_bit_depth(fmttest) == bitdepth
+  bitdepth = PixelFormat(fmttrue).bitdepth
+  assert PixelFormat(fmttest).bitdepth == bitdepth
 
   return RawMetricAggregator(min).calculate(
     RawFileFrameReader(filetrue, width, height, frames, fmttrue),

--- a/lib/metrics2/ssim.py
+++ b/lib/metrics2/ssim.py
@@ -11,14 +11,14 @@ except:
   from skimage.measure import compare_ssim as skimage_ssim
 
 from ..common import get_media, timefn
-from ..formats import get_bit_depth
+from ..formats import PixelFormat
 from .util import RawFileFrameReader, RawMetricAggregator, MetricWithDataRange
 from . import factory
 
 @timefn("ssim:calculate")
 def calculate(filetrue, filetest, width, height, frames, fmttrue, fmttest):
-  bitdepth = get_bit_depth(fmttrue)
-  assert get_bit_depth(fmttest) == bitdepth
+  bitdepth = PixelFormat(fmttrue).bitdepth
+  assert PixelFormat(fmttest).bitdepth == bitdepth
 
   return RawMetricAggregator(min).calculate(
     RawFileFrameReader(filetrue, width, height, frames, fmttrue),

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -5,7 +5,7 @@
 ###
 
 from .....lib import *
-from .....lib.formats import subsampling
+from .....lib.formats import PixelFormat
 from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
 
@@ -25,10 +25,10 @@ class VP9_10EncoderBaseTest(EncoderTest):
 
   def get_vaapi_profile(self):
     return {
-      ("YUV420", 10) : "VAProfileVP9Profile2",
-      ("YUV422", 10) : "VAProfileVP9Profile3",
-      ("YUV444", 10) : "VAProfileVP9Profile3",
-    }[subsampling[self.format]]
+      "YUV420" : "VAProfileVP9Profile2",
+      "YUV422" : "VAProfileVP9Profile3",
+      "YUV444" : "VAProfileVP9Profile3",
+    }[PixelFormat(self.format).subsampling]
 
 @slash.requires(*platform.have_caps("encode", "vp9_10"))
 class VP9_10EncoderTest(VP9_10EncoderBaseTest):

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -5,7 +5,7 @@
 ###
 
 from ....lib import *
-from ....lib.formats import subsampling
+from ....lib.formats import PixelFormat
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
 
@@ -25,10 +25,10 @@ class VP9EncoderBaseTest(EncoderTest):
 
   def get_vaapi_profile(self):
     return {
-      ("YUV420", 8) : "VAProfileVP9Profile0",
-      ("YUV422", 8) : "VAProfileVP9Profile1",
-      ("YUV444", 8) : "VAProfileVP9Profile1",
-    }[subsampling[self.format]]
+      "YUV420" : "VAProfileVP9Profile0",
+      "YUV422" : "VAProfileVP9Profile1",
+      "YUV444" : "VAProfileVP9Profile1",
+    }[PixelFormat(self.format).subsampling]
 
 @slash.requires(*platform.have_caps("encode", "vp9_8"))
 class VP9EncoderTest(VP9EncoderBaseTest):


### PR DESCRIPTION
The Enum support was introduced in Python 3.4 (https://docs.python.org/3/library/enum.html).

Define a `PixelFormat` enum which combines bitdepth, subsampling, and pixel format.

Define a `Codec` enum.  The bitdepth is omitted from the codec values as it is redundant and unnecessary.  In the current code, we often use strings like `"hevc-10"` and `"hevc-8"` in the codec property.  But after examination, it is not necessary to distinguish it that way and only introduces potential bugs, maintenance overhead and inconsistencies.

These enums will eventually replace hard-coded strings throughout the code to enforce and improve consistency.

These enums are directly comparable to strings for maximum backwards compatibility.  For example:
```python
PixelFormat._NV12 == PixelFormat("NV12") == "NV12"
```
...evaluates to `True`
