### PR TITLE
Move and consolidate codec-specialized encode test classes to lib

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -56,6 +56,7 @@ class MediaPlugin(slash.plugins.PluginInterface):
   testspec = dict()
 
   platform = None
+  render_device = "/dev/dri/renderD128"
   suite = os.path.basename(sys.argv[0])
   mypath = __SCRIPT_DIR__
   blacklist = {}

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -14,6 +14,7 @@ from ....lib.ffmpeg.qsv.util import mapprofile, using_compatible_driver, have_en
 from ....lib.ffmpeg.qsv.decoder import Decoder
 from ....lib.common import mapRangeInt, get_media, call, exe2os
 from ....lib.codecs import Codec
+from ....lib.formats import PixelFormat
 
 class Encoder(FFEncoder):
   hwaccel   = property(lambda s: "qsv")
@@ -244,6 +245,10 @@ class HEVC8EncoderTest(HEVCEncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
 class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
   def before(self):
@@ -252,6 +257,10 @@ class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
       caps      = platform.get_caps("vdenc", "hevc_8"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
 
 ############################
 ## HEVC 10 Bit Encoders   ##
@@ -266,6 +275,10 @@ class HEVC10EncoderTest(HEVCEncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
 class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
   def before(self):
@@ -274,6 +287,10 @@ class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
       caps      = platform.get_caps("vdenc", "hevc_10"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
 
 ############################
 ## HEVC 12 Bit Encoders   ##
@@ -287,6 +304,10 @@ class HEVC12EncoderTest(HEVCEncoderBaseTest):
       caps      = platform.get_caps("encode", "hevc_12"),
       lowpower  = 0,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 12
+    super().validate_caps()
 
 ############################
 ## AV1 Base Encoder       ##
@@ -319,6 +340,10 @@ class AV1EncoderTest(AV1EncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "av1_8"))
 class AV1EncoderLPTest(AV1EncoderBaseTest):
   def before(self):
@@ -327,6 +352,10 @@ class AV1EncoderLPTest(AV1EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "av1_8"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
 
 ############################
 ## AV1 10 Bit Encoders    ##
@@ -341,6 +370,10 @@ class AV110EncoderTest(AV1EncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "av1_10"))
 class AV110EncoderLPTest(AV1EncoderBaseTest):
   def before(self):
@@ -349,6 +382,10 @@ class AV110EncoderLPTest(AV1EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "av1_10"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
 
 ############################
 ## VP9 Base Encoder       ##
@@ -381,6 +418,10 @@ class VP9_8EncoderTest(VP9EncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
 class VP9_8EncoderLPTest(VP9EncoderBaseTest):
   def before(self):
@@ -389,6 +430,10 @@ class VP9_8EncoderLPTest(VP9EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "vp9_8"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
 
 ############################
 ## VP9 10 Bit Encoders    ##
@@ -403,6 +448,10 @@ class VP9_10EncoderTest(VP9EncoderBaseTest):
       lowpower  = 0,
     )
 
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
 @slash.requires(*platform.have_caps("vdenc", "vp9_10"))
 class VP9_10EncoderLPTest(VP9EncoderBaseTest):
   def before(self):
@@ -411,6 +460,10 @@ class VP9_10EncoderLPTest(VP9EncoderBaseTest):
       caps      = platform.get_caps("vdenc", "vp9_10"),
       lowpower  = 1,
     )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
 
 ############################
 ## MPEG2 Encoders         ##

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -431,3 +431,23 @@ class MPEG2EncoderTest(EncoderTest):
 
   def get_file_ext(self):
     return "m2v"
+
+############################
+## JPEG/MJPEG Encoders    ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
+@slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "jpeg"),
+      codec     = Codec.JPEG,
+      ffencoder = "mjpeg_qsv",
+      ffdecoder = "mjpeg_qsv",
+    )
+
+  def get_file_ext(self):
+    return "mjpeg" if self.frames > 1 else "jpg"

--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -214,12 +214,12 @@ class AVCEncoderLPTest(AVCEncoderBaseTest):
     )
 
 ############################
-## HEVC 8 Bit Encoders    ##
+## HEVC Base Encoder      ##
 ############################
 
 @slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
 @slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-class HEVC8EncoderBaseTest(EncoderTest):
+class HEVCEncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -231,8 +231,12 @@ class HEVC8EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "h265"
 
+############################
+## HEVC 8 Bit Encoders    ##
+############################
+
 @slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVC8EncoderBaseTest):
+class HEVC8EncoderTest(HEVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -241,7 +245,7 @@ class HEVC8EncoderTest(HEVC8EncoderBaseTest):
     )
 
 @slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
+class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -253,22 +257,8 @@ class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
 ## HEVC 10 Bit Encoders   ##
 ############################
 
-@slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-class HEVC10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = Codec.HEVC,
-      ffencoder = "hevc_qsv",
-      ffdecoder = "hevc_qsv",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
 @slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVC10EncoderBaseTest):
+class HEVC10EncoderTest(HEVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -277,7 +267,7 @@ class HEVC10EncoderTest(HEVC10EncoderBaseTest):
     )
 
 @slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
+class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -289,22 +279,8 @@ class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
 ## HEVC 12 Bit Encoders   ##
 ############################
 
-@slash.requires(*have_ffmpeg_encoder("hevc_qsv"))
-@slash.requires(*have_ffmpeg_decoder("hevc_qsv"))
-class HEVC12EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = Codec.HEVC,
-      ffencoder = "hevc_qsv",
-      ffdecoder = "hevc_qsv",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
 @slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVC12EncoderBaseTest):
+class HEVC12EncoderTest(HEVCEncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -313,7 +289,7 @@ class HEVC12EncoderTest(HEVC12EncoderBaseTest):
     )
 
 ############################
-## AV1 8 Bit Encoders     ##
+## AV1 Base Encoder       ##
 ############################
 
 @slash.requires(*have_ffmpeg_encoder("av1_qsv"))
@@ -329,6 +305,10 @@ class AV1EncoderBaseTest(EncoderTest):
 
   def get_file_ext(self):
     return "ivf"
+
+############################
+## AV1 8 Bit Encoders     ##
+############################
 
 @slash.requires(*platform.have_caps("encode", "av1_8"))
 class AV1EncoderTest(AV1EncoderBaseTest):
@@ -352,22 +332,8 @@ class AV1EncoderLPTest(AV1EncoderBaseTest):
 ## AV1 10 Bit Encoders    ##
 ############################
 
-@slash.requires(*have_ffmpeg_encoder("av1_qsv"))
-@slash.requires(*have_ffmpeg_decoder("av1_qsv"))
-class AV110EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = Codec.AV1,
-      ffencoder = "av1_qsv",
-      ffdecoder = "av1_qsv",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
 @slash.requires(*platform.have_caps("encode", "av1_10"))
-class AV110EncoderTest(AV110EncoderBaseTest):
+class AV110EncoderTest(AV1EncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -376,7 +342,7 @@ class AV110EncoderTest(AV110EncoderBaseTest):
     )
 
 @slash.requires(*platform.have_caps("vdenc", "av1_10"))
-class AV110EncoderLPTest(AV110EncoderBaseTest):
+class AV110EncoderLPTest(AV1EncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -385,12 +351,12 @@ class AV110EncoderLPTest(AV110EncoderBaseTest):
     )
 
 ############################
-## VP9 8 Bit Encoders     ##
+## VP9 Base Encoder       ##
 ############################
 
 @slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
 @slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
-class VP9_8EncoderBaseTest(EncoderTest):
+class VP9EncoderBaseTest(EncoderTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -402,8 +368,12 @@ class VP9_8EncoderBaseTest(EncoderTest):
   def get_file_ext(self):
     return "ivf"
 
+############################
+## VP9 8 Bit Encoders     ##
+############################
+
 @slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9_8EncoderTest(VP9_8EncoderBaseTest):
+class VP9_8EncoderTest(VP9EncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
@@ -412,11 +382,33 @@ class VP9_8EncoderTest(VP9_8EncoderBaseTest):
     )
 
 @slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9_8EncoderLPTest(VP9_8EncoderBaseTest):
+class VP9_8EncoderLPTest(VP9EncoderBaseTest):
   def before(self):
     super().before()
     vars(self).update(
       caps      = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = 1,
+    )
+
+############################
+## VP9 10 Bit Encoders    ##
+############################
+
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+class VP9_10EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
       lowpower  = 1,
     )
 
@@ -439,39 +431,3 @@ class MPEG2EncoderTest(EncoderTest):
 
   def get_file_ext(self):
     return "m2v"
-
-############################
-## VP9 10 Bit Encoders    ##
-############################
-
-@slash.requires(*have_ffmpeg_encoder("vp9_qsv"))
-@slash.requires(*have_ffmpeg_decoder("vp9_qsv"))
-class VP9_10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = Codec.VP9,
-      ffencoder = "vp9_qsv",
-      ffdecoder = "vp9_qsv",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      lowpower  = 1,
-    )

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -437,3 +437,24 @@ class MPEG2EncoderTest(EncoderTest):
 
   def get_vaapi_profile(self):
     return "VAProfileMPEG2.*"
+
+############################
+## JPEG/MJPEG Encoders    ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("vdenc", "jpeg"),
+      codec = Codec.JPEG,
+      ffenc = "mjpeg_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "mjpeg" if self.frames > 1 else "jpg"
+
+  def get_vaapi_profile(self):
+    return "VAProfileJPEGBaseline"

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -131,3 +131,44 @@ class VP8EncoderTest(EncoderTest):
 
   def get_vaapi_profile(self):
     return "VAProfileVP8Version0_3"
