### PR TITLE
assets: register test case sources before start

### DIFF
--- a/.slashrc
+++ b/.slashrc
@@ -279,6 +279,8 @@ class MediaPlugin(slash.plugins.PluginInterface):
 
   def before_session_start(self):
     self.assets = artifacts.MediaAssets()
+    for _, _, params in self._iter_test_spec():
+      self.assets.register(params)
 
   def session_start(self):
     self.session_start = dt.now()

--- a/.slashrc
+++ b/.slashrc
@@ -188,6 +188,16 @@ class MediaPlugin(slash.plugins.PluginInterface):
       spec = spec.setdefault(key, dict())
     return spec.setdefault("--spec--", dict())
 
+  def _iter_test_spec(self):
+    def inner(spec, *context):
+      for k, v in spec.items():
+        if "--spec--" == k:
+          for name, params in v.items():
+            yield context, name, params
+        else:
+          yield from inner(v, *context, k)
+    yield from inner(self.testspec)
+
   def _get_driver_name(self):
     # TODO: query vaapi for driver name (i.e. use ctypes to call vaapi)
     return os.environ.get("LIBVA_DRIVER_NAME", None) or "i965"
@@ -393,24 +403,23 @@ blacklist = os.environ.get(
   os.path.abspath(os.path.join(media.mypath, "blacklist")))
 media._load_blacklist(blacklist)
 
-from slash.core.variation import _PRINTABLE_CHARS
-import numbers
-def validate_spec(spec, context = list()):
-  for k, v in spec.items():
-    if "--spec--" == k:
-      for case in v.keys():
-        _VALID_TYPES = (numbers.Integral, str)
-        assert isinstance(case, _VALID_TYPES), (
-          "{}: {}"
-          "\n\tIllegal type for test case name"
-          "\n\tLegal types: {}".format(context, case, _VALID_TYPES))
-        assert _PRINTABLE_CHARS.issuperset(str(case)), (
-          "{}: {}"
-          "\n\tIllegal character in test case name"
-          "\n\tLegal characters: '{}'".format(context, case, ''.join(_PRINTABLE_CHARS)))
-    else:
-      validate_spec(v, context + [k,])
-validate_spec(media.testspec)
+def validate_case_name(name, context):
+  from slash.core.variation import _PRINTABLE_CHARS
+  import numbers
+  _VALID_TYPES = (numbers.Integral, str)
+
+  assert isinstance(name, _VALID_TYPES), f"""
+    Illegal type for test case name: name = {name}, type = {type(name)}, context = {context}
+    Legal types: {_VALID_TYPES}
+  """
+
+  assert _PRINTABLE_CHARS.issuperset(str(name)), f"""
+    Illegal character(s) in test case name: name = {name}, context = {context}
+    Legal characters: {''.join(sorted(_PRINTABLE_CHARS))}
+  """
+
+for context, name, params in media._iter_test_spec():
+  validate_case_name(name, context)
 
 ###
 ### kate: syntax python;

--- a/.slashrc
+++ b/.slashrc
@@ -277,6 +277,9 @@ class MediaPlugin(slash.plugins.PluginInterface):
     result.data.update(time = str(time))
     self._set_test_details(time = "{} seconds".format(time))
 
+  def before_session_start(self):
+    self.assets = artifacts.MediaAssets()
+
   def session_start(self):
     self.session_start = dt.now()
 

--- a/lib/artifacts.py
+++ b/lib/artifacts.py
@@ -50,16 +50,16 @@ class Artifacts():
     return absfile
 
 class MediaAssets:
-  # cache files that have already been decoded during the test session
-  _decoded = dict()
+  def __init__(self):
+    # cache files that have already been decoded during the test session
+    self._decoded = dict()
 
-  @classmethod
-  def raw(cls, test, **kwargs):
+  def raw(self, test, **kwargs):
     from .codecs import Codec
     if vars(test).get("scodec", Codec.RAW) is Codec.RAW:
       decoded = test.source
     else:
-      decoded = cls._decoded.get(test.source, dict()).get(
+      decoded = self._decoded.get(test.source, dict()).get(
         (test.format, test.frames), None)
 
     if decoded is None:
@@ -72,5 +72,5 @@ class MediaAssets:
       )
       decoder.decode()
       decoded = decoder.decoded
-      cls._decoded.setdefault(test.source, dict())[(test.format, test.frames)] = decoded
+      self._decoded.setdefault(test.source, dict())[(test.format, test.frames)] = decoded
     return decoded

--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -8,7 +8,6 @@ import os
 import re
 import slash
 
-from ...lib.artifacts import MediaAssets
 from ...lib.common import get_media, timefn, call, exe2os, filepath2os
 from ...lib.ffmpeg.util import have_ffmpeg, BaseFormatMapper
 from ...lib.ffmpeg.util import parse_inline_md5, parse_psnr_stats
@@ -225,7 +224,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
     # Decode the input file to raw format if necessary
-    self.encoder.update(source = MediaAssets.raw(self, caps = self.caps))
+    self.encoder.update(source = get_media().assets.raw(self, caps = self.caps))
 
     if vars(self).get("r2r", None) is not None:
       return self._encode_r2r()

--- a/lib/ffmpeg/vppbase.py
+++ b/lib/ffmpeg/vppbase.py
@@ -106,8 +106,7 @@ class BaseVppTest(slash.Test, BaseFormatMapper, VppMetricMixin):
     self.validate_caps()
 
     if self.vpp_op not in ["deinterlace", "tonemap", "stack", "overlay", "range", "pad", "drawbox"]:
-      from ...lib.artifacts import MediaAssets
-      self.source = MediaAssets.raw(self, caps = dict(fmts = self.get_output_formats()))
+      self.source = get_media().assets.raw(self, caps = dict(fmts = self.get_output_formats()))
 
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -8,7 +8,6 @@ import os
 import re
 import slash
 
-from ...lib.artifacts import MediaAssets
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
 from ...lib.gstreamer.util import have_gst, have_gst_element
 from ...lib.gstreamer.util import parse_inline_md5, parse_psnr_stats
@@ -155,7 +154,7 @@ class BaseEncoderTest(slash.Test):
     get_media().test_call_timeout = vars(self).get("call_timeout", 0)
 
     # Decode the input file to raw format if necessary
-    self.encoder.update(source = MediaAssets.raw(self, gstdecoder = "decodebin"))
+    self.encoder.update(source = get_media().assets.raw(self, gstdecoder = "decodebin"))
 
     if vars(self).get("r2r", None) is not None:
       return self._encode_r2r()

--- a/lib/gstreamer/vppbase.py
+++ b/lib/gstreamer/vppbase.py
@@ -105,8 +105,7 @@ class BaseVppTest(slash.Test, VppMetricMixin):
     self.validate_caps()
 
     if self.vpp_op not in ["deinterlace", "tonemap"]:
-      from ...lib.artifacts import MediaAssets
-      self.source = MediaAssets.raw(self, gstdecoder = "decodebin")
+      self.source = get_media().assets.raw(self, gstdecoder = "decodebin")
 
     iopts = self.gen_input_opts()
     oopts = self.gen_output_opts()


### PR DESCRIPTION
Register all coded test source files before starting
the session.

When a source is registered multiple times, only the
number of requested frames is updated if it's more than
the previous registration.  This helps optimize decoded
cache so that we only have to decode the source once,
regardless of how many frames each case is going to
use.

VIZ-20591