### PR TITLE
encode: capture other vbr modes for brgap

### DIFF
--- a/lib/ffmpeg/encoderbase.py
+++ b/lib/ffmpeg/encoderbase.py
@@ -274,7 +274,7 @@ class BaseEncoderTest(slash.Test, BaseFormatMapper):
       # acceptable bitrate within 10% of bitrate
       assert(bitrate_gap <= 0.10)
 
-    elif "vbr" == self.rcmode and vars(self).get("maxframesize", None) is None:
+    elif "vbr" in self.rcmode and vars(self).get("maxframesize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
       if vars(self).get("maxrate", None) is not None:
         assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)

--- a/lib/gstreamer/encoderbase.py
+++ b/lib/gstreamer/encoderbase.py
@@ -204,7 +204,7 @@ class BaseEncoderTest(slash.Test):
       # acceptable bitrate within 10% of bitrate
       assert(bitrate_gap <= 0.10)
 
-    elif self.rcmode in ["vbr", "la_vbr"] and vars(self).get("maxframesize", None) is None:
+    elif "vbr" in self.rcmode and vars(self).get("maxframesize", None) is None:
       # acceptable bitrate within 25% of minrate and 10% of maxrate
       assert(self.minrate * 0.75 <= bitrate_actual <= self.maxrate * 1.10)
 


### PR DESCRIPTION
Capture other vbr rcmode variants like qvbr and la_vbr for bitrate gap checks.

cc: @wenqingx 