### PR TITLE
model: update hevc 10bit QP list

### DIFF
--- a/model/encode/10bit/hevc.py
+++ b/model/encode/10bit/hevc.py
@@ -35,6 +35,9 @@ class trend(HEVC10EncoderTest, TrendModelMixin):
   @slash.parametrize(*TrendModelMixin.filter_spec(spec))
   def test(self, case):
     vars(self).update(case = case)
+    vars(self).update(
+      modelqps = [12, 13, 16, 18, 23, 31, 40, 42, 45, 48, 49, 51, 54, 57, 60, 61, 63]
+    )
     vars(self).update(spec[case].copy())
 
     # Some features/formats are only supported by VDENC (lowpower = 1).


### PR DESCRIPTION
Use a valid QP range accepted by the iHD driver for HEVC 10bit.

Unfortunately, there is still a bug in ffmpeg and vpl that incorrectly forces QP in the wrong range...

See https://github.com/oneapi-src/oneVPL-intel-gpu/issues/297

Thus, until the issue is fixed, the ffmpeg-qsv encoder code needs to be modified, manually, to remove the QP range constraints so that the requested values can propogate to vpl and the driver to properly generate a trendline model.