### PR TITLE
caps: update d3d12 encoder caps for DG2

### DIFF
--- a/lib/caps/DG2/d3d12
+++ b/lib/caps/DG2/d3d12
@@ -27,17 +27,18 @@ caps = dict(
     av1_8   = dict(maxres = res16k , fmts = ["NV12"]),
     av1_10  = dict(maxres = res16k , fmts = ["P010"]),
   ),
-  vdenc   = dict(
-    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
-    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
+  encode   = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
     hevc_8  = dict(
-      maxres    = res16k,
-      fmts      = ["NV12", "AYUV"],
+      maxres    = res8k,
+      fmts      = ["NV12"],
       features  = dict(scc = True),
     ),
-    hevc_10 = dict(maxres = res16k , fmts = ["P010", "Y410"]),
-    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
-    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    hevc_10 = dict(
+      maxres = res8k,
+      fmts = ["P010"],
+      features  = dict(msp = True),
+    ),
     av1_8  = dict(
       maxres    = res8k,
       fmts      = ["NV12"],


### PR DESCRIPTION
D3D12 should use encoder instead of vdenc.