+
+############################
+## AVC Encoders           ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
+class AVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec   = Codec.AVC,
+      ffenc   = "h264_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "h264"
+
+  def get_vaapi_profile(self):
+    return {
+      "high"                  : "VAProfileH264High",
+      "main"                  : "VAProfileH264Main",
+      "constrained-baseline"  : "VAProfileH264ConstrainedBaseline",
+    }[self.profile]
+
+@slash.requires(*platform.have_caps("encode", "avc"))
+class AVCEncoderTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "avc"),
+      lowpower  = 0,
+    )
+
+@slash.requires(*platform.have_caps("vdenc", "avc"))
+class AVCEncoderLPTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "avc"),
+      lowpower  = 1,
+    )

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -345,3 +345,74 @@ class VP9_10EncoderLPTest(VP9EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## AV1 Encoders           ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("av1_vaapi"))
+class AV1EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec = Codec.AV1,
+      ffenc = "av1_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "ivf"
+
+  def get_vaapi_profile(self):
+    return "VAProfileAV1Profile0"
+
+@slash.requires(*platform.have_caps("encode", "av1_8"))
+class AV1EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "av1_8"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "av1_8"))
+class AV1EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_8"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "av1_10"))
+class AV1_10EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "av1_10"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "av1_10"))
+class AV1_10EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_10"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -266,3 +266,82 @@ class HEVC12EncoderTest(HEVCEncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 12
     super().validate_caps()
+
+############################
+## VP9 Encoders           ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
+class VP9EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec   = Codec.VP9,
+      ffenc   = "vp9_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "ivf"
+
+  def get_vaapi_profile(self):
+    pf = PixelFormat(self.format)
+    return {
+      ("YUV420",  8) : "VAProfileVP9Profile0",
+      ("YUV422",  8) : "VAProfileVP9Profile1",
+      ("YUV444",  8) : "VAProfileVP9Profile1",
+      ("YUV420", 10) : "VAProfileVP9Profile2",
+      ("YUV422", 10) : "VAProfileVP9Profile3",
+      ("YUV444", 10) : "VAProfileVP9Profile3",
+    }[(pf.subsampling, pf.bitdepth)]
+
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_8"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+class VP9_10EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -416,3 +416,24 @@ class AV1_10EncoderLPTest(AV1EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## MPEG2 Encoders         ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
+class MPEG2EncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("encode", "mpeg2"),
+      codec = Codec.MPEG2,
+      ffenc = "mpeg2_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "m2v"
+
+  def get_vaapi_profile(self):
+    return "VAProfileMPEG2.*"

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -111,350 +111,116 @@ class EncoderTest(BaseEncoderTest):
     m = re.search(ipbmsgs[ipbmode], self.output, re.MULTILINE)
     assert m is not None, "Possible incorrect IPB mode used"
 
-############################
-## VP8 Encoders           ##
-############################
+def codec_test_class(codec, engine, bitdepth, **kwargs):
+  # lowpower setting for codecs that support it
+  if codec not in [Codec.JPEG, Codec.MPEG2]:
+    kwargs.update(lowpower = 1 if engine == "vdenc" else 0)
 
-@slash.requires(*have_ffmpeg_encoder("vp8_vaapi"))
-@slash.requires(*platform.have_caps("encode", "vp8"))
-class VP8EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec     = Codec.VP8,
-      ffenc     = "vp8_vaapi",
-      caps      = platform.get_caps("encode", "vp8"),
-      lowpower  = 0,
-    )
+  # caps lookup translation
+  capcodec = codec
+  if codec in [Codec.HEVC, Codec.VP9, Codec.AV1]:
+    capcodec = f"{codec}_{bitdepth}"
 
-  def get_file_ext(self):
-    return "ivf"
+  # ffmpeg plugin codec translation
+  ffcodec = {
+    Codec.AVC   : "h264",
+    Codec.JPEG  : "mjpeg",
+  }.get(codec, codec)
 
-  def get_vaapi_profile(self):
-    return "VAProfileVP8Version0_3"
+  @slash.requires(*have_ffmpeg_encoder(f"{ffcodec}_vaapi"))
+  @slash.requires(*platform.have_caps(engine, capcodec))
+  class CodecEncoderTest(EncoderTest):
+    def before(self):
+      super().before()
+      vars(self).update(
+        caps = platform.get_caps(engine, capcodec),
+        codec = codec,
+        ffenc = f"{ffcodec}_vaapi",
+        **kwargs,
+      )
 
-############################
-## AVC Encoders           ##
-############################
+    def validate_caps(self):
+      assert PixelFormat(self.format).bitdepth == bitdepth
+      super().validate_caps()
 
-@slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.AVC,
-      ffenc   = "h264_vaapi",
-    )
+    def get_file_ext(self):
+      return {
+        Codec.AVC   : "h264",
+        Codec.HEVC  : "h265",
+        Codec.JPEG  : "mjpeg" if self.frames > 1 else "jpg",
+        Codec.MPEG2 : "m2v",
+        Codec.VP8   : "ivf",
+        Codec.VP9   : "ivf",
+        Codec.AV1   : "ivf",
+      }[codec]
 
-  def get_file_ext(self):
-    return "h264"
+    def get_vaapi_profile(self):
+      if Codec.AVC == codec:
+        return {
+          "high"                  : "VAProfileH264High",
+          "main"                  : "VAProfileH264Main",
+          "constrained-baseline"  : "VAProfileH264ConstrainedBaseline",
+        }[self.profile]
+      elif Codec.HEVC == codec:
+        return {
+          "main"                  : "VAProfileHEVCMain",
+          "main444"               : "VAProfileHEVCMain444",
+          "scc"                   : "VAProfileHEVCSccMain",
+          "scc-444"               : "VAProfileHEVCSccMain444",
+          "main10"                : "VAProfileHEVCMain10",
+          "main444-10"            : "VAProfileHEVCMain444_10",
+          "main12"                : "VAProfileHEVCMain12",
+          "main422-12"            : "VAProfileHEVCMain422_12",
+        }[self.profile]
+      elif Codec.VP8 == codec:
+        return "VAProfileVP8Version0_3"
+      elif Codec.VP9 == codec:
+        pf = PixelFormat(self.format)
+        return {
+          ("YUV420",  8) : "VAProfileVP9Profile0",
+          ("YUV422",  8) : "VAProfileVP9Profile1",
+          ("YUV444",  8) : "VAProfileVP9Profile1",
+          ("YUV420", 10) : "VAProfileVP9Profile2",
+          ("YUV422", 10) : "VAProfileVP9Profile3",
+          ("YUV444", 10) : "VAProfileVP9Profile3",
+        }[(pf.subsampling, pf.bitdepth)]
+      elif Codec.AV1 == codec:
+        return "VAProfileAV1Profile0"
+      elif Codec.JPEG == codec:
+        return "VAProfileJPEGBaseline"
+      elif Codec.MPEG2 == codec:
+        return "VAProfileMPEG2.*"
 
-  def get_vaapi_profile(self):
-    return {
-      "high"                  : "VAProfileH264High",
-      "main"                  : "VAProfileH264Main",
-      "constrained-baseline"  : "VAProfileH264ConstrainedBaseline",
-    }[self.profile]
+  return CodecEncoderTest
 
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = 0,
-    )
+##### AVC #####
+AVCEncoderTest      = codec_test_class(Codec.AVC, "encode", 8)
+AVCEncoderLPTest    = codec_test_class(Codec.AVC,  "vdenc", 8)
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = 1,
-    )
+##### HEVC #####
+HEVC8EncoderTest    = codec_test_class(Codec.HEVC, "encode",  8)
+HEVC8EncoderLPTest  = codec_test_class(Codec.HEVC,  "vdenc",  8)
+HEVC10EncoderTest   = codec_test_class(Codec.HEVC, "encode", 10)
+HEVC10EncoderLPTest = codec_test_class(Codec.HEVC,  "vdenc", 10)
+HEVC12EncoderTest   = codec_test_class(Codec.HEVC, "encode", 12)
 
-############################
-## HEVC Encoders          ##
-############################
+##### AV1 #####
+AV1EncoderTest      = codec_test_class(Codec.AV1, "encode",  8)
+AV1EncoderLPTest    = codec_test_class(Codec.AV1,  "vdenc",  8)
+AV1_10EncoderTest   = codec_test_class(Codec.AV1, "encode", 10)
+AV1_10EncoderLPTest = codec_test_class(Codec.AV1,  "vdenc", 10)
 
-@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.HEVC,
-      ffenc   = "hevc_vaapi",
-    )
+##### VP9 #####
+VP9EncoderTest      = codec_test_class(Codec.VP9, "encode",  8)
+VP9EncoderLPTest    = codec_test_class(Codec.VP9,  "vdenc",  8)
+VP9_10EncoderTest   = codec_test_class(Codec.VP9, "encode", 10)
+VP9_10EncoderLPTest = codec_test_class(Codec.VP9,  "vdenc", 10)
 
-  def get_file_ext(self):
-    return "h265"
+##### VP8 #####
+VP8EncoderTest      = codec_test_class(Codec.VP8, "encode", 8)
 
