### PR TITLE
gst-va: resolve hwdevice path in decoder element name before slash.requires

### DIFF
--- a/lib/gstreamer/va/decoder.py
+++ b/lib/gstreamer/va/decoder.py
@@ -7,7 +7,10 @@
 import os
 import slash
 
+from ....lib import platform
+from ....lib.codecs import Codec
 from ....lib.common import get_media
+from ....lib.formats import PixelFormat
 from ....lib.gstreamer.decoderbase import BaseDecoderTest, Decoder as GstDecoder
 from ....lib.gstreamer.util import have_gst_element
 from ....lib.gstreamer.va.util import mapformat, mapformatu
@@ -16,17 +19,6 @@ class Decoder(GstDecoder):
   format  = property(lambda s: mapformatu(super().format))
   pformat = property(lambda s: mapformat(super().format))
 
-  @property
-  def hwdevice(self):
-   return get_media().render_device.split('/')[-1]
-
-  @property
-  def gstdecoder(self):
-    #FIXME: use class template (e.g. similar to encoder) to resolve element
-    # name sooner so that it can be used in slash.requires.
-    #TODO: windows hwdevice > 0 is not test
-    return super().gstdecoder if self.hwdevice in [ "renderD128", "0" ] else super().gstdecoder.replace("va", f"va{self.hwdevice}")
-
 @slash.requires(*have_gst_element("va"))
 class DecoderTest(BaseDecoderTest):
   DecoderClass = Decoder
@@ -34,3 +26,67 @@ class DecoderTest(BaseDecoderTest):
   def before(self):
     super().before()
 
+def decode_test_class(codec, bitdepth, **kwargs):
+  # caps lookup translation
+  capcodec = codec
+  if codec in [Codec.HEVC, Codec.VP9, Codec.AV1]:
+    capcodec = f"{codec}_{bitdepth}"
+
+  # gst element codec translation
+  gstcodec = {
+    Codec.AVC   : "h264",
+    Codec.HEVC  : "h265",
+  }.get(codec, codec)
+
+  gstparser = {
+    Codec.MPEG2 : "mpegvideoparse",
+    Codec.VP8   : None,
+  }.get(codec, f"{gstcodec}parse")
+
+  hwdevice = get_media().render_device.split('/')[-1]
+  hw = hwdevice if hwdevice not in ['renderD128', '0'] else ""
+
+  @slash.requires(*have_gst_element(f"va{hw}{gstcodec}dec"))
+  @slash.requires(*platform.have_caps("decode", capcodec))
+  class CodecDecoderTest(DecoderTest):
+    def before(self):
+      super().before()
+      vars(self).update(
+        caps = platform.get_caps("decode", capcodec),
+        codec = codec,
+        gstdecoder = f"va{hw}{gstcodec}dec",
+        gstparser = gstparser,
+        **kwargs,
+      )
+
+    def validate_caps(self):
+      assert PixelFormat(self.format).bitdepth == bitdepth
+      super().validate_caps()
+
+  return CodecDecoderTest
+
+## AVC ##
+AVCDecoderTest      = decode_test_class(codec = Codec.AVC, bitdepth = 8)
+
+## HEVC ##
+HEVC_8DecoderTest   = decode_test_class(codec = Codec.HEVC, bitdepth = 8)
+HEVC_10DecoderTest  = decode_test_class(codec = Codec.HEVC, bitdepth = 10)
+HEVC_12DecoderTest  = decode_test_class(codec = Codec.HEVC, bitdepth = 12)
+
+## AV1 ##
+AV1_8DecoderTest    = decode_test_class(codec = Codec.AV1, bitdepth = 8)
+AV1_10DecoderTest   = decode_test_class(codec = Codec.AV1, bitdepth = 10)
+
+## VP9 ##
+VP9_8DecoderTest    = decode_test_class(codec = Codec.VP9, bitdepth = 8)
+VP9_10DecoderTest   = decode_test_class(codec = Codec.VP9, bitdepth = 10)
+VP9_12DecoderTest   = decode_test_class(codec = Codec.VP9, bitdepth = 12)
+
+## VP8 ##
+VP8DecoderTest      = decode_test_class(codec = Codec.VP8, bitdepth = 8)
+
+## JPEG/MJPEG ##
+JPEGDecoderTest     = decode_test_class(codec = Codec.JPEG, bitdepth = 8)
+
+## MPEG2 ##
+MPEG2DecoderTest    = decode_test_class(codec = Codec.MPEG2, bitdepth = 8)

