### PR TITLE
gst/vaapi: do not rank vaapidecodebin

### DIFF
--- a/lib/gstreamer/vaapi/encoder.py
+++ b/lib/gstreamer/vaapi/encoder.py
@@ -89,7 +89,10 @@ class EncoderTest(BaseEncoderTest):
     # Maximize all gst-vaapi plugin elements rank
     self.__rank_before = os.environ.get("GST_PLUGIN_FEATURE_RANK", None)
     ranks = [] if self.__rank_before is None else self.__rank_before.split(',')
-    ranks += [f"{e}:MAX" for e in get_elements("vaapi")]
+
+    # don't include vaapidecodebin since it forces a vaapipostproc insertion
+    # that does not properly select passthrough when it's possible.
+    ranks += [f"{e}:MAX" for e in set(get_elements("vaapi")) - set(["vaapidecodebin"])]
     os.environ["GST_PLUGIN_FEATURE_RANK"] = ','.join(ranks)
 
   def after(self):


### PR DESCRIPTION
The vaapidecodebin automatically inserts a vaapipostproc into the pipeline which always selects NV12 output.  This causes issues when decoding non 8-bit and non 420 pixel formats.  For example, Y410 (444) coded source can be decoded directly to Y410 output.  But the automatic vpp insertion from vaapidecodebin creates a downsampling CSC operation to NV12 and causes the output to lose detail.

This fixes a VP9 10bit 444 encode regression caused by improperly decoded source file.

Relates To: VIZ-20620

cc: @wenqingx @Hangjie22Coder 