### PR TITLE
ffmpeg/gstreamer: use correct test spec in csc/r2r

### DIFF
--- a/test/ffmpeg-qsv/vpp/csc.py
+++ b/test/ffmpeg-qsv/vpp/csc.py
@@ -28,7 +28,7 @@ class default(VppTest):
 
   @slash.parametrize(*gen_vpp_csc_parameters(spec_r2r))
   def test_r2r(self, case, csc):
-    vars(self).update(spec[case].copy())
+    vars(self).update(spec_r2r[case].copy())
     vars(self).update(case = case, csc = csc)
     vars(self).setdefault("r2r", 5)
     self.vpp()

--- a/test/ffmpeg-vaapi/vpp/csc.py
+++ b/test/ffmpeg-vaapi/vpp/csc.py
@@ -29,7 +29,7 @@ class default(VppTest):
 
   @slash.parametrize(*gen_vpp_csc_parameters(spec_r2r))
   def test_r2r(self, case, csc):
-    vars(self).update(spec[case].copy())
+    vars(self).update(spec_r2r[case].copy())
     vars(self).update(case = case, csc = csc)
     vars(self).setdefault("r2r", 5)
     self.vpp()

--- a/test/gst-msdk/vpp/csc.py
+++ b/test/gst-msdk/vpp/csc.py
@@ -28,7 +28,7 @@ class default(VppTest):
 
   @slash.parametrize(*gen_vpp_csc_parameters(spec_r2r))
   def test_r2r(self, case, csc):
-    vars(self).update(spec[case].copy())
+    vars(self).update(spec_r2r[case].copy())
     vars(self).update(case = case, csc = csc)
     vars(self).setdefault("r2r", 5)
     self.vpp()

--- a/test/gst-vaapi/vpp/csc.py
+++ b/test/gst-vaapi/vpp/csc.py
@@ -28,7 +28,7 @@ class default(VppTest):
 
   @slash.parametrize(*gen_vpp_csc_parameters(spec_r2r))
   def test_r2r(self, case, csc):
-    vars(self).update(spec[case].copy())
+    vars(self).update(spec_r2r[case].copy())
     vars(self).update(case = case, csc = csc)
     vars(self).setdefault("r2r", 5)
     self.vpp()


### PR DESCRIPTION

This change references the number of the previous PR: 582