-  def get_vaapi_profile(self):
-    return {
-      "main"        : "VAProfileHEVCMain",
-      "main444"     : "VAProfileHEVCMain444",
-      "scc"         : "VAProfileHEVCSccMain",
-      "scc-444"     : "VAProfileHEVCSccMain444",
-      "main10"      : "VAProfileHEVCMain10",
-      "main444-10"  : "VAProfileHEVCMain444_10",
-      "main12"      : "VAProfileHEVCMain12",
-      "main422-12"  : "VAProfileHEVCMain422_12",
-    }[self.profile]
+##### JPEG/MJPEG #####
+JPEGEncoderTest     = codec_test_class(Codec.JPEG, "vdenc", 8)
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 12
-    super().validate_caps()
-
-############################
-## VP9 Encoders           ##
-############################
-
-@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.VP9,
-      ffenc   = "vp9_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    pf = PixelFormat(self.format)
-    return {
-      ("YUV420",  8) : "VAProfileVP9Profile0",
-      ("YUV422",  8) : "VAProfileVP9Profile1",
-      ("YUV444",  8) : "VAProfileVP9Profile1",
-      ("YUV420", 10) : "VAProfileVP9Profile2",
-      ("YUV422", 10) : "VAProfileVP9Profile3",
-      ("YUV444", 10) : "VAProfileVP9Profile3",
-    }[(pf.subsampling, pf.bitdepth)]
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_8"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_8"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-############################
-## AV1 Encoders           ##
-############################
-
-@slash.requires(*have_ffmpeg_encoder("av1_vaapi"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec = Codec.AV1,
-      ffenc = "av1_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return "VAProfileAV1Profile0"
-
-@slash.requires(*platform.have_caps("encode", "av1_8"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_8"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "av1_8"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_8"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "av1_10"))
-class AV1_10EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_10"),
-      lowpower  = 0,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "av1_10"))
-class AV1_10EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_10"),
-      lowpower  = 1,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-############################
-## MPEG2 Encoders         ##
-############################
-
-@slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
-@slash.requires(*platform.have_caps("encode", "mpeg2"))
-class MPEG2EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("encode", "mpeg2"),
-      codec = Codec.MPEG2,
-      ffenc = "mpeg2_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "m2v"
-
-  def get_vaapi_profile(self):
-    return "VAProfileMPEG2.*"
-
-############################
-## JPEG/MJPEG Encoders    ##
-############################
-
-@slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("vdenc", "jpeg"),
-      codec = Codec.JPEG,
-      ffenc = "mjpeg_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
-
-  def get_vaapi_profile(self):
-    return "VAProfileJPEGBaseline"
+##### MPEG2 #####
+MPEG2EncoderTest    = codec_test_class(Codec.MPEG2, "encode", 8)

--- a/lib/ffmpeg/vaapi/encoder.py
+++ b/lib/ffmpeg/vaapi/encoder.py
@@ -14,6 +14,7 @@ from ....lib.ffmpeg.vaapi.util import mapprofile
 from ....lib.ffmpeg.vaapi.decoder import Decoder
 from ....lib.common import mapRangeInt
 from ....lib.codecs import Codec
+from ....lib.formats import PixelFormat
 
 class Encoder(FFEncoder):
   hwaccel = property(lambda s: "vaapi")
@@ -172,3 +173,96 @@ class AVCEncoderLPTest(AVCEncoderBaseTest):
       caps      = platform.get_caps("vdenc", "avc"),
       lowpower  = 1,
     )
+
+############################
+## HEVC Encoders          ##
+############################
+
+@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
+class HEVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec   = Codec.HEVC,
+      ffenc   = "hevc_vaapi",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+  def get_vaapi_profile(self):
+    return {
+      "main"        : "VAProfileHEVCMain",
+      "main444"     : "VAProfileHEVCMain444",
+      "scc"         : "VAProfileHEVCSccMain",
+      "scc-444"     : "VAProfileHEVCSccMain444",
+      "main10"      : "VAProfileHEVCMain10",
+      "main444-10"  : "VAProfileHEVCMain444_10",
+      "main12"      : "VAProfileHEVCMain12",
+      "main422-12"  : "VAProfileHEVCMain422_12",
+    }[self.profile]
+
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = 1,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = 0,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 12
+    super().validate_caps()

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -417,3 +417,25 @@ class VP9_10EncoderLPTest(VP9EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## MPEG2 Encoders         ##
+############################
+
+@slash.requires(*have_gst_element("msdkmpeg2enc"))
+@slash.requires(*have_gst_element("msdkmpeg2dec"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
+class MPEG2EncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("encode", "mpeg2"),
+      codec         = Codec.MPEG2,
+      gstencoder    = "msdkmpeg2enc",
+      gstdecoder    = "msdkmpeg2dec",
+      gstmediatype  = "video/mpeg,mpegversion=2",
+      gstparser     = "mpegvideoparse",
+    )
+
+  def get_file_ext(self):
+    return "mpg"

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -343,3 +343,77 @@ class AV1_10EncoderLPTest(AV1EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## VP9 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("msdkvp9enc"))
+@slash.requires(*have_gst_element("msdkvp9dec"))
+class VP9EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.VP9,
+      gstencoder    = "msdkvp9enc",
+      gstdecoder    = "msdkvp9dec",
+      gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("encode", "vp9_8"),
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("vdenc", "vp9_8"),
+      # NOTE: msdkvp9enc does not have lowpower property.
+      # msdkvp9enc lowpower is hardcoded internally
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("encode", "vp9_10"),
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+class VP9_10EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps  = platform.get_caps("vdenc", "vp9_10"),
+      # NOTE: msdkvp9enc does not have lowpower property.
+      # msdkvp9enc lowpower is hardcoded internally
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -184,3 +184,88 @@ class AVCEncoderLPTest(AVCEncoderBaseTest):
       caps      = platform.get_caps("vdenc", "avc"),
       lowpower  = True,
     )
+
+############################
+## HEVC Encoders          ##
+############################
+
+@slash.requires(*have_gst_element("msdkh265enc"))
+@slash.requires(*have_gst_element("msdkh265dec"))
+class HEVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.HEVC,
+      gstencoder    = "msdkh265enc",
+      gstdecoder    = "msdkh265dec",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 12
+    super().validate_caps()

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -269,3 +269,77 @@ class HEVC12EncoderTest(HEVCEncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 12
     super().validate_caps()
+
+############################
+## AV1 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("msdkav1enc"))
+@slash.requires(*have_gst_element("msdkav1dec"))
+class AV1EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.AV1,
+      gstencoder    = "msdkav1enc",
+      gstdecoder    = "msdkav1dec",
+      gstmediatype  = "video/x-av1",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+      gstparser     = "av1parse",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*platform.have_caps("encode", "av1_8"))
+class AV1EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "av1_8"),
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "av1_8"))
+class AV1EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_8"),
+      # NOTE: msdkav1enc does not have lowpower property.
+      # msdkav1enc lowpower is hardcoded internally
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "av1_10"))
+class AV1_10EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "av1_10"),
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "av1_10"))
+class AV1_10EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_10"),
+      # NOTE: msdkav1enc does not have lowpower property.
+      # msdkav1enc lowpower is hardcoded internally
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -439,3 +439,25 @@ class MPEG2EncoderTest(EncoderTest):
 
   def get_file_ext(self):
     return "mpg"
+
+############################
+## JPEG/MJPEG Encoders    ##
+############################
+
+@slash.requires(*have_gst_element("msdkmjpegenc"))
+@slash.requires(*have_gst_element("msdkmjpegdec"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("vdenc", "jpeg"),
+      codec         = Codec.JPEG,
+      gstencoder    = "msdkmjpegenc",
+      gstdecoder    = "msdkmjpegdec",
+      gstmediatype  = "image/jpeg",
+      gstparser     = "jpegparse",
+    )
+
+  def get_file_ext(self):
+    return "jpg"

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -170,3 +170,96 @@ class AVCEncoderLPTest(AVCEncoderBaseTest):
       gstencoder= "vah264lpenc",
       lowpower  = True,
     )
+
+############################
+## HEVC Encoders          ##
+############################
+
+@slash.requires(*have_gst_element("vah265dec"))
+class HEVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.HEVC,
+      gstdecoder    = "vah265dec",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*have_gst_element("vah265enc"))
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      gstencoder= "vah265enc",
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vah265lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      gstencoder= "vah265lpenc",
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vah265enc"))
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      gstencoder= "vah265enc",
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vah265lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      gstencoder= "vah265lpenc",
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vah265enc"))
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      gstencoder= "vah265enc",
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 12
+    super().validate_caps()

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -343,3 +343,83 @@ class AV1_10EncoderLPTest(AV1EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## VP9 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("vavp9dec"))
+class VP9EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.VP9,
+      gstdecoder    = "vavp9dec",
+      gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+@slash.requires(*have_gst_element("vavp9enc"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("encode", "vp9_8"),
+      lowpower      = False,
+      gstencoder    = "vavp9enc",
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+@slash.requires(*have_gst_element("vavp9lpenc"))
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("vdenc", "vp9_8"),
+      lowpower      = True,
+      gstencoder    = "vavp9lpenc",
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vavp9enc"))
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps        = platform.get_caps("encode", "vp9_10"),
+      gstencoder  = "vavp9enc",
+      lowpower    = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vavp9lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+class VP9_10EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps        = platform.get_caps("vdenc", "vp9_10"),
+      gstencoder  = "vavp9lpenc",
+      lowpower    = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -263,3 +263,83 @@ class HEVC12EncoderTest(HEVCEncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 12
     super().validate_caps()
+
+############################
+## AV1 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("vaav1dec"))
+class AV1EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.AV1,
+      gstdecoder    = "vaav1dec",
+      gstmediatype  = "video/x-av1",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+      gstparser     = "av1parse",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*have_gst_element("vaav1enc"))
+@slash.requires(*platform.have_caps("encode", "av1_8"))
+class AV1EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "av1_8"),
+      gstencoder= "vaav1enc",
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vaav1lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "av1_8"))
+class AV1EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "av1_8"),
+      gstencoder= "vaav1lpenc",
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vaav1enc"))
+@slash.requires(*platform.have_caps("encode", "av1_10"))
+class AV1_10EncoderTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps        = platform.get_caps("encode", "av1_10"),
+      gstencoder  = "vaav1enc",
+      lowpower    = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*have_gst_element("vaav1lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "av1_10"))
+class AV1_10EncoderLPTest(AV1EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps        = platform.get_caps("vdenc", "av1_10"),
+      gstencoder  = "vaav1lpenc",
+      lowpower    = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -423,3 +423,25 @@ class VP9_10EncoderLPTest(VP9EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## JPEG/MJPEG Encoders    ##
+############################
+
+@slash.requires(*have_gst_element("vajpegenc"))
+@slash.requires(*have_gst_element("vajpegdec"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("vdenc", "jpeg"),
+      codec         = Codec.JPEG,
+      gstencoder    = "vajpegenc",
+      gstdecoder    = "vajpegdec",
+      gstmediatype  = "image/jpeg",
+      gstparser     = "jpegparse",
+    )
+
+  def get_file_ext(self):
+    return "mjpeg" if self.frames > 1 else "jpg"

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -11,8 +11,10 @@ from ....lib.gstreamer.encoderbase import BaseEncoderTest, Encoder as GstEncoder
 from ....lib.gstreamer.util import have_gst_element, get_elements
 from ....lib.gstreamer.va.util import mapprofile, map_best_hw_format, mapformat
 from ....lib.gstreamer.va.decoder import Decoder
+from ....lib import platform
 from ....lib.codecs import Codec
 from ....lib.common import get_media, mapRangeInt
+from ....lib.formats import PixelFormat
 
 class Encoder(GstEncoder):
   @property
@@ -128,3 +130,43 @@ class EncoderTest(BaseEncoderTest):
 
   def map_profile(self):
     return mapprofile(self.codec, self.profile)
+
+############################
+## AVC Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("vah264dec"))
+class AVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.AVC,
+      gstdecoder    = "vah264dec",
+      gstmediatype  = "video/x-h264",
+      gstparser     = "h264parse",
+    )
+
+  def get_file_ext(self):
+    return "h264"
+
+@slash.requires(*have_gst_element("vah264enc"))
+@slash.requires(*platform.have_caps("encode", "avc"))
+class AVCEncoderTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "avc"),
+      gstencoder= "vah264enc",
+      lowpower  = False,
+    )
+
+@slash.requires(*have_gst_element("vah264lpenc"))
+@slash.requires(*platform.have_caps("vdenc", "avc"))
+class AVCEncoderLPTest(AVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "avc"),
+      gstencoder= "vah264lpenc",
+      lowpower  = True,
+    )

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -139,3 +139,88 @@ class AVCEncoderLPTest(AVCEncoderBaseTest):
       caps      = platform.get_caps("vdenc", "avc"),
       lowpower  = True,
     )
