### PR TITLE
Replace hard-coded strings in "codec" member properties

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -15,7 +15,7 @@ from ...lib.ffmpeg.decoderbase import Decoder
 from ...lib.parameters import format_value
 from ...lib.properties import PropertyHandler
 from ...lib.util import skip_test_if_missing_features
-
+from ...lib.codecs import Codec
 from ...lib import metrics2
 
 class Encoder(PropertyHandler, BaseFormatMapper):
@@ -167,7 +167,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       reference = self.source,
     )
 
-    if self.codec in ["jpeg"]:
+    if self.codec in [Codec.JPEG]:
       self.decoder.update(ffscale_range = "jpeg")
 
     if None in [self.encoder.hwformat, self.encoder.format, self.decoder.hwformat, self.decoder.format]:
@@ -294,7 +294,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     if vars(self).get("vforced_idr", None) is None:
       return
 
-    judge = {"hevc-8" : 19, "avc" : 5}.get(self.codec, None)
+    judge = {Codec.HEVC : 19, Codec.AVC : 5}.get(self.codec, None)
     assert judge is not None, f"{self.codec} codec not supported for forced_idr"
 
     output = call(

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -13,6 +13,7 @@ from ....lib.ffmpeg.util import have_ffmpeg_hwaccel, have_ffmpeg_encoder, have_f
 from ....lib.ffmpeg.qsv.util import mapprofile, using_compatible_driver, have_encode_main10sp
 from ....lib.ffmpeg.qsv.decoder import Decoder
 from ....lib.common import mapRangeInt, get_media, call, exe2os
+from ....lib.codecs import Codec
 
 class Encoder(FFEncoder):
   hwaccel   = property(lambda s: "qsv")
@@ -35,7 +36,7 @@ class Encoder(FFEncoder):
   @property
   def qp(self):
     def inner(qp):
-      if self.codec in ["mpeg2"]:
+      if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [1, 51])
         return f" -q {mqp}"
       return f" -q {qp}"
@@ -44,7 +45,7 @@ class Encoder(FFEncoder):
   @property
   def quality(self):
     def inner(quality):
-      if self.codec in ["jpeg"]:
+      if self.codec in [Codec.JPEG]:
         return f" -global_quality {quality}"
       return f" -preset {quality}"
     return self.ifprop("quality", inner)
@@ -115,13 +116,13 @@ class EncoderTest(BaseEncoderTest):
     assert m is not None, "It appears that the QSV plugin did not load"
 
     # rate control mode
-    if self.codec not in ["jpeg"]:
+    if self.codec not in [Codec.JPEG]:
       mode = "LA" if vars(self).get("ladepth", None) is not None else self.rcmode
       m = re.search(f"RateControlMethod: {mode.upper()}", self.output, re.MULTILINE)
       assert m is not None, "Possible incorrect RC mode used"
 
     # lowpower
-    if self.codec not in ["jpeg", "mpeg2"]:
+    if self.codec not in [Codec.JPEG, Codec.MPEG2]:
       if get_media()._get_gpu_gen() < 13:
          vdenc = "ON" if vars(self).get("lowpower", 0) else "OFF"
       else:
@@ -135,7 +136,7 @@ class EncoderTest(BaseEncoderTest):
       assert m is not None, "Possible incorrect FPS used"
 
     # slices
-    if vars(self).get("slices", None) is not None and self.codec not in ["vp9", "vp9-10"]:
+    if vars(self).get("slices", None) is not None and self.codec not in [Codec.VP9]:
       m = re.search(f"NumSlice: {self.slices};", self.output, re.MULTILINE)
       assert m is not None, "Possible incorrect slices used"
 
@@ -186,7 +187,7 @@ class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "avc",
+      codec     = Codec.AVC,
       ffencoder = "h264_qsv",
       ffdecoder = "h264_qsv",
     )
@@ -222,7 +223,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "hevc-8",
+      codec     = Codec.HEVC,
       ffencoder = "hevc_qsv",
       ffdecoder = "hevc_qsv",
     )
@@ -258,7 +259,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "hevc-10",
+      codec     = Codec.HEVC,
       ffencoder = "hevc_qsv",
       ffdecoder = "hevc_qsv",
     )
@@ -294,7 +295,7 @@ class HEVC12EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "hevc-12",
+      codec     = Codec.HEVC,
       ffencoder = "hevc_qsv",
       ffdecoder = "hevc_qsv",
     )
@@ -321,7 +322,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "av1-8",
+      codec     = Codec.AV1,
       ffencoder = "av1_qsv",
       ffdecoder = "av1_qsv",
     )
@@ -357,7 +358,7 @@ class AV110EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "av1-10",
+      codec     = Codec.AV1,
       ffencoder = "av1_qsv",
       ffdecoder = "av1_qsv",
     )
@@ -393,7 +394,7 @@ class VP9_8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "vp9",
+      codec     = Codec.VP9,
       ffencoder = "vp9_qsv",
       ffdecoder = "vp9_qsv",
     )
@@ -431,7 +432,7 @@ class MPEG2EncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps      = platform.get_caps("encode", "mpeg2"),
-      codec     = "mpeg2",
+      codec     = Codec.MPEG2,
       ffencoder = "mpeg2_qsv",
       ffdecoder = "mpeg2_qsv",
     )
@@ -449,7 +450,7 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec     = "vp9-10",
+      codec     = Codec.VP9,
       ffencoder = "vp9_qsv",
       ffdecoder = "vp9_qsv",
     )

--- a/lib/ffmpeg/qsv/transcoder.py
+++ b/lib/ffmpeg/qsv/transcoder.py
@@ -11,63 +11,64 @@ from ....lib.ffmpeg.transcoderbase import BaseTranscoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_decoder, have_ffmpeg_encoder, have_ffmpeg_hwaccel, have_ffmpeg_filter, have_ffmpeg_filter_options
 from ....lib.ffmpeg.qsv.util import using_compatible_driver
 from ....lib.common import get_media
+from ....lib.codecs import Codec
 
 @slash.requires(*have_ffmpeg_hwaccel("qsv"))
 @slash.requires(using_compatible_driver)
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     decode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("h264"), "h264"),
         hw = (platform.get_caps("decode", "avc"), have_ffmpeg_decoder("h264_qsv"), "h264_qsv"),
         va_hw = (platform.get_caps("decode", "avc"), have_ffmpeg_decoder("h264"), "h264"),
         d3d11_hw = (platform.get_caps("decode", "avc"), have_ffmpeg_decoder("h264"), "h264"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
         hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc_qsv"), "hevc_qsv"),
         va_hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
         d3d11_hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_ffmpeg_decoder("mpeg2_qsv"), "mpeg2_qsv"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("mjpeg"), "mjpeg"),
         hw = (platform.get_caps("decode", "jpeg"), have_ffmpeg_decoder("mjpeg_qsv"), "mjpeg_qsv"),
       ),
