### PR TITLE
ffmpeg/jpeg: use tv scale/color range

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -169,7 +169,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     )
 
     if self.codec in [Codec.JPEG]:
-      self.decoder.update(ffscale_range = "jpeg")
+      self.decoder.update(ffscale_range = "tv")
 
     if None in [self.encoder.hwformat, self.encoder.format, self.decoder.hwformat, self.decoder.format]:
       slash.skip_test("{format} not supported".format(**vars(self)))

--- a/test/ffmpeg-vaapi/decode/jpeg.py
+++ b/test/ffmpeg-vaapi/decode/jpeg.py
@@ -24,7 +24,7 @@ class default(DecoderTest):
     # needed.  This ensures the correct output is produced.  Alternative
     # proposal was to use yuvj* formats... however, hwaccel doesn't support them
     # and they may be removed in the future (deprecated).
-    self.ffscale_range = "jpeg"
+    self.ffscale_range = "tv"
 
     super(default, self).before()
 


### PR DESCRIPTION
Explicitly use tv scale/color range for JPEG decode to make ffmpeg-vaapi consistent with all other tested middleware plugins.

Since 8b76bae8961c

VIZ-20450