### PR TITLE
Fixing ffmpeg-qsv/gst-msdk av1 icq wrong cmd opt rang

### DIFF
--- a/lib/ffmpeg/qsv/encoder.py
+++ b/lib/ffmpeg/qsv/encoder.py
@@ -40,9 +40,9 @@ class Encoder(FFEncoder):
       if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [1, 51])
         return f" -q {mqp}"
-      if self.codec in [Codec.AV1]:
-        if "ICQ" == self.rcmode:
-          return f" -global_quality {qp}"
+      if self.codec in [Codec.AV1] and "ICQ" == self.rcmode:
+        mqp = mapRangeInt(qp, [0, 255], [1, 51])
+        return f" -global_quality {mqp}"
       return f" -q {qp}"
     return self.ifprop("qp", inner)
 

--- a/lib/gstreamer/msdk/encoder.py
+++ b/lib/gstreamer/msdk/encoder.py
@@ -37,13 +37,14 @@ class Encoder(GstEncoder):
 
   @property
   def qp(self):
+    rcmode = super().rcmode
     def inner(qp):
       if self.codec in [Codec.MPEG2]:
         mqp = mapRangeInt(qp, [0, 100], [0, 51])
         return f" qpi={mqp} qpp={mqp} qpb={mqp}"
-      if self.codec in [Codec.AV1]:
-        if "ICQ" == self.rcmode:
-          return f" qpi={qp}"
+      if self.codec in [Codec.AV1] and "icq" == rcmode:
+        mqp = mapRangeInt(qp, [0, 255], [0, 51])
+        return f" qpi={mqp}"
       return f" qpi={qp} qpp={qp} qpb={qp}"
     return self.ifprop("qp", inner)
 


### PR DESCRIPTION
1, based on ICQ define in vpl spec    https://spec.oneapi.io/onevpl/latest/API_ref/VPL_structs_cross_component.html#id10
its value is rang in [1, 51], but qp input is [0, 255], that's why some icq cases failed for ffmpeg-qsv/gst-msdk so there needs a map
2, for gst-msdk, rcmode was replaced by "rate-control =icq hardware=true", so we needs to use super().rcmode for "if", otherwise it still run cmdline with cqp mode