-      "vc1" : dict(
+      Codec.VC1 : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("vc1"), "vc1"),
         hw = (platform.get_caps("decode", "vc1"), have_ffmpeg_decoder("vc1_qsv"), "vc1_qsv"),
       ),
-      "av1" : dict(
+      Codec.AV1 : dict(
         hw = (platform.get_caps("decode", "av1_8"), have_ffmpeg_decoder("av1_qsv"), "av1_qsv"),
       ),
     },
     encode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx264"), "libx264"),
         hw = (platform.get_caps("encode", "avc"), have_ffmpeg_encoder("h264_qsv"), "h264_qsv"),
         lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_qsv"), "h264_qsv -q 20"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
         hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_qsv"), "hevc_qsv"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_ffmpeg_encoder("hevc_qsv"), "hevc_qsv"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("encode", "mpeg2"), have_ffmpeg_encoder("mpeg2_qsv"), "mpeg2_qsv"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("mjpeg"), "mjpeg -global_quality 60"),
         hw = (platform.get_caps("vdenc", "jpeg"), have_ffmpeg_encoder("mjpeg_qsv"), "mjpeg_qsv -global_quality 60"),
       ),
-      "vp9" : dict(
+      Codec.VP9 : dict(
         lp = (platform.get_caps("vdenc", "vp9_8"), have_ffmpeg_encoder("vp9_qsv"), "vp9_qsv"),
       ),
-      "av1" : dict(
+      Codec.AV1 : dict(
         lp = (platform.get_caps("vdenc", "av1_8"), have_ffmpeg_encoder("av1_qsv"), "av1_qsv"),
       ),
     },
@@ -84,10 +85,6 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
   )
-
-  # hevc implies hevc 8 bit
-  requirements["encode"]["hevc"] = requirements["encode"]["hevc-8"]
-  requirements["decode"]["hevc"] = requirements["decode"]["hevc-8"]
 
   def before(self):
     super().before()

--- a/lib/ffmpeg/qsv/util.py
+++ b/lib/ffmpeg/qsv/util.py
@@ -6,6 +6,7 @@
 
 from ....lib.common import memoize, get_media
 from ....lib.ffmpeg.util import *
+from ....lib.codecs import Codec
 
 def using_compatible_driver():
   return get_media()._get_driver_name() in ["iHD", "d3d11", "dxva2"]
