### PR TITLE
 Enabling PTL experimental support

### DIFF
--- a/lib/caps/PTL/d3d11
+++ b/lib/caps/PTL/d3d11
@@ -1,0 +1,112 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
+    av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    av1_10  = dict(maxres = res8k , fmts = ["P010"]),
+    vvc_8   = dict(maxres = res16k , fmts = ["NV12"]),
+    vvc_10  = dict(maxres = res16k , fmts = ["P010"]),
+  ),
+  encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "AYUV"],
+      features  = dict(scc = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    av1_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12"],
+    ),
+    av1_10  = dict(
+      maxres    = res8k,
+      fmts      = ["P010"],
+    ),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+  ),
+  vdenc   = dict(
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
+  ),
+  vpp    = dict(
+    # brightness, contrast, hue and saturation
+    procamp     = dict(
+      ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
+      ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # mirroring and rotation
+    transpose   = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    crop        = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    sharpen     = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    denoise     = dict(
+      ifmts = ["NV12", "P010", "YUY2"],
+      ofmts = ["NV12", "P010", "YUY2"],
+    ),
+    scale       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    blend       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    # tonemap
+    tonemap     = dict(
+      h2s             = dict(
+        ifmts = ["P010"],
+        ofmts = ["NV12", "P010"],
+      ),
+    ),
+    range     = dict(
+      ifmts = ["NV12", "P010"],
+      ofmts = ["NV12", "P010"],
+    ),
+  ),
+)

--- a/lib/caps/PTL/d3d12
+++ b/lib/caps/PTL/d3d12
@@ -1,0 +1,112 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y210", "Y410"]),
+    hevc_12 = dict(maxres = res8k , fmts = ["P012", "Y212", "Y412"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k , fmts = ["P012", "Y412"]),
+    av1_8   = dict(maxres = res8k , fmts = ["NV12"]),
+    av1_10  = dict(maxres = res8k , fmts = ["P010"]),
+    vvc_8   = dict(maxres = res16k , fmts = ["NV12"]),
+    vvc_10  = dict(maxres = res16k , fmts = ["P010"]),
+  ),
+  encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "AYUV"],
+      features  = dict(scc = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    vp9_8   = dict(maxres = res8k , fmts = ["NV12", "AYUV"]),
+    av1_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12"],
+    ),
+    av1_10  = dict(
+      maxres    = res8k,
+      fmts      = ["P010"],
+    ),
+    vp9_10  = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+  ),
+  vdenc   = dict(
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
+  ),
+  vpp    = dict(
+    # brightness, contrast, hue and saturation
+    procamp     = dict(
+      ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
+      ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # mirroring and rotation
+    transpose   = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    crop        = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    sharpen     = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    denoise     = dict(
+      ifmts = ["NV12", "P010", "YUY2"],
+      ofmts = ["NV12", "P010", "YUY2"],
+    ),
+    scale       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    blend       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    # tonemap
+    tonemap     = dict(
+      h2s             = dict(
+        ifmts = ["P010"],
+        ofmts = ["NV12", "P010"],
+      ),
+    ),
+    range     = dict(
+      ifmts = ["NV12", "P010"],
+      ofmts = ["NV12", "P010"],
+    ),
+  ),
+)

