### PR TITLE
gst/xcode: set explicit input fps if unknown

### DIFF
--- a/lib/gstreamer/transcoderbase.py
+++ b/lib/gstreamer/transcoderbase.py
@@ -9,8 +9,8 @@ import os
 
 from ...lib.codecs import Codec
 from ...lib.common import timefn, get_media, call, exe2os, filepath2os
-from ...lib.gstreamer.util import BaseFormatMapper, have_gst, have_gst_element, gst_discover
-
+from ...lib.gstreamer.util import BaseFormatMapper, have_gst, have_gst_element
+from ...lib.gstreamer.util import gst_discover, gst_discover_fps
 from ...lib import metrics2
 
 @slash.requires(have_gst)
@@ -119,6 +119,11 @@ class BaseTranscoderTest(slash.Test, BaseFormatMapper):
     opts += " ! " + self.get_decoder(self.codec, self.mode)
     if self.mode in ["hw", "sw"]:
       opts += " ! video/x-raw,format={mformat}"
+
+    # if input framerate is unknown, then set it explicitly (VIZ-20689)
+    if gst_discover_fps(self.ossource).startswith("0"):
+      opts += " ! videorate ! 'video/x-raw(ANY),framerate=30/1'"
+
     return opts.format(**vars(self))
 
   def gen_output_opts(self):

--- a/lib/gstreamer/util.py
+++ b/lib/gstreamer/util.py
@@ -33,7 +33,7 @@ def gst_discover(filename):
 
 def gst_discover_fps(filename):
   return gst_discover_fps.pattern.findall(gst_discover(filename))[-1]
-gst_discover_fps.pattern = re.compile("Frame rate: (?P<fps>[0-9]+)", re.MULTILINE)
+gst_discover_fps.pattern = re.compile("Frame rate: (?P<fps>[0-9]+/[0-9]+)", re.MULTILINE)
 
 @memoize
 def get_elements(plugin):

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -69,7 +69,7 @@ class TranscoderTest(BaseTranscoderTest):
         hw = (platform.get_caps("vdenc", "jpeg"), have_gst_element("vaapijpegenc"), "vaapijpegenc ! jpegparse"),
       ),
       Codec.VP9 : dict(
-        lp = (platform.get_caps("vdenc", "vp9_8"), have_gst_element("vaapivp9enc"), "videorate ! 'video/x-raw(ANY)',framerate=30/1 ! vaapivp9enc tune=low-power ! vp9parse ! matroskamux"),
+        lp = (platform.get_caps("vdenc", "vp9_8"), have_gst_element("vaapivp9enc"), "vaapivp9enc tune=low-power ! vp9parse ! matroskamux"),
       ),
     },
     vpp = {


### PR DESCRIPTION
AV1 and VP9 encode fails if no framerate is
provided by upstream pipeline element.

VIZ-20689

cc: @wenqingx @HeJunyan