+
+############################
+## HEVC Encoders          ##
+############################
+
+@slash.requires(*have_gst_element("vaapih265enc"))
+@slash.requires(*have_gst_element("vaapih265dec"))
+class HEVCEncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.HEVC,
+      gstencoder    = "vaapih265enc",
+      gstdecoder    = "vaapih265dec",
+      gstmediatype  = "video/x-h265",
+      gstparser     = "h265parse",
+    )
+
+  def get_file_ext(self):
+    return "h265"
+
+@slash.requires(*platform.have_caps("encode", "hevc_8"))
+class HEVC8EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_8"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
+class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_8"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_10"))
+class HEVC10EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_10"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
+class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "hevc_10"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "hevc_12"))
+class HEVC12EncoderTest(HEVCEncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "hevc_12"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 12
+    super().validate_caps()

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -298,3 +298,33 @@ class VP9_10EncoderLPTest(VP9EncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 10
     super().validate_caps()
+
+############################
+## VP8 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("vaapivp8enc"))
+@slash.requires(*have_gst_element("vaapivp8dec"))
+class VP8EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.VP8,
+      gstencoder    = "vaapivp8enc",
+      gstdecoder    = "vaapivp8dec",
+      gstmediatype  = "video/x-vp8",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*platform.have_caps("encode", "vp8"))
+class VP8EncoderTest(VP8EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp8"),
+      lowpower  = False,
+    )

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -328,3 +328,25 @@ class VP8EncoderTest(VP8EncoderBaseTest):
       caps      = platform.get_caps("encode", "vp8"),
       lowpower  = False,
     )
+
+############################
+## MPEG2 Encoders         ##
+############################
+
+@slash.requires(*have_gst_element("vaapimpeg2enc"))
+@slash.requires(*have_gst_element("vaapimpeg2dec"))
+@slash.requires(*platform.have_caps("encode", "mpeg2"))
+class MPEG2EncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("encode", "mpeg2"),
+      codec         = Codec.MPEG2,
+      gstencoder    = "vaapimpeg2enc",
+      gstdecoder    = "vaapimpeg2dec",
+      gstmediatype  = "video/mpeg,mpegversion=2",
+      gstparser     = "mpegvideoparse",
+    )
+
+  def get_file_ext(self):
+    return "m2v"

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -350,3 +350,25 @@ class MPEG2EncoderTest(EncoderTest):
 
   def get_file_ext(self):
     return "m2v"
+
+############################
+## JPEG/MJPEG Encoders    ##
+############################
+
+@slash.requires(*have_gst_element("vaapijpegenc"))
+@slash.requires(*have_gst_element("vaapijpegdec"))
+@slash.requires(*platform.have_caps("vdenc", "jpeg"))
+class JPEGEncoderTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps          = platform.get_caps("vdenc", "jpeg"),
+      codec         = Codec.JPEG,
+      gstencoder    = "vaapijpegenc",
+      gstdecoder    = "vaapijpegdec",
+      gstmediatype  = "image/jpeg",
+      gstparser     = "jpegparse",
+    )
+
+  def get_file_ext(self):
+    return "mjpeg" if self.frames > 1 else "jpg"

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -224,3 +224,77 @@ class HEVC12EncoderTest(HEVCEncoderBaseTest):
   def validate_caps(self):
     assert PixelFormat(self.format).bitdepth == 12
     super().validate_caps()
+
+############################
+## VP9 Encoders           ##
+############################
+
+@slash.requires(*have_gst_element("vaapivp9enc"))
+@slash.requires(*have_gst_element("vaapivp9dec"))
+class VP9EncoderBaseTest(EncoderTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      codec         = Codec.VP9,
+      gstencoder    = "vaapivp9enc",
+      gstdecoder    = "vaapivp9dec",
+      gstmediatype  = "video/x-vp9",
+      gstparser     = "vp9parse",
+      gstmuxer      = "matroskamux",
+      gstdemuxer    = "matroskademux",
+    )
+
+  def get_file_ext(self):
+    return "webm"
+
+@slash.requires(*platform.have_caps("encode", "vp9_8"))
+class VP9EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps = platform.get_caps("encode", "vp9_8"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
+class VP9EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps = platform.get_caps("vdenc", "vp9_8"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 8
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("encode", "vp9_10"))
+class VP9_10EncoderTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("encode", "vp9_10"),
+      lowpower  = False,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()
+
+@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
+class VP9_10EncoderLPTest(VP9EncoderBaseTest):
+  def before(self):
+    super().before()
+    vars(self).update(
+      caps      = platform.get_caps("vdenc", "vp9_10"),
+      lowpower  = True,
+    )
+
+  def validate_caps(self):
+    assert PixelFormat(self.format).bitdepth == 10
+    super().validate_caps()

--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -102,273 +102,110 @@ class EncoderTest(BaseEncoderTest):
   def map_profile(self):
     return mapprofile(self.codec, self.profile)
 
-############################
-## AVC Encoders           ##
-############################
+def codec_test_class(codec, engine, bitdepth, **kwargs):
+  # lowpower setting for codecs that support it
+  if codec not in [Codec.JPEG, Codec.MPEG2]:
+    kwargs.update(lowpower = engine == "vdenc")
 
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AVC,
-      gstencoder    = "vaapih264enc",
-      gstdecoder    = "vaapih264dec",
-      gstmediatype  = "video/x-h264",
-      gstparser     = "h264parse",
-    )
+  # caps lookup translation
+  capcodec = codec
+  if codec in [Codec.HEVC, Codec.VP9]:
+    capcodec = f"{codec}_{bitdepth}"
 
-  def get_file_ext(self):
-    return "h264"
+  # gst element codec translation
+  gstcodec = {
+    Codec.AVC   : "h264",
+    Codec.HEVC  : "h265",
+  }.get(codec, codec)
 
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = False,
-    )
+  @slash.requires(*have_gst_element(f"vaapi{gstcodec}enc"))
+  @slash.requires(*have_gst_element(f"vaapi{gstcodec}dec"))
+  @slash.requires(*platform.have_caps(engine, capcodec))
+  class CodecEncoderTest(EncoderTest):
+    def before(self):
+      super().before()
+      vars(self).update(
+        caps = platform.get_caps(engine, capcodec),
+        codec = codec,
+        gstencoder = f"vaapi{gstcodec}enc",
+        gstdecoder = f"vaapi{gstcodec}dec",
+        **kwargs,
+      )
 
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = True,
-    )
+    def validate_caps(self):
+      assert PixelFormat(self.format).bitdepth == bitdepth
+      super().validate_caps()
 
-############################
-## HEVC Encoders          ##
-############################
+    def get_file_ext(self):
+      return {
+        Codec.AVC   : "h264",
+        Codec.HEVC  : "h265",
+        Codec.JPEG  : "mjpeg" if self.frames > 1 else "jpg",
+        Codec.MPEG2 : "m2v",
+        Codec.VP8   : "webm",
+        Codec.VP9   : "webm",
+      }[codec]
 
-@slash.requires(*have_gst_element("vaapih265enc"))
-@slash.requires(*have_gst_element("vaapih265dec"))
-class HEVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstencoder    = "vaapih265enc",
-      gstdecoder    = "vaapih265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
+  return CodecEncoderTest
 