@@ -40,50 +41,38 @@ def map_transpose_direction(degrees, method):
 @memoize
 def mapprofile(codec, profile):
   return {
-    "avc"      : {
+    Codec.AVC     : {
       "high"      : "high",
       "main"      : "main",
       "baseline"  : "baseline",
-      "unknown"   : "unknown"
+      "unknown"   : "unknown",
     },
-    "hevc-8"   : {
+    Codec.HEVC    : {
       "main"      : "main",
       "main444"   : "rext",
       "scc"       : "scc",
       "scc-444"   : "scc",
       "mainsp"    : "mainsp",
-      "unknown"   : "unknown"
+      "main10"    : "main10",
+      "main10sp"  : "main10 -main10sp 1",
+      "main444-10": "rext",
+      "main12"    : "rext",
+      "main422-12": "rext",
+      "unknown"   : "unknown",
     },
-    "hevc-10"  : {
-      "main10"     : "main10",
-      "main10sp"   : "main10 -main10sp 1",
-      "main444-10" : "rext"
-    },
-    "hevc-12" : {
-      "main12"      : "rext",
-      "main422-12"  : "rext",
-    },
-    "av1-8"   : {
+    Codec.AV1     : {
       "profile0"  : "main",
     },
-    "av1-10"   : {
-      "profile0"  : "main",
-    },
-    "vp9"   : {
+    Codec.VP9     : {
       "profile0"  : "profile0",
       "profile1"  : "profile1",
-    },
-    "vp9-10" : {
       "profile2"  : "profile2",
       "profile3"  : "profile3",
     },
-    "vp9-12" : {
-      "profile3"  : "profile3",
-    },
-    "mpeg2" : {
-      "simple"  : "simple",
-      "main"    : "main",
-      "high"    : "high",
+    Codec.MPEG2   : {
+      "simple"    : "simple",
+      "main"      : "main",
+      "high"      : "high",
     },
   }.get(codec, {}).get(profile, None)
 

--- a/lib/ffmpeg/transcoderbase.py
+++ b/lib/ffmpeg/transcoderbase.py
@@ -12,6 +12,7 @@ from ...lib.ffmpeg.util import BaseFormatMapper, have_ffmpeg, ffmpeg_probe_resol
 
 from ...lib import metrics2
 from ...lib.parameters import format_value
+from ...lib.codecs import Codec
 
 @slash.requires(have_ffmpeg)
 class BaseTranscoderTest(slash.Test,BaseFormatMapper):
@@ -52,13 +53,12 @@ class BaseTranscoderTest(slash.Test,BaseFormatMapper):
 
   def get_file_ext(self, codec):
     return {
-      "avc"            : "h264",
-      "hevc"           : "h265",
-      "hevc-8"         : "h265",
-      "mpeg2"          : "m2v",
-      "mjpeg"          : "mjpeg",
-      "vp9"            : "ivf",
-      "av1"            : "ivf"
+      Codec.AVC   : "h264",
+      Codec.HEVC  : "h265",
+      Codec.MPEG2 : "m2v",
+      Codec.MJPEG : "mjpeg",
+      Codec.VP9   : "ivf",
+      Codec.AV1   : "ivf"
     }.get(codec, "???")
 
   def validate_caps(self):
@@ -148,7 +148,7 @@ class BaseTranscoderTest(slash.Test,BaseFormatMapper):
       ext = self.get_file_ext(codec)
 
       # WA: LDB is not enabled by default for HEVCe on gen11+, yet.
-      if codec.startswith("hevc") and get_media()._get_gpu_gen() > 10:
+      if Codec.HEVC == codec and get_media()._get_gpu_gen() > 10:
         encoder += " -b_strategy 1"
       if "lp" == mode:
         encoder += " -low_power 1"
@@ -232,7 +232,7 @@ class BaseTranscoderTest(slash.Test,BaseFormatMapper):
 
         # WA: FFMpeg does not have an AV1 SW decoder
         ocodec = output["codec"]
-        if ocodec in ["av1"]:
+        if ocodec in [Codec.AV1]:
           format = vars(self).get("format", "NV12")
           iopts = (
             f"-hwaccel {self.hwaccel}"

--- a/lib/ffmpeg/vaapi/transcoder.py
+++ b/lib/ffmpeg/vaapi/transcoder.py
@@ -9,59 +9,60 @@ import slash
 from ....lib import platform
 from ....lib.ffmpeg.transcoderbase import BaseTranscoderTest
 from ....lib.ffmpeg.util import have_ffmpeg_decoder, have_ffmpeg_encoder, have_ffmpeg_hwaccel, have_ffmpeg_filter, have_ffmpeg_filter_options
+from ....lib.codecs import Codec
 
 @slash.requires(*have_ffmpeg_hwaccel("vaapi"))
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     # ffmpeg-vaapi HW decoders are built-in
     decode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("h264"), "h264"),
         hw = (platform.get_caps("decode", "avc"), have_ffmpeg_decoder("h264"), "h264"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("hevc"), "hevc"),
         hw = (platform.get_caps("decode", "hevc_8"), have_ffmpeg_decoder("hevc"), "hevc"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("decode", "mpeg2"), have_ffmpeg_decoder("mpeg2video"), "mpeg2video"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("mjpeg"), "mjpeg"),
         hw = (platform.get_caps("decode", "jpeg"), have_ffmpeg_decoder("mjpeg"), "mjpeg"),
       ),
-      "vc1" : dict(
+      Codec.VC1 : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_decoder("vc1"), "vc1"),
         hw = (platform.get_caps("decode", "vc1"), have_ffmpeg_decoder("vc1"), "vc1"),
       ),
-      "av1" : dict(
+      Codec.AV1 : dict(
         hw = (platform.get_caps("decode", "av1_8"), have_ffmpeg_decoder("av1"), "av1"),
       ),
     },
     encode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx264"), "libx264"),
         hw = (platform.get_caps("encode", "avc"), have_ffmpeg_encoder("h264_vaapi"), "h264_vaapi"),
         lp = (platform.get_caps("vdenc", "avc"), have_ffmpeg_encoder("h264_vaapi"), "h264_vaapi -qp 20"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("libx265"), "libx265"),
         hw = (platform.get_caps("encode", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_ffmpeg_encoder("hevc_vaapi"), "hevc_vaapi"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_ffmpeg_encoder("mpeg2video"), "mpeg2video"),
         hw = (platform.get_caps("encode", "mpeg2"), have_ffmpeg_encoder("mpeg2_vaapi"), "mpeg2_vaapi"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_ffmpeg_encoder("mjpeg"), "mjpeg"),
         hw = (platform.get_caps("vdenc", "jpeg"), have_ffmpeg_encoder("mjpeg_vaapi"), "mjpeg_vaapi"),
       ),
-      "vp9" : dict(
+      Codec.VP9 : dict(
         lp = (platform.get_caps("vdenc", "vp9_8"), have_ffmpeg_encoder("vp9_vaapi"), "vp9_vaapi"),
       ),
-      "av1" : dict(
+      Codec.AV1 : dict(
         lp = (platform.get_caps("vdenc", "av1_8"), have_ffmpeg_encoder("av1_vaapi"), "av1_vaapi"),
       ),
     },
@@ -78,10 +79,6 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
   )
-
-  # hevc implies hevc 8 bit
-  requirements["encode"]["hevc"] = requirements["encode"]["hevc-8"]
-  requirements["decode"]["hevc"] = requirements["decode"]["hevc-8"]
 
   def before(self):
     super().before()

--- a/lib/ffmpeg/vaapi/util.py
+++ b/lib/ffmpeg/vaapi/util.py
@@ -6,6 +6,7 @@
 
 from ....lib.common import memoize
 from ....lib.ffmpeg.util import *
+from ....lib.codecs import Codec
 
 @memoize
 def map_deinterlace_method(method):
@@ -41,53 +42,40 @@ def map_transpose_direction(degrees, method):
 @memoize
 def mapprofile(codec, profile):
   return {
-    "avc"      : {
+    Codec.AVC   : {
       "high"                  : "high",
       "main"                  : "main",
       "constrained-baseline"  : "constrained_baseline",
     },
-    "hevc-8"   : {
+    Codec.HEVC  : {
       "main"                  : "main",
       "main444"               : "rext",
       "scc"                   : "scc",
       "scc-444"               : "scc",
-    },
-    "hevc-10"  : {
       "main10"                : "main10",
       "main444-10"            : "rext",
-    },
-    "hevc-12" : {
       "main12"                : "rext",
       "main422-12"            : "rext",
     },
-    "jpeg"     : {
+    Codec.JPEG  : {
       "baseline"              : "baseline",
     },
-    "mpeg2"    : {
+    Codec.MPEG2 : {
       "main"                  : 4,
       "simple"                : 5,
     },
-    "vp8"      : {
+    Codec.VP8   : {
       "version0_3"            : "version0_3",
     },
-    "vp9"      : {
+    Codec.VP9   : {
       "profile0"              : "profile0",
       "profile1"              : "profile1",
-    },
-    "vp9-10" : {
-      "profile2"  : "profile2",
-      "profile3"  : "profile3",
-    },
-    "vp9-12"      : {
+      "profile2"              : "profile2",
       "profile3"              : "profile3",
     },
-    "av1-8"   : {
+    Codec.AV1   : {
       "main"                  : "main",
-      "profile0"              : "main"
-    },
-    "av1-10"   : {
-      "main"                  : "main",
-      "profile0"              : "main"
+      "profile0"              : "main",
     },
   }.get(codec, {}).get(profile, None)
 

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -12,13 +12,14 @@ from ....lib.gstreamer.encoderbase import BaseEncoderTest, Encoder as GstEncoder
 from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.msdk.util import using_compatible_driver, mapprofile, map_best_hw_format, mapformat
 from ....lib.gstreamer.msdk.decoder import Decoder
+from ....lib.codecs import Codec
 from ....lib.common import get_media, mapRangeInt
 
 class Encoder(GstEncoder):
   @property
   def hwformat(self):
     ifmts = self.props["caps"]["fmts"]
-    if self.codec not in ["hevc-8", "vp9", "vp9-10"]:
+    if self.codec not in [Codec.HEVC, Codec.VP9]:
       ifmts = list(set(ifmts) - set(["AYUV"]))
     return map_best_hw_format(super().format, ifmts)
 
@@ -28,14 +29,14 @@ class Encoder(GstEncoder):
 
   @property
   def rcmode(self):
-    if self.codec in ["jpeg"]:
+    if self.codec in [Codec.JPEG]:
       return ""
     return f" rate-control={super().rcmode} hardware=true"
 
   @property
   def qp(self):
     def inner(qp):
-      if self.codec in ["mpeg2"]:
+      if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [0, 51])
         return f" qpi={mqp} qpp={mqp} qpb={mqp}"
       return f" qpi={qp} qpp={qp} qpb={qp}"
@@ -44,7 +45,7 @@ class Encoder(GstEncoder):
   @property
   def quality(self):
     def inner(quality):
-      if self.codec in ["jpeg"]:
+      if self.codec in [Codec.JPEG]:
         return f" quality={quality}"
       return f" target-usage={quality}"
     return self.ifprop("quality", inner)

--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -8,6 +8,7 @@ import os
 import slash
 
 from ....lib import platform
+from ....lib.codecs import Codec
 from ....lib.common import get_media
 from ....lib.gstreamer.transcoderbase import BaseTranscoderTest
 from ....lib.gstreamer.util import have_gst_element
@@ -18,29 +19,29 @@ from ....lib.gstreamer.msdk.util import using_compatible_driver
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     decode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("openh264dec"), "h264parse ! openh264dec ! videoconvert"),
         hw = (platform.get_caps("decode", "avc"), have_gst_element("msdkh264dec"), "h264parse ! msdkh264dec"),
         va_hw = (platform.get_caps("decode", "avc"), have_gst_element("vah264dec"), "h264parse ! vah264dec"),
         d3d11_hw = (platform.get_caps("decode", "avc"), have_gst_element("d3d11h264dec"), "h264parse ! d3d11h264dec"),
         dma = (platform.get_caps("decode", "avc"), have_gst_element("msdkh264dec"), "h264parse ! msdkh264dec ! \"video/x-raw(memory:DMABuf)\""),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("libde265dec"), "h265parse ! libde265dec ! videoconvert"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("msdkh265dec"), "h265parse ! msdkh265dec"),
         va_hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vah265dec"), "h265parse ! vah265dec"),
         d3d11_hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("d3d11h265dec"), "h265parse ! d3d11h265dec"),
         dma = (platform.get_caps("decode", "hevc_8"), have_gst_element("msdkh265dec"), "h265parse ! msdkh265dec ! \"video/x-raw(memory:DMABuf)\""),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("mpeg2dec"), "mpegvideoparse ! mpeg2dec ! videoconvert"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("msdkmpeg2dec"), "mpegvideoparse ! msdkmpeg2dec"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegdec"), "jpegparse ! jpegdec"),
         hw = (platform.get_caps("decode", "jpeg"), have_gst_element("msdkmjpegdec"), "jpegparse ! msdkmjpegdec"),
       ),
-      "vc1" : dict(
+      Codec.VC1 : dict(
         sw = (
           dict(maxres = (16384, 16384)), have_gst_element("avdec_vc1"),
           "'video/x-wmv,profile=(string)advanced'"
@@ -54,21 +55,21 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
     encode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc ! video/x-h264,profile=main ! h264parse"),
         lp = (platform.get_caps("vdenc", "avc"), have_gst_element("msdkh264enc"), "msdkh264enc rate-control=cqp tune=low-power ! video/x-h264,profile=main ! h264parse"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc ! h265parse"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("msdkh265enc"), "msdkh265enc tune=low-power ! h265parse"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
         hw = (platform.get_caps("encode", "mpeg2"), have_gst_element("msdkmpeg2enc"), "msdkmpeg2enc ! mpegvideoparse"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegenc"), "jpegenc ! jpegparse"),
         hw = (platform.get_caps("vdenc", "jpeg"), have_gst_element("msdkmjpegenc"), "msdkmjpegenc ! jpegparse"),
       ),
@@ -81,10 +82,6 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
   )
-
-  # hevc implies hevc 8 bit
-  requirements["encode"]["hevc"] = requirements["encode"]["hevc-8"]
-  requirements["decode"]["hevc"] = requirements["decode"]["hevc-8"]
 
   def before(self):
     super().before()

--- a/lib/gstreamer/msdk/util.py
+++ b/lib/gstreamer/msdk/util.py
@@ -4,6 +4,7 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+from ....lib.codecs import Codec
 from ....lib.common import memoize, get_media
 from ....lib.formats import match_best_format
 from ....lib.gstreamer.util import *
@@ -81,33 +82,26 @@ def map_deinterlace_method(method):
 @memoize
 def mapprofile(codec,profile):
   return {
-    "avc"     : {
+    Codec.AVC   : {
       "high"                  : "high",
       "main"                  : "main",
       "baseline"              : "baseline",
       "constrained-baseline"  : "constrained-baseline",
     },
-    "hevc-8"  : {
+    Codec.HEVC  : {
       "main"                  : "main",
       "scc"                   : "screen-extended-main",
       "scc-444"               : "screen-extended-main-444",
       "main444"               : "main-444",
       "mainsp"                : "main-still-picture",
-    },
-    "hevc-10" : {
       "main10"                : "main-10",
       "main444-10"            : "main-444-10",
-    },
-    "hevc-12" : {
       "main12"                : "main-12",
     },
-    "av1-8"  : {
+    Codec.AV1   : {
       "profile0"              : "main",
     },
-    "av1-10"  : {
-      "profile0"              : "main",
-    },    
-    "vp9-12" : {
+    Codec.VP9   : {
       "profile3"              : "profile3",
     },
   }.get(codec, {}).get(profile, None)

--- a/lib/gstreamer/transcoderbase.py
+++ b/lib/gstreamer/transcoderbase.py
@@ -7,6 +7,7 @@
 import slash
 import os
 
+from ...lib.codecs import Codec
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.gstreamer.util import BaseFormatMapper, have_gst, have_gst_element, gst_discover
 
@@ -44,13 +45,11 @@ class BaseTranscoderTest(slash.Test, BaseFormatMapper):
 
   def get_file_ext(self, codec):
     return {
-      "avc"            : "h264",
-      "hevc"           : "h265",
-      "hevc-8"         : "h265",
-      "av1"            : "webm",
-      "av1-8"          : "webm",
-      "mpeg2"          : "m2v",
-      "mjpeg"          : "mjpeg",
+      Codec.AVC   : "h264",
+      Codec.HEVC  : "h265",
+      Codec.AV1   : "webm",
+      Codec.MPEG2 : "m2v",
+      Codec.MJPEG : "mjpeg",
     }.get(codec, "???")
 
   def validate_caps(self):

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.encoderbase import BaseEncoderTest, Encoder as GstEncoder
 from ....lib.gstreamer.util import have_gst_element, get_elements
 from ....lib.gstreamer.va.util import mapprofile, map_best_hw_format, mapformat
 from ....lib.gstreamer.va.decoder import Decoder
+from ....lib.codecs import Codec
 from ....lib.common import get_media, mapRangeInt
 
 class Encoder(GstEncoder):
@@ -24,14 +25,14 @@ class Encoder(GstEncoder):
 
   @property
   def rcmode(self):
-    if self.codec in ["jpeg"]:
+    if self.codec in [Codec.JPEG]:
       return ""
     return f" rate-control={super().rcmode}"
 
   @property
   def bframes(self):
     def inner(bframes):
-      if self.codec in ["av1-8", "av1-10"]:
+      if self.codec in [Codec.AV1]:
         return " gf-group-size={bframes}"
       return f" b-frames={bframes}"
     return self.ifprop("bframes", inner)
@@ -39,10 +40,10 @@ class Encoder(GstEncoder):
   @property
   def qp(self):
     def inner(qp):
-      if self.codec in ["mpeg2"]:
+      if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [0, 51])
         return f" qpi={mqp} qpp={mqp} qpb={mqp}"
-      if self.codec in ["av1-8", "av1-10", "vp9", "vp9-10"]:
+      if self.codec in [Codec.AV1, Codec.VP9]:
         return f" max-qp={qp} min-qp={qp} qp={qp}"
       return f" qpi={qp} qpp={qp} qpb={qp}"
     return self.ifprop("qp", inner)
@@ -50,7 +51,7 @@ class Encoder(GstEncoder):
   @property
   def quality(self):
     def inner(quality):
-      if self.codec in ["jpeg"]:
+      if self.codec in [Codec.JPEG]:
         return f" quality={quality}"
       return f" target-usage={quality}"
     return self.ifprop("quality", inner)

--- a/lib/gstreamer/va/transcoder.py
+++ b/lib/gstreamer/va/transcoder.py
@@ -8,6 +8,7 @@ import os
 import slash
 
 from ....lib import platform
+from ....lib.codecs import Codec
 from ....lib.common import get_media
 from ....lib.gstreamer.transcoderbase import BaseTranscoderTest
 from ....lib.gstreamer.util import have_gst_element
@@ -16,45 +17,45 @@ from ....lib.gstreamer.util import have_gst_element
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     decode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("openh264dec"), "h264parse ! openh264dec ! videoconvert"),
         hw = (platform.get_caps("decode", "avc"), have_gst_element("vah264dec"), "h264parse ! vah264dec"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("libde265dec"), "h265parse ! libde265dec ! videoconvert"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vah265dec"), "h265parse ! vah265dec"),
       ),
-      "av1-8" : dict(
+      Codec.AV1 : dict(
         hw = (platform.get_caps("decode", "av1_8"), have_gst_element("vaav1dec"), " matroskademux ! av1parse ! vaav1dec"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("mpeg2dec"), "mpegvideoparse ! mpeg2dec ! videoconvert"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("vampeg2dec"), "mpegvideoparse ! vampeg2dec"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegdec"), "jpegparse ! jpegdec"),
         hw = (platform.get_caps("decode", "jpeg"), have_gst_element("vajpegdec"), "jpegparse ! vajpegdec"),
       ),      
     },
     encode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vah264enc"), "vah264enc ! video/x-h264,profile=main ! h264parse"),
         lp = (platform.get_caps("vdenc", "avc"), have_gst_element("vah264lpenc"), "vah264lpenc ! video/x-h264,profile=main ! h264parse"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vah265enc"), "vah265enc ! video/x-h265,profile=main ! h265parse"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("vah265lpenc"), "vah265lpenc ! video/x-h265,profile=main ! h265parse"),
       ),
-      "av1-8" : dict(
+      Codec.AV1 : dict(
         lp = (platform.get_caps("vdenc", "av1_8"), have_gst_element("vaav1lpenc"), "vaav1lpenc ! video/x-av1,profile=main ! av1parse ! matroskamux"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
         hw = (platform.get_caps("encode", "mpeg2"), have_gst_element("vampeg2enc"), "vampeg2enc ! mpegvideoparse"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegenc"), "jpegenc ! jpegparse"),
         hw = (platform.get_caps("vdenc", "jpeg"), have_gst_element("vajpegenc"), "vajpegenc ! jpegparse"),
       ),
@@ -67,13 +68,6 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
   )
-
-  # hevc implies hevc 8 bit
-  requirements["encode"]["hevc"] = requirements["encode"]["hevc-8"]
-  requirements["decode"]["hevc"] = requirements["decode"]["hevc-8"]
-  # av1 implies av1 8 bit
-  requirements["encode"]["av1"] = requirements["encode"]["av1-8"]
-  requirements["decode"]["av1"] = requirements["decode"]["av1-8"]
 
   def before(self):
     super().before()

--- a/lib/gstreamer/va/util.py
+++ b/lib/gstreamer/va/util.py
@@ -4,6 +4,7 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+from ....lib.codecs import Codec
 from ....lib.common import memoize
 from ....lib.formats import match_best_format
 from ....lib.gstreamer.util import *
@@ -72,7 +73,7 @@ def map_transpose_direction(degrees, method):
 @memoize
 def mapprofile(codec, profile):
   return {
-    "avc"       : {
+    Codec.AVC   : {
       "high"                  : "high",
       "main"                  : "main",
       "baseline"              : "baseline",
@@ -80,25 +81,18 @@ def mapprofile(codec, profile):
       "multiview-high"        : "multiview-high",
       "stereo-high"           : "stereo-high",
     },
-    "hevc-8"    : {
+    Codec.HEVC  : {
       "main"                  : "main",
       "scc"                   : "screen-extended-main",
       "scc-444"               : "screen-extended-main-444",
       "main444"               : "main-444",
-    },
-    "hevc-10"   : {
       "main10"                : "main-10",
       "main444-10"            : "main-444-10",
-    },
-    "hevc-12"   : {
       "main12"                : "main-12",
       "main422-12"            : "main-422-12",
       "main444-12"            : "main-444-12",
     },
-    "av1-8"     : {
-      "profile0"              : "main",
-    },
-    "av1-10"    : {
+    Codec.AV1   : {
       "profile0"              : "main",
     },
   }.get(codec, {}).get(profile, None)

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -11,6 +11,7 @@ from ....lib.gstreamer.encoderbase import BaseEncoderTest, Encoder as GstEncoder
 from ....lib.gstreamer.util import have_gst_element, get_elements
 from ....lib.gstreamer.vaapi.util import mapprofile, map_best_hw_format, mapformat
 from ....lib.gstreamer.vaapi.decoder import Decoder
+from ....lib.codecs import Codec
 from ....lib.common import get_media, mapRangeInt
 
 class Encoder(GstEncoder):
@@ -24,17 +25,17 @@ class Encoder(GstEncoder):
 
   @property
   def rcmode(self):
-    if self.codec in ["jpeg"]:
+    if self.codec in [Codec.JPEG]:
       return ""
     return f" rate-control={super().rcmode}"
 
   @property
   def qp(self):
     def inner(qp):
-      if self.codec in ["mpeg2"]:
+      if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [2, 62])
         return f" quantizer={mqp}"
-      if self.codec in ["vp8", "vp9", "vp9-10"]:
+      if self.codec in [Codec.VP8, Codec.VP9]:
         return f" yac-qi={qp}"
       return f" init-qp={qp}"
     return self.ifprop("qp", inner)
@@ -42,7 +43,7 @@ class Encoder(GstEncoder):
   @property
   def quality(self):
     def inner(quality):
-      if self.codec in ["jpeg"]:
+      if self.codec in [Codec.JPEG]:
         return f" quality={quality}"
       return f" quality-level={quality}"
     return self.ifprop("quality", inner)

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -8,6 +8,7 @@ import os
 import slash
 
 from ....lib import platform
+from ....lib.codecs import Codec
 from ....lib.common import get_media
 from ....lib.gstreamer.transcoderbase import BaseTranscoderTest
 from ....lib.gstreamer.util import have_gst_element
@@ -16,23 +17,23 @@ from ....lib.gstreamer.util import have_gst_element
 class TranscoderTest(BaseTranscoderTest):
   requirements = dict(
     decode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("openh264dec"), "h264parse ! openh264dec ! videoconvert"),
         hw = (platform.get_caps("decode", "avc"), have_gst_element("vaapih264dec"), "h264parse ! vaapih264dec"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("libde265dec"), "h265parse ! libde265dec ! videoconvert"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element("vaapih265dec"), "h265parse ! vaapih265dec"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("mpeg2dec"), "mpegvideoparse ! mpeg2dec ! videoconvert"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element("vaapimpeg2dec"), "mpegvideoparse ! vaapimpeg2dec"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegdec"), "jpegparse ! jpegdec"),
         hw = (platform.get_caps("decode", "jpeg"), have_gst_element("vaapijpegdec"), "jpegparse ! vaapijpegdec"),
       ),
-      "vc1" : dict(
+      Codec.VC1 : dict(
         sw = (
           dict(maxres = (16384, 16384)), have_gst_element("avdec_vc1"),
           "'video/x-wmv,profile=(string)advanced'"
@@ -46,21 +47,21 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
     encode = {
-      "avc" : dict(
+      Codec.AVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x264enc"), "x264enc ! video/x-h264,profile=main ! h264parse"),
         hw = (platform.get_caps("encode", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc ! video/x-h264,profile=main ! h264parse"),
         lp = (platform.get_caps("vdenc", "avc"), have_gst_element("vaapih264enc"), "vaapih264enc rate-control=cqp tune=low-power ! video/x-h264,profile=main ! h264parse"),
       ),
-      "hevc-8" : dict(
+      Codec.HEVC : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("x265enc"), "videoconvert chroma-mode=none dither=0 ! video/x-raw,format=I420 ! x265enc ! video/x-h265,profile=main ! h265parse"),
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc ! video/x-h265,profile=main ! h265parse"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element("vaapih265enc"), "vaapih265enc tune=low-power ! video/x-h265,profile=main ! h265parse"),
       ),
-      "mpeg2" : dict(
+      Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
         hw = (platform.get_caps("encode", "mpeg2"), have_gst_element("vaapimpeg2enc"), "vaapimpeg2enc ! mpegvideoparse"),
       ),
-      "mjpeg" : dict(
+      Codec.MJPEG : dict(
         sw = (dict(maxres = (16384, 16384)), have_gst_element("jpegenc"), "jpegenc ! jpegparse"),
         hw = (platform.get_caps("vdenc", "jpeg"), have_gst_element("vaapijpegenc"), "vaapijpegenc ! jpegparse"),
       ),
@@ -73,10 +74,6 @@ class TranscoderTest(BaseTranscoderTest):
       ),
     },
   )
-
-  # hevc implies hevc 8 bit
-  requirements["encode"]["hevc"] = requirements["encode"]["hevc-8"]
-  requirements["decode"]["hevc"] = requirements["decode"]["hevc-8"]
 
   def before(self):
     super().before()

--- a/lib/gstreamer/vaapi/util.py
+++ b/lib/gstreamer/vaapi/util.py
@@ -4,6 +4,7 @@
 ### SPDX-License-Identifier: BSD-3-Clause
 ###
 
+from ....lib.codecs import Codec
 from ....lib.common import memoize
 from ....lib.formats import match_best_format
 from ....lib.gstreamer.util import *
@@ -80,7 +81,7 @@ def map_transpose_direction(degrees, method):
 @memoize
 def mapprofile(codec, profile):
   return {
-    "avc"      : {
+    Codec.AVC   : {
       "high"                  : "high",
       "main"                  : "main",
       "baseline"              : "baseline",
@@ -88,26 +89,16 @@ def mapprofile(codec, profile):
       "multiview-high"        : "multiview-high",
       "stereo-high"           : "stereo-high",
     },
-    "hevc-8"   : {
+    Codec.HEVC  : {
       "main"                  : "main",
       "scc"                   : "screen-extended-main",
       "scc-444"               : "screen-extended-main-444",
       "main444"               : "main-444",
-    },
-    "hevc-10"  : {
       "main10"                : "main-10",
       "main444-10"            : "main-444-10",
-    },
-    "av1-8"   : {
-      "main"                  : "main",
-    },
-    "av1-10"   : {
-      "main"                  : "main",
-    },
-    "hevc-12" : {
       "main12"                : "main-12",
     },
-    "vp9-12" : {
+    Codec.VP9   : {
       "profile3"              : "profile3",
     },
   }.get(codec, {}).get(profile, None)

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
@@ -19,7 +20,7 @@ class JPEGEncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps      = platform.get_caps("vdenc", "jpeg"),
-      codec     = "jpeg",
+      codec     = Codec.JPEG,
       ffencoder = "mjpeg_qsv",
       ffdecoder = "mjpeg_qsv",
     )

--- a/test/ffmpeg-qsv/transcode/av1.py
+++ b/test/ffmpeg-qsv/transcode/av1.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("av1", "transcode")
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "av1",
+      codec = Codec.AV1,
     )
     self.transcode()
 

--- a/test/ffmpeg-qsv/transcode/avc.py
+++ b/test/ffmpeg-qsv/transcode/avc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("avc", "transcode")
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "avc",
+      codec = Codec.AVC,
     )
     self.transcode()
 

--- a/test/ffmpeg-qsv/transcode/hevc.py
+++ b/test/ffmpeg-qsv/transcode/hevc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("hevc", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/ffmpeg-qsv/transcode/hevc_h2s.py
+++ b/test/ffmpeg-qsv/transcode/hevc_h2s.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("hevc", "h2s")
 
@@ -18,6 +19,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/ffmpeg-qsv/transcode/mpeg2.py
+++ b/test/ffmpeg-qsv/transcode/mpeg2.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("mpeg2", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
     )
     self.transcode()

--- a/test/ffmpeg-qsv/transcode/vc1.py
+++ b/test/ffmpeg-qsv/transcode/vc1.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
 from ....lib.ffmpeg.qsv.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("vc1", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "vc1",
+      codec = Codec.VC1,
     )
     self.transcode()

--- a/test/ffmpeg-vaapi/encode/10bit/av1.py
+++ b/test/ffmpeg-vaapi/encode/10bit/av1.py
@@ -7,6 +7,7 @@
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
+from .....lib.codecs import Codec
 
 spec      = load_test_spec("av1", "encode", "10bit")
 spec_r2r  = load_test_spec("av1", "encode", "10bit", "r2r")
@@ -16,7 +17,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec = "av1-10",
+      codec = Codec.AV1,
       ffenc = "av1_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -7,6 +7,7 @@
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
+from .....lib.codecs import Codec
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
@@ -16,7 +17,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec   = "hevc-10",
+      codec   = Codec.HEVC,
       ffenc   = "hevc_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -8,6 +8,7 @@ from .....lib import *
 from .....lib.formats import PixelFormat
 from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
+from .....lib.codecs import Codec
 
 spec = load_test_spec("vp9", "encode", "10bit")
 
@@ -16,7 +17,7 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec    = "vp9-10",
+      codec    = Codec.VP9,
       ffenc    = "vp9_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/12bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/12bit/hevc.py
@@ -7,6 +7,7 @@
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
 from .....lib.ffmpeg.vaapi.encoder import EncoderTest
+from .....lib.codecs import Codec
 
 spec = load_test_spec("hevc", "encode", "12bit")
 
@@ -15,7 +16,7 @@ class HEVC12EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec   = "hevc-12",
+      codec   = Codec.HEVC,
       ffenc   = "hevc_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/av1.py
+++ b/test/ffmpeg-vaapi/encode/av1.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("av1", "encode", "8bit")
 spec_r2r  = load_test_spec("av1", "encode", "8bit", "r2r")
@@ -16,7 +17,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec = "av1-8",
+      codec = Codec.AV1,
       ffenc = "av1_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
@@ -16,7 +17,7 @@ class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec   = "avc",
+      codec   = Codec.AVC,
       ffenc   = "h264_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
@@ -16,7 +17,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec   = "hevc-8",
+      codec   = Codec.HEVC,
       ffenc   = "hevc_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
@@ -18,7 +19,7 @@ class JPEGEncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps  = platform.get_caps("vdenc", "jpeg"),
-      codec = "jpeg",
+      codec = Codec.JPEG,
       ffenc = "mjpeg_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
@@ -18,7 +19,7 @@ class MPEG2EncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps  = platform.get_caps("encode", "mpeg2"),
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
       ffenc = "mpeg2_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -8,6 +8,7 @@ from ....lib import *
 from ....lib.formats import PixelFormat
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.encoder import EncoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("vp9", "encode", "8bit")
 
@@ -16,7 +17,7 @@ class VP9EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec   = "vp9",
+      codec   = Codec.VP9,
       ffenc   = "vp9_vaapi",
     )
 

--- a/test/ffmpeg-vaapi/transcode/av1.py
+++ b/test/ffmpeg-vaapi/transcode/av1.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("av1", "transcode")
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "av1",
+      codec = Codec.AV1,
     )
     self.transcode()
 

--- a/test/ffmpeg-vaapi/transcode/avc.py
+++ b/test/ffmpeg-vaapi/transcode/avc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("avc", "transcode")
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "avc",
+      codec = Codec.AVC,
     )
     self.transcode()
 

--- a/test/ffmpeg-vaapi/transcode/hevc.py
+++ b/test/ffmpeg-vaapi/transcode/hevc.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("hevc", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/ffmpeg-vaapi/transcode/hevc_h2s.py
+++ b/test/ffmpeg-vaapi/transcode/hevc_h2s.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("hevc", "h2s")
 
@@ -18,6 +19,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/ffmpeg-vaapi/transcode/mpeg2.py
+++ b/test/ffmpeg-vaapi/transcode/mpeg2.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("mpeg2", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
     )
     self.transcode()

--- a/test/ffmpeg-vaapi/transcode/vc1.py
+++ b/test/ffmpeg-vaapi/transcode/vc1.py
@@ -7,6 +7,7 @@
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
 from ....lib.ffmpeg.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
 
 spec = load_test_spec("vc1", "transcode")
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "vc1",
+      codec = Codec.VC1,
     )
     self.transcode()

--- a/test/gst-msdk/encode/10bit/av1.py
+++ b/test/gst-msdk/encode/10bit/av1.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
 from .....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "av1-10",
+      codec         = Codec.AV1,
       gstencoder    = "msdkav1enc",
       gstdecoder    = "msdkav1dec",
       gstmediatype  = "video/x-av1",

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
 from .....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-10",
+      codec         = Codec.HEVC,
       gstencoder    = "msdkh265enc",
       gstdecoder    = "msdkh265dec",
       gstmediatype  = "video/x-h265",

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
 from .....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9-10",
+      codec         = Codec.VP9,
       gstencoder    = "msdkvp9enc",
       gstdecoder    = "msdkvp9dec",
       gstmediatype  = "video/x-vp9",

--- a/test/gst-msdk/encode/12bit/hevc.py
+++ b/test/gst-msdk/encode/12bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
 from .....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class HEVC12EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-12",
+      codec         = Codec.HEVC,
       gstdecoder    = "msdkh265dec",
       gstencoder    = "msdkh265enc",
       gstmediatype  = "video/x-h265",

--- a/test/gst-msdk/encode/av1.py
+++ b/test/gst-msdk/encode/av1.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "av1-8",
+      codec         = Codec.AV1,
       gstencoder    = "msdkav1enc",
       gstdecoder    = "msdkav1dec",
       gstmediatype  = "video/x-av1",

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "avc",
+      codec         = Codec.AVC,
       gstencoder    = "msdkh264enc",
       gstdecoder    = "msdkh264dec",
       gstmediatype  = "video/x-h264",

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-8",
+      codec         = Codec.HEVC,
       gstencoder    = "msdkh265enc",
       gstdecoder    = "msdkh265dec",
       gstmediatype  = "video/x-h265",

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -19,7 +20,7 @@ class JPEGEncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = "jpeg",
+      codec         = Codec.JPEG,
       gstencoder    = "msdkmjpegenc",
       gstdecoder    = "msdkmjpegdec",
       gstmediatype  = "image/jpeg",

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -19,7 +20,7 @@ class MPEG2EncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps          = platform.get_caps("encode", "mpeg2"),
-      codec         = "mpeg2",
+      codec         = Codec.MPEG2,
       gstencoder    = "msdkmpeg2enc",
       gstdecoder    = "msdkmpeg2dec",
       gstmediatype  = "video/mpeg,mpegversion=2",

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class VP9EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9",
+      codec         = Codec.VP9,
       gstencoder    = "msdkvp9enc",
       gstdecoder    = "msdkvp9dec",
       gstmediatype  = "video/x-vp9",

--- a/test/gst-msdk/transcode/avc.py
+++ b/test/gst-msdk/transcode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "avc",
+      codec = Codec.AVC,
     )
     self.transcode()
 

--- a/test/gst-msdk/transcode/hevc.py
+++ b/test/gst-msdk/transcode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/gst-msdk/transcode/mpeg2.py
+++ b/test/gst-msdk/transcode/mpeg2.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
     )
     self.transcode()

--- a/test/gst-msdk/transcode/vc1.py
+++ b/test/gst-msdk/transcode/vc1.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
 from ....lib.gstreamer.msdk.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "vc1",
+      codec = Codec.VC1,
     )
     self.transcode()

--- a/test/gst-va/encode/10bit/av1.py
+++ b/test/gst-va/encode/10bit/av1.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
 from .....lib.gstreamer.va.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "av1-10",
+      codec         = Codec.AV1,
       gstdecoder    = "vaav1dec",
       gstmediatype  = "video/x-av1",
       gstmuxer      = "matroskamux",

--- a/test/gst-va/encode/10bit/hevc.py
+++ b/test/gst-va/encode/10bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
 from .....lib.gstreamer.va.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-10",
+      codec         = Codec.HEVC,
       gstdecoder    = "vah265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",

--- a/test/gst-va/encode/10bit/vp9.py
+++ b/test/gst-va/encode/10bit/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
 from .....lib.gstreamer.va.encoder import EncoderTest
 
@@ -15,7 +16,7 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9-10",
+      codec         = Codec.VP9,
       gstdecoder    = "vavp9dec",
       gstmediatype  = "video/x-vp9",
       gstparser     = "vp9parse",

--- a/test/gst-va/encode/12bit/hevc.py
+++ b/test/gst-va/encode/12bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
 from .....lib.gstreamer.va.encoder import EncoderTest
 
@@ -15,7 +16,7 @@ class HEVC12EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-12",
+      codec         = Codec.HEVC,
       gstdecoder    = "vah265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",

--- a/test/gst-va/encode/av1.py
+++ b/test/gst-va/encode/av1.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class AV1EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "av1-8",
+      codec         = Codec.AV1,
       gstdecoder    = "vaav1dec",
       gstmediatype  = "video/x-av1",
       gstmuxer      = "matroskamux",

--- a/test/gst-va/encode/avc.py
+++ b/test/gst-va/encode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "avc",
+      codec         = Codec.AVC,
       gstdecoder    = "vah264dec",
       gstmediatype  = "video/x-h264",
       gstparser     = "h264parse",

--- a/test/gst-va/encode/hevc.py
+++ b/test/gst-va/encode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-8",
+      codec         = Codec.HEVC,
       gstdecoder    = "vah265dec",
       gstmediatype  = "video/x-h265",
       gstparser     = "h265parse",

--- a/test/gst-va/encode/jpeg.py
+++ b/test/gst-va/encode/jpeg.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.encoder import EncoderTest
 
@@ -19,7 +20,7 @@ class JPEGEncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = "jpeg",
+      codec         = Codec.JPEG,
       gstencoder    = "vajpegenc",
       gstdecoder    = "vajpegdec",
       gstmediatype  = "image/jpeg",

--- a/test/gst-va/encode/vp9.py
+++ b/test/gst-va/encode/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.encoder import EncoderTest
 
@@ -15,7 +16,7 @@ class VP9EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9",
+      codec         = Codec.VP9,
       gstdecoder    = "vavp9dec",
       gstmediatype  = "video/x-vp9",
       gstparser     = "vp9parse",

--- a/test/gst-va/transcode/avc.py
+++ b/test/gst-va/transcode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.transcoder import TranscoderTest
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "avc",
+      codec = Codec.AVC,
     )
     self.transcode()
 

--- a/test/gst-va/transcode/hevc.py
+++ b/test/gst-va/transcode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/gst-va/transcode/mpeg2.py
+++ b/test/gst-va/transcode/mpeg2.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
 from ....lib.gstreamer.va.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
     )
     self.transcode()

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
 from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class HEVC10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-10",
+      codec         = Codec.HEVC,
       gstencoder    = "vaapih265enc",
       gstdecoder    = "vaapih265dec",
       gstmediatype  = "video/x-h265",

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
 from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class VP9_10EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9-10",
+      codec         = Codec.VP9,
       gstencoder    = "vaapivp9enc",
       gstdecoder    = "vaapivp9dec",
       gstmediatype  = "video/x-vp9",

--- a/test/gst-vaapi/encode/12bit/hevc.py
+++ b/test/gst-vaapi/encode/12bit/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from .....lib import *
+from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
 from .....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class HEVC12EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-12",
+      codec         = Codec.HEVC,
       gstdecoder    = "vaapih265dec",
       gstencoder    = "vaapih265enc",
       gstmediatype  = "video/x-h265",

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class AVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "avc",
+      codec         = Codec.AVC,
       gstencoder    = "vaapih264enc",
       gstdecoder    = "vaapih264dec",
       gstmediatype  = "video/x-h264",

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -17,7 +18,7 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "hevc-8",
+      codec         = Codec.HEVC,
       gstencoder    = "vaapih265enc",
       gstdecoder    = "vaapih265dec",
       gstmediatype  = "video/x-h265",

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -19,7 +20,7 @@ class JPEGEncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = "jpeg",
+      codec         = Codec.JPEG,
       gstencoder    = "vaapijpegenc",
       gstdecoder    = "vaapijpegdec",
       gstmediatype  = "image/jpeg",

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -19,7 +20,7 @@ class MPEG2EncoderTest(EncoderTest):
     super().before()
     vars(self).update(
       caps          = platform.get_caps("encode", "mpeg2"),
-      codec         = "mpeg2",
+      codec         = Codec.MPEG2,
       gstencoder    = "vaapimpeg2enc",
       gstdecoder    = "vaapimpeg2dec",
       gstmediatype  = "video/mpeg,mpegversion=2",

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class VP8EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp8",
+      codec         = Codec.VP8,
       gstencoder    = "vaapivp8enc",
       gstdecoder    = "vaapivp8dec",
       gstmediatype  = "video/x-vp8",

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.encoder import EncoderTest
 
@@ -16,7 +17,7 @@ class VP9EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
-      codec         = "vp9",
+      codec         = Codec.VP9,
       gstencoder    = "vaapivp9enc",
       gstdecoder    = "vaapivp9dec",
       gstmediatype  = "video/x-vp9",

--- a/test/gst-vaapi/transcode/avc.py
+++ b/test/gst-vaapi/transcode/avc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
@@ -16,7 +17,7 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "avc",
+      codec = Codec.AVC,
     )
     self.transcode()
 

--- a/test/gst-vaapi/transcode/hevc.py
+++ b/test/gst-vaapi/transcode/hevc.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "hevc",
+      codec = Codec.HEVC,
     )
     self.transcode()

--- a/test/gst-vaapi/transcode/mpeg2.py
+++ b/test/gst-vaapi/transcode/mpeg2.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "mpeg2",
+      codec = Codec.MPEG2,
     )
     self.transcode()

--- a/test/gst-vaapi/transcode/vc1.py
+++ b/test/gst-vaapi/transcode/vc1.py
@@ -5,6 +5,7 @@
 ###
 
 from ....lib import *
+from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
 from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
 
@@ -16,6 +17,6 @@ class default(TranscoderTest):
     vars(self).update(spec[case].copy())
     vars(self).update(
       case  = case,
-      codec = "vc1",
+      codec = Codec.VC1,
     )
     self.transcode()


### PR DESCRIPTION
Depends on https://github.com/intel/vaapi-fits/pull/573

Different and inconsistent hard-coded strings that represent
the same codec can introduce bugs and make it harder to maintain.
Thus, use the new common Codec enum to improve consistency and
maintenance problems.
    
The bitdepth in codec strings are overkill and unnecessary, so
that distinction is removed.
    
For transcode, currently only 8-bit is supported and assumed.
Additional bitdepth support may be added in the future using
a different logic.
