### PR TITLE
Lock reqirement version to 1.14.0 void issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ distro
 psutil
 py-cpuinfo
 matplotlib
+scipy == 1.14.0


### PR DESCRIPTION
22236 assert-rewrite which effect scikit-image to load structural_similarity  error