-  def get_file_ext(self):
-    return "h265"
+##### AVC #####
+AVCCommonArgs = dict(
+  codec         = Codec.AVC,
+  gstmediatype  = "video/x-h264",
+  gstparser     = "h264parse",
+)
+AVCEncoderTest    = codec_test_class(bitdepth = 8, engine = "encode", **AVCCommonArgs)
+AVCEncoderLPTest  = codec_test_class(bitdepth = 8, engine =  "vdenc", **AVCCommonArgs)
 
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      lowpower  = False,
-    )
+##### HEVC #####
+HEVCCommonArgs = dict(
+  codec         = Codec.HEVC,
+  gstmediatype  = "video/x-h265",
+  gstparser     = "h265parse",
+)
+HEVC8EncoderTest    = codec_test_class(bitdepth =  8, engine = "encode", **HEVCCommonArgs)
+HEVC8EncoderLPTest  = codec_test_class(bitdepth =  8, engine =  "vdenc", **HEVCCommonArgs)
+HEVC10EncoderTest   = codec_test_class(bitdepth = 10, engine = "encode", **HEVCCommonArgs)
+HEVC10EncoderLPTest = codec_test_class(bitdepth = 10, engine =  "vdenc", **HEVCCommonArgs)
+HEVC12EncoderTest   = codec_test_class(bitdepth = 12, engine = "encode", **HEVCCommonArgs)
 
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
+##### VP9 #####
+VP9CommonArgs = dict(
+  codec         = Codec.VP9,
+  gstmediatype  = "video/x-vp9",
+  gstparser     = "vp9parse",
+  gstmuxer      = "matroskamux",
+  gstdemuxer    = "matroskademux",
+)
+VP9EncoderTest      = codec_test_class(bitdepth =  8, engine = "encode", **VP9CommonArgs)
+VP9EncoderLPTest    = codec_test_class(bitdepth =  8, engine =  "vdenc", **VP9CommonArgs)
+VP9_10EncoderTest   = codec_test_class(bitdepth = 10, engine = "encode", **VP9CommonArgs)
+VP9_10EncoderLPTest = codec_test_class(bitdepth = 10, engine =  "vdenc", **VP9CommonArgs)
 
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      lowpower  = True,
-    )
+##### VP8 #####
+VP8EncoderTest  = codec_test_class(
+  codec         = Codec.VP8,
+  engine        = "encode",
+  bitdepth      = 8,
+  gstmediatype  = "video/x-vp8",
+  gstmuxer      = "matroskamux",
+  gstdemuxer    = "matroskademux",
+)
 
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
+##### JPEG/MJPEG #####
+JPEGEncoderTest = codec_test_class(
+  codec         = Codec.JPEG,
+  engine        = "vdenc",
+  bitdepth      = 8,
+  gstmediatype  = "image/jpeg",
+  gstparser     = "jpegparse",
+)
 
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      lowpower  = False,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      lowpower  = True,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      lowpower  = False,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 12
-    super().validate_caps()
-
-############################
-## VP9 Encoders           ##
-############################
-
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstencoder    = "vaapivp9enc",
-      gstdecoder    = "vaapivp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps = platform.get_caps("encode", "vp9_8"),
-      lowpower  = False,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps = platform.get_caps("vdenc", "vp9_8"),
-      lowpower  = True,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 8
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      lowpower  = False,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      lowpower  = True,
-    )
-
-  def validate_caps(self):
-    assert PixelFormat(self.format).bitdepth == 10
-    super().validate_caps()
-
-############################
-## VP8 Encoders           ##
-############################
-
-@slash.requires(*have_gst_element("vaapivp8enc"))
-@slash.requires(*have_gst_element("vaapivp8dec"))
-class VP8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP8,
-      gstencoder    = "vaapivp8enc",
-      gstdecoder    = "vaapivp8dec",
-      gstmediatype  = "video/x-vp8",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp8"))
-class VP8EncoderTest(VP8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp8"),
-      lowpower  = False,
-    )
-
-############################
-## MPEG2 Encoders         ##
-############################
-
-@slash.requires(*have_gst_element("vaapimpeg2enc"))
-@slash.requires(*have_gst_element("vaapimpeg2dec"))
-@slash.requires(*platform.have_caps("encode", "mpeg2"))
-class MPEG2EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("encode", "mpeg2"),
-      codec         = Codec.MPEG2,
-      gstencoder    = "vaapimpeg2enc",
-      gstdecoder    = "vaapimpeg2dec",
-      gstmediatype  = "video/mpeg,mpegversion=2",
-      gstparser     = "mpegvideoparse",
-    )
-
-  def get_file_ext(self):
-    return "m2v"
-
-############################
-## JPEG/MJPEG Encoders    ##
-############################
-
-@slash.requires(*have_gst_element("vaapijpegenc"))
-@slash.requires(*have_gst_element("vaapijpegdec"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = Codec.JPEG,
-      gstencoder    = "vaapijpegenc",
-      gstdecoder    = "vaapijpegdec",
-      gstmediatype  = "image/jpeg",
-      gstparser     = "jpegparse",
-    )
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
+##### MPEG2 #####
+MPEG2EncoderTest = codec_test_class(
+  codec         = Codec.MPEG2,
+  engine        = "encode",
+  bitdepth      = 8,
+  gstmediatype  = "video/mpeg,mpegversion=2",
+  gstparser     = "mpegvideoparse",
+)

--- a/test/ffmpeg-qsv/encode/jpeg.py
+++ b/test/ffmpeg-qsv/encode/jpeg.py
@@ -6,27 +6,11 @@
 
 from ....lib import *
 from ....lib.ffmpeg.qsv.util import *
-from ....lib.ffmpeg.qsv.encoder import EncoderTest
+from ....lib.ffmpeg.qsv.encoder import JPEGEncoderTest
 from ....lib.codecs import Codec
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("mjpeg_qsv"))
-@slash.requires(*have_ffmpeg_decoder("mjpeg_qsv"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "jpeg"),
-      codec     = Codec.JPEG,
-      ffencoder = "mjpeg_qsv",
-      ffdecoder = "mjpeg_qsv",
-    )
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):

--- a/test/ffmpeg-vaapi/encode/10bit/av1.py
+++ b/test/ffmpeg-vaapi/encode/10bit/av1.py
@@ -6,46 +6,12 @@
 
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
-from .....lib.ffmpeg.vaapi.encoder import EncoderTest
-from .....lib.codecs import Codec
+from .....lib.ffmpeg.vaapi.encoder import AV1_10EncoderTest, AV1_10EncoderLPTest
 
 spec      = load_test_spec("av1", "encode", "10bit")
 spec_r2r  = load_test_spec("av1", "encode", "10bit", "r2r")
 