--- a/lib/gstreamer/va/decoder.py
+++ b/lib/gstreamer/va/decoder.py
@@ -22,6 +22,8 @@ class Decoder(GstDecoder):
 
   @property
   def gstdecoder(self):
+    #FIXME: use class template (e.g. similar to encoder) to resolve element
+    # name sooner so that it can be used in slash.requires.
     #TODO: windows hwdevice > 0 is not test
     return super().gstdecoder if self.hwdevice in [ "renderD128", "0" ] else super().gstdecoder.replace("va", f"va{self.hwdevice}")
 

--- a/lib/gstreamer/va/encoder.py
+++ b/lib/gstreamer/va/encoder.py
@@ -149,7 +149,7 @@ def codec_test_class(codec, engine, bitdepth, **kwargs):
   hw = hwdevice if hwdevice not in ['renderD128', '0'] else ""
 
   @slash.requires(*have_gst_element(f"va{hw}{gstcodec}{lp}enc"))
-  @slash.requires(*have_gst_element(f"va{gstcodec}dec"))
+  @slash.requires(*have_gst_element(f"va{hw}{gstcodec}dec"))
   @slash.requires(*platform.have_caps(engine, capcodec))
   class CodecEncoderTest(EncoderTest):
     def before(self):
@@ -158,7 +158,7 @@ def codec_test_class(codec, engine, bitdepth, **kwargs):
         caps = platform.get_caps(engine, capcodec),
         codec = codec,
         gstencoder = f"va{hw}{gstcodec}{lp}enc",
-        gstdecoder = f"va{gstcodec}dec",
+        gstdecoder = f"va{hw}{gstcodec}dec",
         **kwargs,
       )
 

--- a/test/gst-va/decode/10bit/av1.py
+++ b/test/gst-va/decode/10bit/av1.py
@@ -6,21 +6,16 @@
 
 from .....lib import *
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.decoder import DecoderTest
+from .....lib.gstreamer.va.decoder import AV1_10DecoderTest as DecoderTest
 
 spec = load_test_spec("av1", "decode", "10bit")
 
-@slash.requires(*platform.have_caps("decode", "av1_10"))
-@slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "av1_10"),
-      gstdecoder  = "vaav1dec",
-      gstparser   = "av1parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/10bit/hevc.py
+++ b/test/gst-va/decode/10bit/hevc.py
@@ -6,21 +6,16 @@
 
 from .....lib import *
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.decoder import DecoderTest
+from .....lib.gstreamer.va.decoder import HEVC_10DecoderTest as DecoderTest
 
 spec = load_test_spec("hevc", "decode", "10bit")
 
-@slash.requires(*platform.have_caps("decode", "hevc_10"))
-@slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "hevc_10"),
-      gstdecoder  = "vah265dec",
-      gstparser   = "h265parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/10bit/vp9.py
+++ b/test/gst-va/decode/10bit/vp9.py
@@ -6,21 +6,16 @@
 
 from .....lib import *
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.decoder import DecoderTest
+from .....lib.gstreamer.va.decoder import VP9_10DecoderTest as DecoderTest
 
 spec = load_test_spec("vp9", "decode", "10bit")
 
-@slash.requires(*platform.have_caps("decode", "vp9_10"))
-@slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "vp9_10"),
-      gstdecoder  = "vavp9dec",
-      gstparser   = "vp9parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/12bit/hevc.py
+++ b/test/gst-va/decode/12bit/hevc.py
@@ -6,21 +6,16 @@
 
 from .....lib import *
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.decoder import DecoderTest
+from .....lib.gstreamer.va.decoder import HEVC_12DecoderTest as DecoderTest
 
 spec = load_test_spec("hevc", "decode", "12bit")
 
-@slash.requires(*platform.have_caps("decode", "hevc_12"))
-@slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "hevc_12"),
-      gstdecoder  = "vah265dec",
-      gstparser   = "h265parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/12bit/vp9.py
+++ b/test/gst-va/decode/12bit/vp9.py
@@ -6,20 +6,16 @@
 
 from .....lib import *
 from .....lib.gstreamer.va.util import *
-from .....lib.gstreamer.va.decoder import DecoderTest
+from .....lib.gstreamer.va.decoder import VP9_12DecoderTest as DecoderTest
 
 spec = load_test_spec("vp9", "decode", "12bit")
