### PR TITLE
ffmpeg/decode: fix autoscale usage break

### DIFF
--- a/lib/ffmpeg/decoderbase.py
+++ b/lib/ffmpeg/decoderbase.py
@@ -86,14 +86,14 @@ class Decoder(PropertyHandler, BaseFormatMapper):
         f" -f rawvideo -pix_fmt {self.format} -s:v {self.width}x{self.height}"
         f" -r:v {fps} -i {self.osreference}"
         f" -lavfi \"{self.scale_range},{mtype}=f=\\'{self.osstatsfile}\\':shortest=1\""
-        f" -fps_mode passthrough -autoscale 0 -vframes {self.frames} -f null -"
+        f" -fps_mode passthrough -noautoscale -vframes {self.frames} -f null -"
       )
 
     return call(
       f"{exe2os('ffmpeg')} -v verbose {self.hwinit}"
       f" {self.ffdecoder} -i {self.ossource} -lavfi '{self.scale_range}'"
       f" -c:v rawvideo -pix_fmt {self.format} -fps_mode passthrough"
-      f" -autoscale 0 -vframes {self.frames} -y {self.ffoutput}"
+      f" -noautoscale -vframes {self.frames} -y {self.ffoutput}"
     )
 
 @slash.requires(have_ffmpeg)


### PR DESCRIPTION
The -autoscale 0 option no longer works and causes pipeline to error/abort.

The correct usage, apparently, is to use -noautoscale.
```
Since FFMpeg commit 25c98566e8a45b50415c80ca6450282f2ec0657a
Author: Anton Khirnov <anton@khirnov.net>
Date:   Fri Dec 15 02:31:03 2023 +0100

    fftools/ffmpeg_opt: drop HAS_ARG from auto{scale,rotate}
```