-@slash.requires(*have_ffmpeg_encoder("av1_vaapi"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec = Codec.AV1,
-      ffenc = "av1_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return "VAProfileAV1Profile0"
-
-@slash.requires(*platform.have_caps("encode", "av1_10"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_10"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "av1_10"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_10"),
-      lowpower  = 1,
-    )
-
-class cqp(AV1EncoderTest):
+class cqp(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -71,7 +37,7 @@ class cqp(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cbr(AV1EncoderTest):
+class cbr(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -100,7 +66,7 @@ class cbr(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cqp_lp(AV1EncoderLPTest):
+class cqp_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -126,7 +92,7 @@ class cqp_lp(AV1EncoderLPTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cbr_lp(AV1EncoderLPTest):
+class cbr_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(

--- a/test/ffmpeg-vaapi/encode/10bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/10bit/hevc.py
@@ -6,47 +6,10 @@
 
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
-from .....lib.ffmpeg.vaapi.encoder import EncoderTest
-from .....lib.codecs import Codec
+from .....lib.ffmpeg.vaapi.encoder import HEVC10EncoderTest, HEVC10EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVC10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.HEVC,
-      ffenc   = "hevc_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-  def get_vaapi_profile(self):
-    return {
-      "main10"      : "VAProfileHEVCMain10",
-      "main444-10"  : "VAProfileHEVCMain444_10",
-    }[self.profile]
-
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      lowpower  = 1,
-    )
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/ffmpeg-vaapi/encode/10bit/vp9.py
+++ b/test/ffmpeg-vaapi/encode/10bit/vp9.py
@@ -5,49 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.formats import PixelFormat
 from .....lib.ffmpeg.vaapi.util import *
-from .....lib.ffmpeg.vaapi.encoder import EncoderTest
-from .....lib.codecs import Codec
+from .....lib.ffmpeg.vaapi.encoder import VP9_10EncoderTest, VP9_10EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
-
-@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-class VP9_10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec    = Codec.VP9,
-      ffenc    = "vp9_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return {
-      "YUV420" : "VAProfileVP9Profile2",
-      "YUV422" : "VAProfileVP9Profile3",
-      "YUV444" : "VAProfileVP9Profile3",
-    }[PixelFormat(self.format).subsampling]
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      lowpower  = 1,
-    )
 
 class cqp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):

--- a/test/ffmpeg-vaapi/encode/12bit/hevc.py
+++ b/test/ffmpeg-vaapi/encode/12bit/hevc.py
@@ -6,37 +6,9 @@
 
 from .....lib import *
 from .....lib.ffmpeg.vaapi.util import *
-from .....lib.ffmpeg.vaapi.encoder import EncoderTest
-from .....lib.codecs import Codec
+from .....lib.ffmpeg.vaapi.encoder import HEVC12EncoderTest
 
 spec = load_test_spec("hevc", "encode", "12bit")
-
-@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVC12EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.HEVC,
-      ffenc   = "hevc_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-  def get_vaapi_profile(self):
-    return {
-      "main12"      : "VAProfileHEVCMain12",
-      "main422-12"  : "VAProfileHEVCMain422_12",
-    }[self.profile]
-
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVC12EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      lowpower  = 0,
-    )
 
 class cqp(HEVC12EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/ffmpeg-vaapi/encode/av1.py
+++ b/test/ffmpeg-vaapi/encode/av1.py
@@ -6,44 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import AV1EncoderTest, AV1EncoderLPTest
 
 spec      = load_test_spec("av1", "encode", "8bit")
 spec_r2r  = load_test_spec("av1", "encode", "8bit", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("av1_vaapi"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec = Codec.AV1,
-      ffenc = "av1_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return "VAProfileAV1Profile0"
-
-@slash.requires(*platform.have_caps("encode", "av1_8"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_8"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "av1_8"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_8"),
-      lowpower  = 1,
-    )
 
 class cqp(AV1EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):

--- a/test/ffmpeg-vaapi/encode/avc.py
+++ b/test/ffmpeg-vaapi/encode/avc.py
@@ -6,48 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import AVCEncoderTest, AVCEncoderLPTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("h264_vaapi"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.AVC,
-      ffenc   = "h264_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "h264"
-
-  def get_vaapi_profile(self):
-    return {
-      "high"                  : "VAProfileH264High",
-      "main"                  : "VAProfileH264Main",
-      "constrained-baseline"  : "VAProfileH264ConstrainedBaseline",
-    }[self.profile]
-
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = 1,
-    )
 
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/ffmpeg-vaapi/encode/hevc.py
+++ b/test/ffmpeg-vaapi/encode/hevc.py
@@ -6,49 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import HEVC8EncoderTest, HEVC8EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("hevc_vaapi"))
-class HEVC8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.HEVC,
-      ffenc   = "hevc_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-  def get_vaapi_profile(self):
-    return {
-      "main"     : "VAProfileHEVCMain",
-      "main444"  : "VAProfileHEVCMain444",
-      "scc"      : "VAProfileHEVCSccMain",
-      "scc-444"  : "VAProfileHEVCSccMain444",
-    }[self.profile]
-
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      lowpower  = 1,
-    )
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/ffmpeg-vaapi/encode/jpeg.py
+++ b/test/ffmpeg-vaapi/encode/jpeg.py
@@ -6,28 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import JPEGEncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("mjpeg_vaapi"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("vdenc", "jpeg"),
-      codec = Codec.JPEG,
-      ffenc = "mjpeg_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
-
-  def get_vaapi_profile(self):
-    return "VAProfileJPEGBaseline"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):

--- a/test/ffmpeg-vaapi/encode/mpeg2.py
+++ b/test/ffmpeg-vaapi/encode/mpeg2.py
@@ -6,28 +6,10 @@
 
 from ....lib import *
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import MPEG2EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
-
-@slash.requires(*have_ffmpeg_encoder("mpeg2_vaapi"))
-@slash.requires(*platform.have_caps("encode", "mpeg2"))
-class MPEG2EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("encode", "mpeg2"),
-      codec = Codec.MPEG2,
-      ffenc = "mpeg2_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "m2v"
-
-  def get_vaapi_profile(self):
-    return "VAProfileMPEG2.*"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):

--- a/test/ffmpeg-vaapi/encode/vp9.py
+++ b/test/ffmpeg-vaapi/encode/vp9.py
@@ -5,49 +5,10 @@
 ###
 
 from ....lib import *
-from ....lib.formats import PixelFormat
 from ....lib.ffmpeg.vaapi.util import *
-from ....lib.ffmpeg.vaapi.encoder import EncoderTest
-from ....lib.codecs import Codec
+from ....lib.ffmpeg.vaapi.encoder import VP9EncoderTest, VP9EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
-
-@slash.requires(*have_ffmpeg_encoder("vp9_vaapi"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec   = Codec.VP9,
-      ffenc   = "vp9_vaapi",
-    )
-
-  def get_file_ext(self):
-    return "ivf"
-
-  def get_vaapi_profile(self):
-    return {
-      "YUV420" : "VAProfileVP9Profile0",
-      "YUV422" : "VAProfileVP9Profile1",
-      "YUV444" : "VAProfileVP9Profile1",
-    }[PixelFormat(self.format).subsampling]
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_8"),
-      lowpower  = 0,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_8"),
-      lowpower  = 1,
-    )
 
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices, looplvl, loopshp):

--- a/test/gst-msdk/encode/10bit/av1.py
+++ b/test/gst-msdk/encode/10bit/av1.py
@@ -5,50 +5,13 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
-from .....lib.gstreamer.msdk.encoder import EncoderTest
+from .....lib.gstreamer.msdk.encoder import AV1_10EncoderTest, AV1_10EncoderLPTest
 
 spec      = load_test_spec("av1", "encode", "10bit")
 spec_r2r  = load_test_spec("av1", "encode", "10bit", "r2r")
 
-@slash.requires(*have_gst_element("msdkav1enc"))
-@slash.requires(*have_gst_element("msdkav1dec"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AV1,
-      gstencoder    = "msdkav1enc",
-      gstdecoder    = "msdkav1dec",
-      gstmediatype  = "video/x-av1",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-      gstparser     = "av1parse",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "av1_10"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_10"),
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "av1_10"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_10"),
-      # NOTE: msdkav1enc does not have lowpower property.
-      # msdkav1enc lowpower is hardcoded internally
-    )
-
-class cqp(AV1EncoderTest):
+class cqp(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -74,7 +37,7 @@ class cqp(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cbr(AV1EncoderTest):
+class cbr(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -103,7 +66,7 @@ class cbr(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class vbr(AV1EncoderTest):
+class vbr(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -133,7 +96,7 @@ class vbr(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cqp_lp(AV1EncoderLPTest):
+class cqp_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -159,7 +122,7 @@ class cqp_lp(AV1EncoderLPTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cbr_lp(AV1EncoderLPTest):
+class cbr_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -188,7 +151,7 @@ class cbr_lp(AV1EncoderLPTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class vbr_lp(AV1EncoderLPTest):
+class vbr_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(

--- a/test/gst-msdk/encode/10bit/hevc.py
+++ b/test/gst-msdk/encode/10bit/hevc.py
@@ -5,46 +5,11 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
-from .....lib.gstreamer.msdk.encoder import EncoderTest
+from .....lib.gstreamer.msdk.encoder import HEVC10EncoderTest, HEVC10EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
-
-@slash.requires(*have_gst_element("msdkh265enc"))
-@slash.requires(*have_gst_element("msdkh265dec"))
-class HEVC10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstencoder    = "msdkh265enc",
-      gstdecoder    = "msdkh265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      lowpower  = True,
-    )
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-msdk/encode/10bit/vp9.py
+++ b/test/gst-msdk/encode/10bit/vp9.py
@@ -5,47 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
-from .....lib.gstreamer.msdk.encoder import EncoderTest
+from .....lib.gstreamer.msdk.encoder import VP9_10EncoderTest, VP9_10EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
-
-@slash.requires(*have_gst_element("msdkvp9enc"))
-@slash.requires(*have_gst_element("msdkvp9dec"))
-class VP9_10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstencoder    = "msdkvp9enc",
-      gstdecoder    = "msdkvp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("encode", "vp9_10"),
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("vdenc", "vp9_10"),
-      # NOTE: msdkvp9enc does not have lowpower property.
-      # msdkvp9enc lowpower is hardcoded internally
-    )
 
 class cqp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, slices):

--- a/test/gst-msdk/encode/12bit/hevc.py
+++ b/test/gst-msdk/encode/12bit/hevc.py
@@ -5,37 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.msdk.util import *
-from .....lib.gstreamer.msdk.encoder import EncoderTest
+from .....lib.gstreamer.msdk.encoder import HEVC12EncoderTest
 
 spec = load_test_spec("hevc", "encode", "12bit")
-
-@slash.requires(*have_gst_element("msdkh265dec"))
-@slash.requires(*have_gst_element("msdkh265enc"))
-class HEVC12EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstdecoder    = "msdkh265dec",
-      gstencoder    = "msdkh265enc",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVC12EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      lowpower  = False,
-    )
 
 class cqp(HEVC12EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-msdk/encode/av1.py
+++ b/test/gst-msdk/encode/av1.py
@@ -5,48 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import AV1EncoderTest, AV1EncoderLPTest
 
 spec = load_test_spec("av1", "encode", "8bit")
 spec_r2r  = load_test_spec("av1", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("msdkav1enc"))
-@slash.requires(*have_gst_element("msdkav1dec"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AV1,
-      gstencoder    = "msdkav1enc",
-      gstdecoder    = "msdkav1dec",
-      gstmediatype  = "video/x-av1",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-      gstparser     = "av1parse",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "av1_8"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_8"),
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "av1_8"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_8"),
-      # NOTE: msdkav1enc does not have lowpower property.
-      # msdkav1enc lowpower is hardcoded internally
-    )
 
 class cqp(AV1EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):

--- a/test/gst-msdk/encode/avc.py
+++ b/test/gst-msdk/encode/avc.py
@@ -5,46 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import AVCEncoderTest, AVCEncoderLPTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
-
-@slash.requires(*have_gst_element("msdkh264enc"))
-@slash.requires(*have_gst_element("msdkh264dec"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AVC,
-      gstencoder    = "msdkh264enc",
-      gstdecoder    = "msdkh264dec",
-      gstmediatype  = "video/x-h264",
-      gstparser     = "h264parse",
-    )
-
-  def get_file_ext(self):
-    return "h264"
-
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = True,
-    )
 
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-msdk/encode/hevc.py
+++ b/test/gst-msdk/encode/hevc.py
@@ -5,46 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import HEVC8EncoderTest, HEVC8EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("msdkh265enc"))
-@slash.requires(*have_gst_element("msdkh265dec"))
-class HEVC8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstencoder    = "msdkh265enc",
-      gstdecoder    = "msdkh265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      lowpower  = True,
-    )
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-msdk/encode/jpeg.py
+++ b/test/gst-msdk/encode/jpeg.py
@@ -5,30 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import JPEGEncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
-
-@slash.requires(*have_gst_element("msdkmjpegenc"))
-@slash.requires(*have_gst_element("msdkmjpegdec"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = Codec.JPEG,
-      gstencoder    = "msdkmjpegenc",
-      gstdecoder    = "msdkmjpegdec",
-      gstmediatype  = "image/jpeg",
-      gstparser     = "jpegparse",
-    )
-
-  def get_file_ext(self):
-    return "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):

--- a/test/gst-msdk/encode/mpeg2.py
+++ b/test/gst-msdk/encode/mpeg2.py
@@ -5,30 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import MPEG2EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
-
-@slash.requires(*have_gst_element("msdkmpeg2enc"))
-@slash.requires(*have_gst_element("msdkmpeg2dec"))
-@slash.requires(*platform.have_caps("encode", "mpeg2"))
-class MPEG2EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("encode", "mpeg2"),
-      codec         = Codec.MPEG2,
-      gstencoder    = "msdkmpeg2enc",
-      gstdecoder    = "msdkmpeg2dec",
-      gstmediatype  = "video/mpeg,mpegversion=2",
-      gstparser     = "mpegvideoparse",
-    )
-
-  def get_file_ext(self):
-    return "mpg"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):

--- a/test/gst-msdk/encode/vp9.py
+++ b/test/gst-msdk/encode/vp9.py
@@ -5,48 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.msdk.util import *
-from ....lib.gstreamer.msdk.encoder import EncoderTest
+from ....lib.gstreamer.msdk.encoder import VP9EncoderTest, VP9EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
 spec_r2r  = load_test_spec("vp9", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("msdkvp9enc"))
-@slash.requires(*have_gst_element("msdkvp9dec"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstencoder    = "msdkvp9enc",
-      gstdecoder    = "msdkvp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("encode", "vp9_8"),
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps  = platform.get_caps("vdenc", "vp9_8"),
-      # NOTE: msdkvp9enc does not have lowpower property.
-      # msdkvp9enc lowpower is hardcoded internally
-    )
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, slices):

--- a/test/gst-va/encode/10bit/av1.py
+++ b/test/gst-va/encode/10bit/av1.py
@@ -5,52 +5,13 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.encoder import EncoderTest
+from .....lib.gstreamer.va.encoder import AV1_10EncoderTest, AV1_10EncoderLPTest
 
 spec = load_test_spec("av1", "encode", "10bit")
 spec_r2r  = load_test_spec("av1", "encode", "10bit", "r2r")
 
-@slash.requires(*have_gst_element("vaav1dec"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AV1,
-      gstdecoder    = "vaav1dec",
-      gstmediatype  = "video/x-av1",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-      gstparser     = "av1parse",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*have_gst_element("vaav1enc"))
-@slash.requires(*platform.have_caps("encode", "av1_10"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps        = platform.get_caps("encode", "av1_10"),
-      gstencoder  = "vaav1enc",
-      lowpower    = False,
-    )
-
-@slash.requires(*have_gst_element("vaav1lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "av1_10"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps        = platform.get_caps("vdenc", "av1_10"),
-      gstencoder  = "vaav1lpenc",
-      lowpower    = True,
-    )
-
-class cqp(AV1EncoderTest):
+class cqp(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -76,8 +37,7 @@ class cqp(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-
-class cbr(AV1EncoderTest):
+class cbr(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -106,7 +66,7 @@ class cbr(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class vbr(AV1EncoderTest):
+class vbr(AV1_10EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -135,7 +95,7 @@ class vbr(AV1EncoderTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class cqp_lp(AV1EncoderLPTest):
+class cqp_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -162,7 +122,7 @@ class cqp_lp(AV1EncoderLPTest):
     self.encode()
 
 
-class cbr_lp(AV1EncoderLPTest):
+class cbr_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(
@@ -191,7 +151,7 @@ class cbr_lp(AV1EncoderLPTest):
     vars(self).setdefault("r2r", 5)
     self.encode()
 
-class vbr_lp(AV1EncoderLPTest):
+class vbr_lp(AV1_10EncoderLPTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows, bitrate, fps, quality, profile):
     vars(self).update(tspec[case].copy())
     vars(self).update(

--- a/test/gst-va/encode/10bit/hevc.py
+++ b/test/gst-va/encode/10bit/hevc.py
@@ -5,48 +5,11 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.encoder import EncoderTest
+from .....lib.gstreamer.va.encoder import HEVC10EncoderTest, HEVC10EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
-
-@slash.requires(*have_gst_element("vah265dec"))
-class HEVC10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstdecoder    = "vah265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*have_gst_element("vah265enc"))
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      gstencoder= "vah265enc",
-      lowpower  = False,
-    )
-
-@slash.requires(*have_gst_element("vah265lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      gstencoder= "vah265lpenc",
-      lowpower  = True,
-    )
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-va/encode/10bit/vp9.py
+++ b/test/gst-va/encode/10bit/vp9.py
@@ -5,49 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.encoder import EncoderTest
+from .....lib.gstreamer.va.encoder import VP9_10EncoderTest, VP9_10EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
-
-@slash.requires(*have_gst_element("vavp9dec"))
-class VP9_10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstdecoder    = "vavp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*have_gst_element("vavp9enc"))
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      gstencoder    = "vavp9enc",
-      lowpower  = False,
-    )
-
-@slash.requires(*have_gst_element("vavp9lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      gstencoder    = "vavp9lpenc",
-      lowpower  = True,
-    )
 
 class cqp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):

--- a/test/gst-va/encode/12bit/hevc.py
+++ b/test/gst-va/encode/12bit/hevc.py
@@ -5,36 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.encoder import EncoderTest
+from .....lib.gstreamer.va.encoder import HEVC12EncoderTest
 
 spec = load_test_spec("hevc", "encode", "12bit")
-
-@slash.requires(*have_gst_element("vah265dec"))
-class HEVC12EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstdecoder    = "vah265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*have_gst_element("vah265enc"))
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVC12EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      gstencoder= "vah265enc",
-      lowpower  = False,
-    )
 
 class cqp(HEVC12EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-va/encode/av1.py
+++ b/test/gst-va/encode/av1.py
@@ -5,50 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.encoder import EncoderTest
+from ....lib.gstreamer.va.encoder import AV1EncoderTest, AV1EncoderLPTest
 
 spec = load_test_spec("av1", "encode", "8bit")
 spec_r2r  = load_test_spec("av1", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("vaav1dec"))
-class AV1EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AV1,
-      gstdecoder    = "vaav1dec",
-      gstmediatype  = "video/x-av1",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-      gstparser     = "av1parse",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*have_gst_element("vaav1enc"))
-@slash.requires(*platform.have_caps("encode", "av1_8"))
-class AV1EncoderTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "av1_8"),
-      gstencoder    = "vaav1enc",
-      lowpower  = False,
-    )
-
-@slash.requires(*have_gst_element("vaav1lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "av1_8"))
-class AV1EncoderLPTest(AV1EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "av1_8"),
-      gstencoder    = "vaav1lpenc",
-      lowpower  = True,
-    )
 
 class cqp(AV1EncoderTest):
   def init(self, tspec, case, gop, bframes, tilecols, tilerows,qp, quality, profile):

--- a/test/gst-va/encode/avc.py
+++ b/test/gst-va/encode/avc.py
@@ -5,48 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.encoder import EncoderTest
+from ....lib.gstreamer.va.encoder import AVCEncoderTest, AVCEncoderLPTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
-
-@slash.requires(*have_gst_element("vah264dec"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AVC,
-      gstdecoder    = "vah264dec",
-      gstmediatype  = "video/x-h264",
-      gstparser     = "h264parse",
-    )
-
-  def get_file_ext(self):
-    return "h264"
-
-@slash.requires(*have_gst_element("vah264enc"))
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      gstencoder= "vah264enc",
-      lowpower  = False,
-    )
-
-@slash.requires(*have_gst_element("vah264lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      gstencoder= "vah264lpenc",
-      lowpower  = True,
-    )
 
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-va/encode/hevc.py
+++ b/test/gst-va/encode/hevc.py
@@ -5,48 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.encoder import EncoderTest
+from ....lib.gstreamer.va.encoder import HEVC8EncoderTest, HEVC8EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("vah265dec"))
-class HEVC8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstdecoder    = "vah265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*have_gst_element("vah265enc"))
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      gstencoder= "vah265enc",
-      lowpower  = False,
-    )
-
-@slash.requires(*have_gst_element("vah265lpenc"))
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      gstencoder= "vah265lpenc",
-      lowpower  = True,
-    )
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-va/encode/jpeg.py
+++ b/test/gst-va/encode/jpeg.py
@@ -5,30 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.encoder import EncoderTest
+from ....lib.gstreamer.va.encoder import JPEGEncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
-
-@slash.requires(*have_gst_element("vajpegenc"))
-@slash.requires(*have_gst_element("vajpegdec"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = Codec.JPEG,
-      gstencoder    = "vajpegenc",
-      gstdecoder    = "vajpegdec",
-      gstmediatype  = "image/jpeg",
-      gstparser     = "jpegparse",
-    )
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):

--- a/test/gst-va/encode/vp9.py
+++ b/test/gst-va/encode/vp9.py
@@ -5,49 +5,10 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.encoder import EncoderTest
+from ....lib.gstreamer.va.encoder import VP9EncoderTest, VP9EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
-
-@slash.requires(*have_gst_element("vavp9dec"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstdecoder    = "vavp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-@slash.requires(*have_gst_element("vavp9enc"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("encode", "vp9_8"),
-      lowpower      = False,
-      gstencoder    = "vavp9enc",
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-@slash.requires(*have_gst_element("vavp9lpenc"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("vdenc", "vp9_8"),
-      lowpower      = True,
-      gstencoder    = "vavp9lpenc",
-    )
 
 class cqp_lp(VP9EncoderLPTest):
   def init(self, tspec, case, ipmode, qp, quality, looplvl, loopshp):

--- a/test/gst-vaapi/encode/10bit/hevc.py
+++ b/test/gst-vaapi/encode/10bit/hevc.py
@@ -5,46 +5,11 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
-from .....lib.gstreamer.vaapi.encoder import EncoderTest
+from .....lib.gstreamer.vaapi.encoder import HEVC10EncoderTest, HEVC10EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "10bit")
 spec_r2r  = load_test_spec("hevc", "encode", "10bit", "r2r")
-
-@slash.requires(*have_gst_element("vaapih265enc"))
-@slash.requires(*have_gst_element("vaapih265dec"))
-class HEVC10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstencoder    = "vaapih265enc",
-      gstdecoder    = "vaapih265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*platform.have_caps("encode", "hevc_10"))
-class HEVC10EncoderTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_10"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_10"))
-class HEVC10EncoderLPTest(HEVC10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_10"),
-      lowpower  = True,
-    )
 
 class cqp(HEVC10EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-vaapi/encode/10bit/vp9.py
+++ b/test/gst-vaapi/encode/10bit/vp9.py
@@ -5,47 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
-from .....lib.gstreamer.vaapi.encoder import EncoderTest
+from .....lib.gstreamer.vaapi.encoder import VP9_10EncoderTest, VP9_10EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "10bit")
-
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-class VP9_10EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstencoder    = "vaapivp9enc",
-      gstdecoder    = "vaapivp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_10"))
-class VP9_10EncoderTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp9_10"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_10"))
-class VP9_10EncoderLPTest(VP9_10EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "vp9_10"),
-      lowpower  = True,
-    )
 
 class cqp(VP9_10EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):

--- a/test/gst-vaapi/encode/12bit/hevc.py
+++ b/test/gst-vaapi/encode/12bit/hevc.py
@@ -5,36 +5,10 @@
 ###
 
 from .....lib import *
-from .....lib.codecs import Codec
 from .....lib.gstreamer.vaapi.util import *
-from .....lib.gstreamer.vaapi.encoder import EncoderTest
+from .....lib.gstreamer.vaapi.encoder import HEVC12EncoderTest
 
 spec = load_test_spec("hevc", "encode", "12bit")
-
-@slash.requires(*have_gst_element("vaapih265dec"))
-@slash.requires(*have_gst_element("vaapih265enc"))
-class HEVC12EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstdecoder    = "vaapih265dec",
-      gstencoder    = "vaapih265enc",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*platform.have_caps("encode", "hevc_12"))
-class HEVC12EncoderTest(HEVC12EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_12"),
-      lowpower  = False,
-    )
 
 class cqp(HEVC12EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-vaapi/encode/avc.py
+++ b/test/gst-vaapi/encode/avc.py
@@ -5,46 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import AVCEncoderTest, AVCEncoderLPTest
 
 spec      = load_test_spec("avc", "encode")
 spec_r2r  = load_test_spec("avc", "encode", "r2r")
-
-@slash.requires(*have_gst_element("vaapih264enc"))
-@slash.requires(*have_gst_element("vaapih264dec"))
-class AVCEncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.AVC,
-      gstencoder    = "vaapih264enc",
-      gstdecoder    = "vaapih264dec",
-      gstmediatype  = "video/x-h264",
-      gstparser     = "h264parse",
-    )
-
-  def get_file_ext(self):
-    return "h264"
-
-@slash.requires(*platform.have_caps("encode", "avc"))
-class AVCEncoderTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "avc"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "avc"))
-class AVCEncoderLPTest(AVCEncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "avc"),
-      lowpower  = True,
-    )
 
 class cqp(AVCEncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-vaapi/encode/hevc.py
+++ b/test/gst-vaapi/encode/hevc.py
@@ -5,46 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import HEVC8EncoderTest, HEVC8EncoderLPTest
 
 spec      = load_test_spec("hevc", "encode", "8bit")
 spec_r2r  = load_test_spec("hevc", "encode", "8bit", "r2r")
-
-@slash.requires(*have_gst_element("vaapih265enc"))
-@slash.requires(*have_gst_element("vaapih265dec"))
-class HEVC8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.HEVC,
-      gstencoder    = "vaapih265enc",
-      gstdecoder    = "vaapih265dec",
-      gstmediatype  = "video/x-h265",
-      gstparser     = "h265parse",
-    )
-
-  def get_file_ext(self):
-    return "h265"
-
-@slash.requires(*platform.have_caps("encode", "hevc_8"))
-class HEVC8EncoderTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "hevc_8"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "hevc_8"))
-class HEVC8EncoderLPTest(HEVC8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("vdenc", "hevc_8"),
-      lowpower  = True,
-    )
 
 class cqp(HEVC8EncoderTest):
   def init(self, tspec, case, gop, slices, bframes, qp, quality, profile):

--- a/test/gst-vaapi/encode/jpeg.py
+++ b/test/gst-vaapi/encode/jpeg.py
@@ -5,31 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import JPEGEncoderTest
 
 spec      = load_test_spec("jpeg", "encode")
 spec_r2r  = load_test_spec("jpeg", "encode", "r2r")
-
-@slash.requires(*have_gst_element("vaapijpegenc"))
-@slash.requires(*have_gst_element("vaapijpegdec"))
-@slash.requires(*platform.have_caps("vdenc", "jpeg"))
-class JPEGEncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("vdenc", "jpeg"),
-      codec         = Codec.JPEG,
-      gstencoder    = "vaapijpegenc",
-      gstdecoder    = "vaapijpegdec",
-      gstmediatype  = "image/jpeg",
-      gstparser     = "jpegparse",
-    )
-    super(JPEGEncoderTest, self).before()
-
-  def get_file_ext(self):
-    return "mjpeg" if self.frames > 1 else "jpg"
 
 class cqp(JPEGEncoderTest):
   def init(self, tspec, case, quality):

--- a/test/gst-vaapi/encode/mpeg2.py
+++ b/test/gst-vaapi/encode/mpeg2.py
@@ -5,30 +5,11 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import MPEG2EncoderTest
 
 spec      = load_test_spec("mpeg2", "encode")
 spec_r2r  = load_test_spec("mpeg2", "encode", "r2r")
-
-@slash.requires(*have_gst_element("vaapimpeg2enc"))
-@slash.requires(*have_gst_element("vaapimpeg2dec"))
-@slash.requires(*platform.have_caps("encode", "mpeg2"))
-class MPEG2EncoderTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps          = platform.get_caps("encode", "mpeg2"),
-      codec         = Codec.MPEG2,
-      gstencoder    = "vaapimpeg2enc",
-      gstdecoder    = "vaapimpeg2dec",
-      gstmediatype  = "video/mpeg,mpegversion=2",
-      gstparser     = "mpegvideoparse",
-    )
-
-  def get_file_ext(self):
-    return "m2v"
 
 class cqp(MPEG2EncoderTest):
   def init(self, tspec, case, gop, bframes, qp, quality):