--- a/lib/caps/PTL/iHD
+++ b/lib/caps/PTL/iHD
@@ -1,0 +1,112 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"]),
+    avc_10  = dict(maxres = res4k, fmts = ["P010", "P210"]),
+    mpeg2   = dict(maxres = res2k , fmts = ["NV12"]),
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "411P", "422H", "422V", "444P", "Y800"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "YUY2", "AYUV"],
+      features  = dict(scc = True, msp = True),
+    ),
+    hevc_10 = dict(maxres = res8k ,  fmts = ["P010", "Y210", "Y410"]),
+    hevc_12 = dict(maxres = res8k ,  fmts = ["P012", "Y212", "Y412"]),
+    vp8     = dict(maxres = res4k , fmts = ["NV12"]),
+    vp9_8   = dict(maxres = res8k ,  fmts = ["NV12", "AYUV"]),
+    vp9_10  = dict(maxres = res8k ,  fmts = ["P010", "Y410"]),
+    vp9_12  = dict(maxres = res8k ,  fmts = ["P012", "Y412"]),
+    av1_8   = dict(maxres = res8k ,  fmts = ["NV12", "YUV444"]),
+    av1_10  = dict(maxres = res8k ,  fmts = ["P010", "P410"]),
+    vvc_8   = dict(maxres = res16k , fmts = ["NV12"]),
+    vvc_10  = dict(maxres = res16k , fmts = ["P010"]),
+  ),
+  encode  = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12", "YUY2", "YUYV", "YVYU", "UYVY", "AYUV"]),
+    hevc_8  = dict(
+      maxres    = res8k,
+      fmts      = ["NV12", "AYUV"],
+      features  = dict(scc = True),
+    ),
+    hevc_10 = dict(maxres = res8k , fmts = ["P010", "Y410"]),
+    av1_8  = dict(
+      maxres    = res16k,
+      fmts      = ["NV12"],
+    ),
+    av1_10  = dict(
+      maxres    = res8k,
+      fmts      = ["P010"],
+    ),
+  ),
+  vdenc   = dict(
+    jpeg    = dict(maxres = res16k, fmts = ["NV12", "YUY2", "UYVY",         "Y800"]),
+  ),
+  vpp    = dict(
+    # brightness, contrast, hue and saturation
+    procamp     = dict(
+      ifmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410"],
+      ofmts = ["NV12", "P010", "YUY2", "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # mirroring and rotation
+    transpose   = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    crop        = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    sharpen     = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    denoise     = dict(
+      ifmts = ["NV12", "P010", "YUY2"],
+      ofmts = ["NV12", "P010", "YUY2"],
+    ),
+    scale       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    blend       = dict(
+      ifmts = ["NV12", "YV12", "I420", "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12", "YV12", "I420", "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA", "BGRX"],
+    ),
+    # tonemap
+    tonemap     = dict(
+      h2s             = dict(
+        ifmts = ["P010"],
+        ofmts = ["NV12", "P010"],
+      ),
+    ),
+    range     = dict(
+      ifmts = ["NV12", "P010"],
+      ofmts = ["NV12", "P010"],
+    ),
+  ),
+)

--- a/lib/caps/PTL/info
+++ b/lib/caps/PTL/info
@@ -1,0 +1,13 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+info = dict(
+  gpu = dict(gen = 16),
+)

--- a/lib/caps/PTL/vaon12
+++ b/lib/caps/PTL/vaon12
@@ -1,0 +1,63 @@
+###
+### Copyright (C) 2024 Intel Corporation
+###
+### SPDX-License-Identifier: BSD-3-Clause
+###
+
+###
+### kate: syntax python;
+###
+
+# https://github.com/intel/media-driver/blob/master/docs/media_features.md
+caps = dict(
+  decode  = dict(
+    avc     = dict(minres = res64, maxres = res4k, fmts = ["NV12"]),
+    hevc_8  = dict(
+      minres    = res64,
+      maxres    = res16k,
+      fmts      = ["NV12"],
+      features  = dict(scc = False, msp = True),
+    ),
+    hevc_10 = dict(minres = res64, maxres = res16k , fmts = ["P010"]),
+    vp9_8   = dict(minres = res64, maxres = res16k , fmts = ["NV12"]),
+    vp9_10  = dict(minres = res64, maxres = res16k , fmts = ["P010"]),
+    av1_8   = dict(minres = res64, maxres = res16k , fmts = ["NV12"]),
+    av1_10  = dict(minres = res64, maxres = res16k , fmts = ["P010"]),
+    vvc_8   = dict(maxres = res16k , fmts = ["NV12"]),
+    vvc_10  = dict(maxres = res16k , fmts = ["P010"]),
+  ),
+  encode   = dict(
+    avc     = dict(maxres = res4k , fmts = ["NV12"], bframes = False),
+    hevc_8  = dict(
+      maxres    = res16k,
+      fmts      = ["NV12"],
+      features  = dict(scc = False),
+    ),
+    hevc_10 = dict(maxres = res16k , fmts = ["P010"]),
+  ),
+  vpp    = dict(
+    crop        = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "AYUV", "Y410", "BGRA"],
+    ),
+    deinterlace = dict(
+      bob             = dict(
+        ifmts = ["NV12", "YV12", "P010", "YUY2"],
+        ofmts = ["NV12", "YV12", "P010", "YUY2"],
+      ),
+      motion_adaptive = dict(
+        ifmts = ["NV12", "P010", "YUY2"],
+        ofmts = ["NV12", "P010", "YUY2"],
+      ),
+    ),
+    scale       = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+    # colorspace conversion
+    csc         = dict(
+      ifmts = ["NV12",                 "P010", "YUY2", "UYVY", "Y210", "AYUV", "Y410", "BGRA"],
+      ofmts = ["NV12",                 "P010", "YUY2",         "Y210", "AYUV", "Y410", "BGRA"],
+    ),
+  ),
+)


### PR DESCRIPTION
[Enabling PTL experimental support to keep up with the Intel Media Driver (https://github.com/intel/media-driver/releases/tag/intel-media-25.1.4)](https://github.com/intel/vaapi-fits/pull/707)