### PR TITLE
.slashrc: set gst vaapi/msdk device before slash.requires

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -106,6 +106,16 @@ class MediaPlugin(slash.plugins.PluginInterface):
     if self._get_os() == 'linux' and "NONE" != self.platform.upper():
       assert os.path.exists(args.device), "Target Device {} not exist".format(args.device)
 
+    # Gstreamer msdk/vaapi plugins will register elements based on the
+    # device.  In a multi-gpu system, this device is arbitrary by default.
+    # The default may not represent the actual device we are targeting for
+    # testing.  Therefore, we must set the target device env variable for the
+    # msdk/vaapi plugins before any of the slash.requires are evaluated so
+    # that test cases are not inadvertently skipped due to missing feature
+    # on one device vs. the other.
+    os.environ["GST_MSDK_DRM_DEVICE"] = self.render_device
+    os.environ["GST_VAAPI_DRM_DEVICE"] = self.render_device
+
   def _calls_allowed(self):
     # only enabled during test function execution (see test_start/test_end)
     if not self.cta_enabled:


### PR DESCRIPTION
Gstreamer msdk/vaapi plugins will register elements based on the device.  In a multi-gpu system, this device is arbitrary by default. The default may not represent the actual device we are targeting for testing.  Therefore, we must set the target device env variable for the msdk/vaapi plugins before any of the slash.requires are evaluated so that test cases are not inadvertently skipped due to missing feature on one device vs. the other.

For example, on ADL+DG2 system the ADL gpu supports mpeg2 enc.  But, the DG2 gpu does not support mpeg2 enc.  If the gstreamer plugin registers features for DG2 by default and our target test device is ADL, then the mpeg2 enc tests would be skipped inadvertently because of slash.requires was evaluated without the environment variable set.  With the environment variable set before any slash.requires evaluation, the gstreamer plugin features will be loaded correctly.

Depends on:
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5675 https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5615 https://github.com/intel-media-ci/gstreamer/pull/91