--- a/test/gst-vaapi/encode/vp8.py
+++ b/test/gst-vaapi/encode/vp8.py
@@ -5,37 +5,10 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import VP8EncoderTest
 
 spec = load_test_spec("vp8", "encode")
-
-@slash.requires(*have_gst_element("vaapivp8enc"))
-@slash.requires(*have_gst_element("vaapivp8dec"))
-class VP8EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP8,
-      gstencoder    = "vaapivp8enc",
-      gstdecoder    = "vaapivp8dec",
-      gstmediatype  = "video/x-vp8",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp8"))
-class VP8EncoderTest(VP8EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps      = platform.get_caps("encode", "vp8"),
-      lowpower  = False,
-    )
 
 class cqp(VP8EncoderTest):
   @slash.parametrize(*gen_vp8_cqp_parameters(spec))

--- a/test/gst-vaapi/encode/vp9.py
+++ b/test/gst-vaapi/encode/vp9.py
@@ -5,47 +5,10 @@
 ###
 
 from ....lib import *
-from ....lib.codecs import Codec
 from ....lib.gstreamer.vaapi.util import *
-from ....lib.gstreamer.vaapi.encoder import EncoderTest
+from ....lib.gstreamer.vaapi.encoder import VP9EncoderTest, VP9EncoderLPTest
 
 spec = load_test_spec("vp9", "encode", "8bit")
