### PR TITLE
gh/workflows: add non-gpu unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,31 @@
+name: unit
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu-version: [ "ubuntu-22.04", "ubuntu-24.04", "ubuntu-latest" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
+    runs-on: ${{ matrix.ubuntu-version }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        lfs: 'true'
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt setuptools
+        sudo sysctl kernel.dmesg_restrict=0
+    - name: Test "list"
+      run: ./vaapi-fits list
+    - name: Test "self"
+      run: ./vaapi-fits run --pl NA --device /dev/null -vv --parallel-metrics --call-timeout 10 --ctapr 0 test/self

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slash>=1.12.0
+slash >= 1.12.0
 numpy
 scikit-image
 distro


### PR DESCRIPTION
Add GitHub workflow to execute non-gpu unit tests on the GitHub runners.