### PR TITLE
gst/xcode: fix AV1 demux assumption and add gst-vaapi AV1 xcode test

### DIFF
--- a/lib/gstreamer/msdk/transcoder.py
+++ b/lib/gstreamer/msdk/transcoder.py
@@ -54,10 +54,10 @@ class TranscoderTest(BaseTranscoderTest):
         ),
       ),
       Codec.VP9 : dict(
-        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"msdkvp9dec"), f"matroskademux ! vp9parse ! msdkvp9dec"),
+        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"msdkvp9dec"), "vp9parse ! msdkvp9dec"),
       ),
       Codec.AV1 : dict(
-        hw = (platform.get_caps("decode", "av1_8"), have_gst_element(f"msdkav1dec"), f"matroskademux ! av1parse ! msdkav1dec"),
+        hw = (platform.get_caps("decode", "av1_8"), have_gst_element(f"msdkav1dec"), "av1parse ! msdkav1dec"),
       ),
     },
     encode = {

--- a/lib/gstreamer/va/transcoder.py
+++ b/lib/gstreamer/va/transcoder.py
@@ -27,9 +27,6 @@ def make_requirements():
         sw = (dict(maxres = (16384, 16384)), have_gst_element("libde265dec"), "h265parse ! libde265dec ! videoconvert"),
         hw = (platform.get_caps("decode", "hevc_8"), have_gst_element(f"va{hw}h265dec"), f"h265parse ! va{hw}h265dec"),
       ),
-      Codec.AV1 : dict(
-        hw = (platform.get_caps("decode", "av1_8"), have_gst_element(f"va{hw}av1dec"), f"matroskademux ! av1parse ! va{hw}av1dec"),
-      ),
       Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("mpeg2dec"), "mpegvideoparse ! mpeg2dec ! videoconvert"),
         hw = (platform.get_caps("decode", "mpeg2"), have_gst_element(f"va{hw}mpeg2dec"), f"mpegvideoparse ! va{hw}mpeg2dec"),
@@ -39,7 +36,10 @@ def make_requirements():
         hw = (platform.get_caps("decode", "jpeg"), have_gst_element(f"va{hw}jpegdec"), f"jpegparse ! va{hw}jpegdec"),
       ),
       Codec.VP9 : dict(
-        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"va{hw}vp9dec"), f"matroskademux ! vp9parse ! va{hw}vp9dec"),
+        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"va{hw}vp9dec"), f"vp9parse ! va{hw}vp9dec"),
+      ),
+      Codec.AV1 : dict(
+        hw = (platform.get_caps("decode", "av1_8"), have_gst_element(f"va{hw}av1dec"), f"av1parse ! va{hw}av1dec"),
       ),
     },
     encode = {
@@ -53,9 +53,6 @@ def make_requirements():
         hw = (platform.get_caps("encode", "hevc_8"), have_gst_element(f"va{hw}h265enc"), f"va{hw}h265enc ! video/x-h265,profile=main ! h265parse"),
         lp = (platform.get_caps("vdenc", "hevc_8"), have_gst_element(f"va{hw}h265lpenc"), f"va{hw}h265lpenc ! video/x-h265,profile=main ! h265parse"),
       ),
-      Codec.AV1 : dict(
-        lp = (platform.get_caps("vdenc", "av1_8"), have_gst_element(f"va{hw}av1lpenc"), f"va{hw}av1lpenc ! video/x-av1,profile=main ! av1parse ! matroskamux"),
-      ),
       Codec.MPEG2 : dict(
         sw = (dict(maxres = (2048, 2048)), have_gst_element("avenc_mpeg2video"), "avenc_mpeg2video ! mpegvideoparse"),
         hw = (platform.get_caps("encode", "mpeg2"), have_gst_element(f"va{hw}mpeg2enc"), f"va{hw}mpeg2enc ! mpegvideoparse"),
@@ -66,6 +63,9 @@ def make_requirements():
       ),
       Codec.VP9 : dict(
         lp = (platform.get_caps("vdenc", "vp9_8"), have_gst_element(f"va{hw}vp9lpenc"), f"va{hw}vp9lpenc ! vp9parse ! matroskamux"),
+      ),
+      Codec.AV1 : dict(
+        lp = (platform.get_caps("vdenc", "av1_8"), have_gst_element(f"va{hw}av1lpenc"), f"va{hw}av1lpenc ! video/x-av1,profile=main ! av1parse ! matroskamux"),
       ),
     },
     vpp = {

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -46,7 +46,7 @@ class TranscoderTest(BaseTranscoderTest):
         ),
       ),
       Codec.VP9 : dict(
-        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"vaapivp9dec"), f"matroskademux ! vp9parse !  vaapivp9dec"),
+        hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"vaapivp9dec"), f"vp9parse !  vaapivp9dec"),
       ),
     },
     encode = {

--- a/lib/gstreamer/vaapi/transcoder.py
+++ b/lib/gstreamer/vaapi/transcoder.py
@@ -48,6 +48,9 @@ class TranscoderTest(BaseTranscoderTest):
       Codec.VP9 : dict(
         hw = (platform.get_caps("decode", "vp9_8"), have_gst_element(f"vaapivp9dec"), f"vp9parse !  vaapivp9dec"),
       ),
+      Codec.AV1 : dict(
+        hw = (platform.get_caps("decode", "av1_8"), have_gst_element("vaapiav1dec"), "av1parse ! vaapiav1dec"),
+      ),
     },
     encode = {
       Codec.AVC : dict(

--- a/test/gst-vaapi/transcode/av1.py
+++ b/test/gst-vaapi/transcode/av1.py
@@ -1,0 +1,23 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+from ....lib import *
+from ....lib.gstreamer.vaapi.util import *
+from ....lib.gstreamer.vaapi.transcoder import TranscoderTest
+from ....lib.codecs import Codec
+
+spec = load_test_spec("av1", "transcode")
+
+class default(TranscoderTest):
+  @slash.parametrize(("case"), sorted_by_resolution(spec))
+  def test(self, case):
+    vars(self).update(spec[case].copy())
+    vars(self).update(
+      case  = case,
+      codec = Codec.AV1,
+    )
+    self.transcode()
+


### PR DESCRIPTION
* gst/xcode: choose decode demuxer based on file ext

    In https://github.com/intel/vaapi-fits/pull/662 we made
    the assumption that the user test config will always use
    a webm (matroska) formatted input source file for AV1
    xcode.

    However, our internal AV1 test cases use ivf input
    source files.  Unfortunately, gstreamer does not have
    a ivf muxer for the encode side of the pipeline. Nor is
    it able to discover an elementary AV1 (or VP9) file.
    Thus, when AV1 (or VP9) is the target output format,
    we still need to use the matroska container format
    (matroskamux).

    Thus, dynamically choose the proper demuxer to decode
    the input source file and the output result files
    based on the filename extension.

* gst-vaapi/xcode: add AV1 xcode support

cc: @wenqingx 