-
-@slash.requires(*have_gst_element("vaapivp9enc"))
-@slash.requires(*have_gst_element("vaapivp9dec"))
-class VP9EncoderBaseTest(EncoderTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      codec         = Codec.VP9,
-      gstencoder    = "vaapivp9enc",
-      gstdecoder    = "vaapivp9dec",
-      gstmediatype  = "video/x-vp9",
-      gstparser     = "vp9parse",
-      gstmuxer      = "matroskamux",
-      gstdemuxer    = "matroskademux",
-    )
-
-  def get_file_ext(self):
-    return "webm"
-
-@slash.requires(*platform.have_caps("encode", "vp9_8"))
-class VP9EncoderTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps = platform.get_caps("encode", "vp9_8"),
-      lowpower  = False,
-    )
-
-@slash.requires(*platform.have_caps("vdenc", "vp9_8"))
-class VP9EncoderLPTest(VP9EncoderBaseTest):
-  def before(self):
-    super().before()
-    vars(self).update(
-      caps = platform.get_caps("vdenc", "vp9_8"),
-      lowpower  = True,
-    )
 
 class cqp(VP9EncoderTest):
   def init(self, tspec, case, ipmode, qp, quality, refmode, looplvl, loopshp):


### PR DESCRIPTION
Move all the codec-specialized encode test classes to lib so that they can be reused.  Use dynamic class template to generate test classes.