-@slash.requires(*platform.have_caps("decode", "vp9_12"))
-@slash.requires(*have_gst_element("vavp9dec"))
+
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "vp9_12"),
-      gstdecoder  = "vavp9dec",
-      gstparser   = "vp9parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/av1.py
+++ b/test/gst-va/decode/av1.py
@@ -6,21 +6,16 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import AV1_8DecoderTest as DecoderTest
 
 spec = load_test_spec("av1", "decode", "8bit")
 
-@slash.requires(*platform.have_caps("decode", "av1_8"))
-@slash.requires(*have_gst_element("vaav1dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "av1_8"),
-      gstdecoder  = "vaav1dec",
-      gstparser   = "av1parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/avc.py
+++ b/test/gst-va/decode/avc.py
@@ -6,21 +6,16 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import AVCDecoderTest as DecoderTest
 
 spec = load_test_spec("avc", "decode")
 
-@slash.requires(*platform.have_caps("decode", "avc"))
-@slash.requires(*have_gst_element("vah264dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "avc"),
-      gstdecoder  = "vah264dec",
-      gstparser   = "h264parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/hevc.py
+++ b/test/gst-va/decode/hevc.py
@@ -6,21 +6,16 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import HEVC_8DecoderTest as DecoderTest
 
 spec = load_test_spec("hevc", "decode", "8bit")
 
-@slash.requires(*platform.have_caps("decode", "hevc_8"))
-@slash.requires(*have_gst_element("vah265dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "hevc_8"),
-      gstdecoder  = "vah265dec",
-      gstparser   = "h265parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/jpeg.py
+++ b/test/gst-va/decode/jpeg.py
@@ -6,22 +6,17 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import JPEGDecoderTest as DecoderTest
 
 spec = load_test_spec("jpeg", "decode")
 spec_r2r = load_test_spec("jpeg", "decode", "r2r")
 
-@slash.requires(*platform.have_caps("decode", "jpeg"))
-@slash.requires(*have_gst_element("vajpegdec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
-      caps        = platform.get_caps("decode", "jpeg"),
-      gstdecoder  = "vajpegdec",
-      gstparser   = "jpegparse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/mpeg2.py
+++ b/test/gst-va/decode/mpeg2.py
@@ -6,22 +6,17 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import MPEG2DecoderTest as DecoderTest
 
 spec = load_test_spec("mpeg2", "decode")
 spec_r2r = load_test_spec("mpeg2", "decode", "r2r")
 
-@slash.requires(*platform.have_caps("decode", "mpeg2"))
-@slash.requires(*have_gst_element("vampeg2dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 0.99, minu = 0.99, minv = 0.99),
-      caps        = platform.get_caps("decode", "mpeg2"),
-      gstdecoder  = "vampeg2dec",
-      gstparser   = "mpegvideoparse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/vp8.py
+++ b/test/gst-va/decode/vp8.py
@@ -6,20 +6,16 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import VP8DecoderTest as DecoderTest
 
 spec = load_test_spec("vp8", "decode")
 
-@slash.requires(*platform.have_caps("decode", "vp8"))
-@slash.requires(*have_gst_element("vavp8dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "vp8"),
-      gstdecoder  = "vavp8dec",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))

--- a/test/gst-va/decode/vp9.py
+++ b/test/gst-va/decode/vp9.py
@@ -6,21 +6,16 @@
 
 from ....lib import *
 from ....lib.gstreamer.va.util import *
-from ....lib.gstreamer.va.decoder import DecoderTest
+from ....lib.gstreamer.va.decoder import VP9_8DecoderTest as DecoderTest
 
 spec = load_test_spec("vp9", "decode", "8bit")
 
-@slash.requires(*platform.have_caps("decode", "vp9_8"))
-@slash.requires(*have_gst_element("vavp9dec"))
 class default(DecoderTest):
   def before(self):
     super().before()
     vars(self).update(
       # default metric
       metric      = dict(type = "ssim", miny = 1.0, minu = 1.0, minv = 1.0),
-      caps        = platform.get_caps("decode", "vp9_8"),
-      gstdecoder  = "vavp9dec",
-      gstparser   = "vp9parse",
     )
 
   @slash.parametrize(("case"), sorted(spec.keys()))


### PR DESCRIPTION
On some multi-gpu systems the default decoder element
may not exist but the device specific decoder element
does.

For example, CFL+DG2 will not have a default "vaav1dec"
element but has a "varenderD129av1dec" element.  Thus,
a hard-coded slash.requires for the default decode
element will cause av1 decode cases to be unintentionally
skipped on DG2.

To fix this, define a codec specialized class template so
that the device specific element name can be resolved
before the slash.requires check.
